### PR TITLE
Crash url session instrumentation ALPH-2195

### DIFF
--- a/Example/DemoAppSwift/AppDelegate.swift
+++ b/Example/DemoAppSwift/AppDelegate.swift
@@ -22,9 +22,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let options = CoralogixExporterOptions(coralogixDomain: CoralogixDomain.STG,
                                                userContext: userContext,
                                                environment: "PROD",
-                                               application: "DemoApp-iOS-swift",
+                                               application: "",
                                                version: "1",
-                                               publicKey: "cxtp_3EBvvOiDcFwgutlSBX507UsXvrSQts",
+                                               publicKey: "",
                                                instrumentations: [.mobileVitals: false,
                                                                   .custom: false,
                                                                   .errors: true,
@@ -45,14 +45,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         AppDelegate.coralogixRum = CoralogixRum(options: options)
         
         // Must be initialized after CoralogixRum
-        let sessionReplayOptions = SessionReplayOptions(recordingType: .image,
-                                                        captureTimeInterval: 10.0,
-                                                        captureScale: 2.0,
-                                                        captureCompressionQuality: 0.8,
-                                                        maskText: ["Stop"],
-                                                        maskImages: true ,
-                                                        autoStartSessionRecording: true)
-        SessionReplay.initializeWithOptions(sessionReplayOptions:sessionReplayOptions)
+//        let sessionReplayOptions = SessionReplayOptions(recordingType: .image,
+//                                                        captureTimeInterval: 10.0,
+//                                                        captureScale: 2.0,
+//                                                        captureCompressionQuality: 0.8,
+//                                                        maskText: ["Stop"],
+//                                                        maskImages: true ,
+//                                                        autoStartSessionRecording: true)
+//        SessionReplay.initializeWithOptions(sessionReplayOptions:sessionReplayOptions)
         return true
     }
     

--- a/SessionReplay/Sources/SRNetworkManager.swift
+++ b/SessionReplay/Sources/SRNetworkManager.swift
@@ -41,6 +41,7 @@ public class MetadataBuilder {
             Keys.keySessionCreationDate.rawValue: sessionCreationTime.milliseconds,
             Keys.keySessionId.rawValue: sessionId,
             Keys.subIndex.rawValue: subIndex,
+            Keys.snapshotId.rawValue: UUID().uuidString
         ]
     }
 }
@@ -120,6 +121,7 @@ public class SRNetworkManager {
 
         // Create the URLRequest
         var request = URLRequest(url: url)
+        Log.d(String(describing: request))
         request.httpMethod = "POST"
         request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
         request.addValue("Bearer \(publicKey)", forHTTPHeaderField: "Authorization")

--- a/SessionReplay/Sources/URLManager.swift
+++ b/SessionReplay/Sources/URLManager.swift
@@ -9,17 +9,28 @@ import Foundation
 import Combine
 import CoralogixInternal
 
+struct URLEntry {
+    let url: URL
+    let timestamp: TimeInterval
+    let completion: ((Bool, TimeInterval) -> Void)?
+}
+
 class URLManager: ObservableObject {
-    @Published private(set) var savedURLs: [URL] = []
+    @Published private(set) var savedURLs: [URLEntry] = []
     private let maxUrlsToKeep: Int
         
     init(maxUrlsToKeep: Int = 100) {
         self.maxUrlsToKeep = max(1, maxUrlsToKeep)
     }
-    func addURL(_ url: URL) {
-        savedURLs.append(url)
-        if savedURLs.count > maxUrlsToKeep {
-            savedURLs.removeFirst(savedURLs.count - maxUrlsToKeep)
+    
+    func addURL(_ url: URL, timestamp: TimeInterval, completion: ((Bool,TimeInterval) -> Void)? = nil) {
+        DispatchQueue.main.async {
+            self.savedURLs.append(URLEntry(url: url,
+                                      timestamp: timestamp,
+                                      completion: completion))
+            if self.savedURLs.count > self.maxUrlsToKeep {
+                self.savedURLs.removeFirst(self.savedURLs.count - self.maxUrlsToKeep)
+            }
         }
     }
 }
@@ -33,12 +44,17 @@ class URLObserver {
     init(urlManager: URLManager, sessionReplayOptions: SessionReplayOptions?) {
         self.sessionReplayOptions = sessionReplayOptions
         cancellable = urlManager.$savedURLs
-            .sink { [weak self] updatedURLs in
-                // Perform your desired action here
-                Log.d("New URL added. Total count: \(updatedURLs.count)")
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] updatedEntries in
+                
                 guard let self = self,
-                      let inputURL = updatedURLs.last,
+                      let lastEntry = updatedEntries.last,
                       let sessionReplayOptions = self.sessionReplayOptions else { return }
+                
+                let inputURL = lastEntry.url
+                let completion = lastEntry.completion
+                let timestamp = lastEntry.timestamp
+                
                 if let patterns = sessionReplayOptions.maskText {
                     self.pipeline.isTextScannerEnabled = !patterns.isEmpty
                 }
@@ -58,15 +74,16 @@ class URLObserver {
                         isValid: { [weak self] id in
                             return self?.currentOperationId == id
                         },
-                        completion: { success in
+                        completion: { isSuccess in
                             DispatchQueue.main.async {
                                 // Only log completion if this is still the current operation
                                 if self.currentOperationId == operationId {
-                                    if success {
+                                    if isSuccess {
                                         Log.d("Pipeline completed successfully for URL: \(inputURL.lastPathComponent)")
                                     } else {
                                         Log.e("Pipeline encountered an error for URL: \(inputURL.lastPathComponent)")
                                     }
+                                    completion?(isSuccess, timestamp)
                                 }
                             }
                         }


### PR DESCRIPTION
This change replaces DispatchQueue.concurrentPerform with a serial for loop to avoid concurrent modification of Objective-C runtime structures, which could lead to unsafe behavior and crashes. It introduces an NSLock and a didInject flag to ensure injectInNSURLClasses() is executed only once in a thread-safe manner. This prevents simultaneous instrumentation attempts from multiple threads during SDK initialization. The change ensures that swizzling is safe and idempotent, resolving a known crash in OpenTelemetry Swift SDK v1.9.1. The rest of the instrumentation logic remains unchanged to preserve behavior and compatibility.








<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new test to verify that captured data handling correctly triggers URL addition and data compression.
  - Metadata for network requests now includes a unique snapshot ID.

- **Improvements**
  - Enhanced concurrency safety and robustness in network instrumentation.
  - URL management now tracks additional metadata, such as timestamps and completion callbacks, for each entry.
  - Improved control flow for handling captured session replay data, ensuring actions occur after URL storage completes.

- **Bug Fixes**
  - Logging added to help debug network requests in session replay.

- **Chores**
  - Demo app configuration updated; session replay initialization is now disabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->