### PR TITLE
Screenshot events in session recording ALPH-2159 

### DIFF
--- a/Coralogix.podspec
+++ b/Coralogix.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "Coralogix"
-  spec.version      = "1.0.20"
+  spec.version      = "1.0.21"
   spec.summary      = "Coralogix OpenTelemetry pod for iOS."
 
   spec.description  = <<-DESC

--- a/Coralogix/Sources/Actions/UserActionsInstrumentation.swift
+++ b/Coralogix/Sources/Actions/UserActionsInstrumentation.swift
@@ -63,7 +63,7 @@ extension CoralogixRum {
     }
     
     private func getUserActionsSpan() -> any Span {
-        var span = tracer().spanBuilder(spanName: Keys.iosSdk.rawValue).startSpan()
+        var span = tracerProvider().spanBuilder(spanName: Keys.iosSdk.rawValue).startSpan()
         self.addUserMetadata(to: &span)
         span.setAttribute(key: Keys.eventType.rawValue, value: CoralogixEventType.userInteraction.rawValue)
         span.setAttribute(key: Keys.severity.rawValue, value: AttributeValue.int(CoralogixLogSeverity.info.rawValue))

--- a/Coralogix/Sources/CoralogixRum.swift
+++ b/Coralogix/Sources/CoralogixRum.swift
@@ -144,6 +144,7 @@ public class CoralogixRum {
         UITableViewController.swizzleUITableViewControllerDelegate
         UICollectionView.swizzleTouchesEnded
         UIPageControl.swizzleSetCurrentPage
+        UIApplication.swizzleSendEvent
     }
     
     public func setUserContext(userContext: UserContext) {

--- a/Coralogix/Sources/CoralogixRum.swift
+++ b/Coralogix/Sources/CoralogixRum.swift
@@ -20,6 +20,12 @@ public class CoralogixRum {
     internal var sessionManager: SessionManager?
     internal var sessionInstrumentation: URLSessionInstrumentation? = nil
     internal var metricsManager = MetricsManager()
+    internal var tracerProvider: () -> Tracer = {
+        return OpenTelemetry.instance.tracerProvider.get(
+            instrumentationName: Keys.iosSdk.rawValue,
+            instrumentationVersion: Global.sdk.rawValue
+        )
+    }
     
     let notificationCenter = NotificationCenter.default
     

--- a/Coralogix/Sources/Exporter/CoralogixExporter.swift
+++ b/Coralogix/Sources/Exporter/CoralogixExporter.swift
@@ -85,7 +85,7 @@ public class CoralogixExporter: SpanExporter {
                 return .success
             }
             
-            if (CoralogixRum.sdkFramework == .reactNative && self.options.beforeSendCallBack != nil) {
+            if ([.reactNative, .flutter].contains(CoralogixRum.sdkFramework) && self.options.beforeSendCallBack != nil) {
                 self.options.beforeSendCallBack?(cxSpansDictionary)
                 return .success
             } else {

--- a/Coralogix/Sources/Instrumentation/ANRInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/ANRInstrumentation.swift
@@ -28,7 +28,7 @@ extension CoralogixRum {
     }
     
     private func getSpan() -> any Span {
-        var span = tracer().spanBuilder(spanName: Keys.iosSdk.rawValue).startSpan()
+        var span = tracerProvider().spanBuilder(spanName: Keys.iosSdk.rawValue).startSpan()
         span.setAttribute(key: Keys.eventType.rawValue, value: CoralogixEventType.error.rawValue)
         span.setAttribute(key: Keys.source.rawValue, value: Keys.console.rawValue)
         span.setAttribute(key: Keys.severity.rawValue, value: AttributeValue.int(CoralogixLogSeverity.error.rawValue))

--- a/Coralogix/Sources/Instrumentation/CrashInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/CrashInstrumentation.swift
@@ -29,7 +29,7 @@ extension CoralogixRum {
                 
                 // Retrieving crash reporter data.
                 let report = try PLCrashReport(data: data)
-                var span = tracer().spanBuilder(spanName: Keys.iosSdk.rawValue).startSpan()
+                var span = tracerProvider().spanBuilder(spanName: Keys.iosSdk.rawValue).startSpan()
                 span.setAttribute(key: Keys.eventType.rawValue, value: CoralogixEventType.error.rawValue)
                 span.setAttribute(key: Keys.source.rawValue, value: Keys.console.rawValue)
                 span.setAttribute(key: Keys.severity.rawValue, value: AttributeValue.int(CoralogixLogSeverity.error.rawValue))

--- a/Coralogix/Sources/Instrumentation/ErrorInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/ErrorInstrumentation.swift
@@ -127,7 +127,20 @@ extension CoralogixRum {
         span.setAttribute(key: Keys.severity.rawValue, value: AttributeValue.int(CoralogixLogSeverity.error.rawValue))
         self.addUserMetadata(to: &span)
         self.addSnapshotContext(to: &span)
+        self.addScreenshotId(to: &span)
         return span
+    }
+    
+    internal func addScreenshotId(to span: inout any Span) {
+        let screenshotId = UUID().uuidString.lowercased()
+        if let sessionReplay = SdkManager.shared.getSessionReplay() {
+            let metadata: [String: Any] = [
+                Keys.timestamp.rawValue: Date().timeIntervalSince1970,
+                Keys.screenshotId.rawValue: screenshotId
+            ]
+            span.setAttribute(key: Keys.screenshotId.rawValue, value: screenshotId)
+            sessionReplay.captureEvent(properties: metadata)
+        }
     }
     
     private func addSnapshotContext(to span: inout any Span) {

--- a/Coralogix/Sources/Instrumentation/ErrorInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/ErrorInstrumentation.swift
@@ -132,14 +132,14 @@ extension CoralogixRum {
     }
     
     internal func addScreenshotId(to span: inout any Span) {
-        let screenshotId = UUID().uuidString.lowercased()
         if let sessionReplay = SdkManager.shared.getSessionReplay() {
-            let metadata: [String: Any] = [
+            let screenshotId = UUID().uuidString.lowercased()
+            let properties: [String: Any] = [
                 Keys.timestamp.rawValue: Date().timeIntervalSince1970,
                 Keys.screenshotId.rawValue: screenshotId
             ]
             span.setAttribute(key: Keys.screenshotId.rawValue, value: screenshotId)
-            sessionReplay.captureEvent(properties: metadata)
+            sessionReplay.captureEvent(properties: properties)
         }
     }
     

--- a/Coralogix/Sources/Instrumentation/ErrorInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/ErrorInstrumentation.swift
@@ -115,6 +115,7 @@ extension CoralogixRum {
             
             if severity.rawValue == CoralogixLogSeverity.error.rawValue {
                 self.addSnapshotContext(to: &span)
+                self.addScreenshotId(to: &span)
             }
             span.end()
         }

--- a/Coralogix/Sources/Instrumentation/ErrorInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/ErrorInstrumentation.swift
@@ -9,12 +9,6 @@ import Foundation
 import CoralogixInternal
 
 extension CoralogixRum {
-    
-    internal func tracer() -> Tracer {
-        return OpenTelemetry.instance.tracerProvider.get(instrumentationName: Keys.iosSdk.rawValue,
-                                                         instrumentationVersion: Global.sdk.rawValue)
-    }
-    
     func reportErrorWith(exception: NSException) {
         if let options = self.coralogixExporter?.getOptions(),
            options.shouldInitInstumentation(instumentation: .errors) {
@@ -107,7 +101,7 @@ extension CoralogixRum {
         if let options = self.coralogixExporter?.getOptions(),
            options.shouldInitInstumentation(instumentation: .custom) ||
             options.shouldInitInstumentation(instumentation: .lifeCycle) {
-            var span = tracer().spanBuilder(spanName: Keys.iosSdk.rawValue).startSpan()
+            var span = tracerProvider().spanBuilder(spanName: Keys.iosSdk.rawValue).startSpan()
             span.setAttribute(key: Keys.message.rawValue, value: message)
             span.setAttribute(key: Keys.eventType.rawValue, value: CoralogixEventType.log.rawValue)
             span.setAttribute(key: Keys.source.rawValue, value: Keys.code.rawValue)
@@ -127,7 +121,7 @@ extension CoralogixRum {
     }
     
     private func getSpan() -> any Span {
-        var span = tracer().spanBuilder(spanName: Keys.iosSdk.rawValue).startSpan()
+        var span = tracerProvider().spanBuilder(spanName: Keys.iosSdk.rawValue).startSpan()
         span.setAttribute(key: Keys.eventType.rawValue, value: CoralogixEventType.error.rawValue)
         span.setAttribute(key: Keys.source.rawValue, value: Keys.console.rawValue)
         span.setAttribute(key: Keys.severity.rawValue, value: AttributeValue.int(CoralogixLogSeverity.error.rawValue))

--- a/Coralogix/Sources/Instrumentation/LifeCycleInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/LifeCycleInstrumentation.swift
@@ -70,7 +70,7 @@ extension CoralogixRum {
     }
     
     private func getLifeCycleSpan() -> any Span {
-        var span = tracer().spanBuilder(spanName: Keys.iosSdk.rawValue).startSpan()
+        var span = tracerProvider().spanBuilder(spanName: Keys.iosSdk.rawValue).startSpan()
         self.addUserMetadata(to: &span)
         span.setAttribute(key: Keys.eventType.rawValue, value: CoralogixEventType.lifeCycle.rawValue)
         span.setAttribute(key: Keys.source.rawValue, value: Keys.console.rawValue)

--- a/Coralogix/Sources/Instrumentation/MobileVitalsInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/MobileVitalsInstrumentation.swift
@@ -46,7 +46,7 @@ extension CoralogixRum {
     }
     
     private func getMobileVitalsSpan() -> any Span {
-        var span = tracer().spanBuilder(spanName: Keys.iosSdk.rawValue).startSpan()
+        var span = tracerProvider().spanBuilder(spanName: Keys.iosSdk.rawValue).startSpan()
         self.addUserMetadata(to: &span)
         span.setAttribute(key: Keys.eventType.rawValue, value: CoralogixEventType.mobileVitals.rawValue)
         span.setAttribute(key: Keys.severity.rawValue, value: AttributeValue.int(CoralogixLogSeverity.info.rawValue))

--- a/Coralogix/Sources/Instrumentation/NavigationInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/NavigationInstrumentation.swift
@@ -62,8 +62,8 @@ extension CoralogixRum {
         span.setAttribute(key: Keys.snapshotContext.rawValue, value: jsonString)
     }
     
-    private func getNavigationSpan() -> any Span {
-        var span = tracer().spanBuilder(spanName: Keys.iosSdk.rawValue).startSpan()
+    internal func getNavigationSpan() -> any Span {
+        var span = tracerProvider().spanBuilder(spanName: Keys.iosSdk.rawValue).startSpan()
         self.addUserMetadata(to: &span)
         span.setAttribute(key: Keys.eventType.rawValue, value: CoralogixEventType.navigation.rawValue)
         span.setAttribute(key: Keys.source.rawValue, value: Keys.console.rawValue)

--- a/Coralogix/Sources/Instrumentation/NetworkInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/NetworkInstrumentation.swift
@@ -55,7 +55,7 @@ extension CoralogixRum {
     }
     
     private func getSpan() -> any Span {
-        var span = tracer().spanBuilder(spanName: Keys.iosSdk.rawValue).startSpan()
+        var span = tracerProvider().spanBuilder(spanName: Keys.iosSdk.rawValue).startSpan()
         self.addUserMetadata(to: &span)
         span.setAttribute(key: Keys.eventType.rawValue, value: CoralogixEventType.networkRequest.rawValue)
         span.setAttribute(key: Keys.source.rawValue, value: Keys.fetch.rawValue)

--- a/Coralogix/Sources/Instrumentation/NetworkInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/NetworkInstrumentation.swift
@@ -9,6 +9,8 @@ import Foundation
 import CoralogixInternal
 
 extension CoralogixRum {
+    private static let exporterQueue = DispatchQueue(label: "com.coralogix.exporter.queue")
+
     public func initializeNetworkInstrumentation() {
         let configuration = URLSessionInstrumentationConfiguration(spanCustomization: self.spanCustomization, shouldInjectTracingHeaders: { _ /*request*/ in
             // TBD: need to implement the follow
@@ -31,19 +33,34 @@ extension CoralogixRum {
             span.setAttribute(key: Keys.severity.rawValue, value: AttributeValue.int(logSeverity.rawValue))
         }
         
-        let options = self.coralogixExporter?.getOptions()
-        span.setAttribute(key: Keys.userId.rawValue, value: options?.userContext?.userId ?? "")
-        span.setAttribute(key: Keys.userName.rawValue, value: options?.userContext?.userName ?? "")
-        span.setAttribute(key: Keys.userEmail.rawValue, value: options?.userContext?.userEmail ?? "")
-        span.setAttribute(key: Keys.environment.rawValue, value: options?.environment ?? "")
+        var options: CoralogixExporterOptions?
+        CoralogixRum.exporterQueue.sync {
+            options = self.coralogixExporter?.getOptions()
+        }
+        
+        guard let options else {
+#if DEBUG
+            assertionFailure("CoralogixExporterOptions unexpectedly nil during network response handling") // 🆕
+#endif
+            return
+        }
+        
+        let userContext = options.userContext
+
+        span.setAttribute(key: Keys.userId.rawValue, value: userContext?.userId ?? "")
+        span.setAttribute(key: Keys.userName.rawValue, value: userContext?.userName ?? "")
+        span.setAttribute(key: Keys.userEmail.rawValue, value: userContext?.userEmail ?? "")
+        span.setAttribute(key: Keys.environment.rawValue, value: options.environment)
     }
     
     public func setNetworkRequestContext(dictionary: [String: Any]) {
         let span = self.getSpan()
+        
         if let statusCode = dictionary[Keys.statusCode.rawValue] as? Int {
             let logSeverity = statusCode > 400 ?  CoralogixLogSeverity.error : CoralogixLogSeverity.info
             span.setAttribute(key: Keys.severity.rawValue, value: AttributeValue.int(logSeverity.rawValue))
         }
+        
         span.setAttribute(key: SemanticAttributes.httpUrl.rawValue, value: dictionary[Keys.url.rawValue] as? String ?? "")
         span.setAttribute(key: SemanticAttributes.netPeerName.rawValue, value: dictionary[Keys.host.rawValue] as? String ?? "")
         span.setAttribute(key: SemanticAttributes.httpMethod.rawValue, value: dictionary[Keys.method.rawValue] as? String ?? "")

--- a/Coralogix/Sources/Instrumentation/UserActionsInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/UserActionsInstrumentation.swift
@@ -58,7 +58,8 @@ extension CoralogixRum {
             Keys.timestamp.rawValue: timestamp,
             Keys.screenshotId.rawValue: screenshotId
         ]
-        metadata.merge(properties) { (_, new) in new }
+        // Keep SDK-generated keys if duplicates exist
+        metadata.merge(properties) { (_, current) in current }
         return metadata
     }
     

--- a/Coralogix/Sources/Instrumentation/UserActionsInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/UserActionsInstrumentation.swift
@@ -30,39 +30,44 @@ extension CoralogixRum {
     // Increment the click counter and handle the tap object
     private func processTapObject(_ tapObject: [String: Any]) {
         self.sessionManager?.incrementClickCounter()
-        
-        if containsXY(tapObject) {
-            handleSessionReplayEvent(tapObject)
-        } else {
-            handleNonXYEvent(tapObject)
-        }
+        let span = getUserActionsSpan()
+        handleUserInteractionEvent(tapObject, span: span)
     }
     
     // Handle the case where x and y coordinates are present
-    private func handleSessionReplayEvent(_ tapObject: [String: Any]) {
-        if let sessionReplay = SdkManager.shared.getSessionReplay() {
-            sessionReplay.captureEvent(properties: tapObject)
-        } else {
-            Log.e("[SessionReplay] is not initialized")
-        }
-    }
+    internal func handleUserInteractionEvent(_ properties: [String: Any], span: any Span) {
+        let timestamp = Date().timeIntervalSince1970
+        let screenshotId = UUID().uuidString.lowercased()
 
-    // Handle the case where x and y coordinates are not present
-    private func handleNonXYEvent(_ tapObject: [String: Any]) {
-        let span = getUserActionsSpan()
+        if let sessionReplay = SdkManager.shared.getSessionReplay(),
+           containsXY(properties) {
+            let metadata = buildMetadata(properties: properties, timestamp: timestamp, screenshotId: screenshotId)
+            span.setAttribute(key: Keys.screenshotId.rawValue, value: screenshotId)
+            sessionReplay.captureEvent(properties: metadata)
+        }
+        
         span.setAttribute(
             key: Keys.tapObject.rawValue,
-            value: Helper.convertDictionayToJsonString(dict: tapObject)
+            value: Helper.convertDictionayToJsonString(dict: properties)
         )
         span.end()
     }
     
+    internal func buildMetadata(properties: [String: Any], timestamp: TimeInterval, screenshotId: String) -> [String: Any] {
+        var metadata: [String: Any] = [
+            Keys.timestamp.rawValue: timestamp,
+            Keys.screenshotId.rawValue: screenshotId
+        ]
+        metadata.merge(properties) { (_, new) in new }
+        return metadata
+    }
+    
     // Check if the dictionary contains x and y properties
-    private func containsXY(_ dict: [String: Any]) -> Bool {
+    internal func containsXY(_ dict: [String: Any]) -> Bool {
         return dict[Keys.positionX.rawValue] != nil && dict[Keys.positionY.rawValue] != nil
     }
     
-    private func getUserActionsSpan() -> any Span {
+    internal func getUserActionsSpan() -> any Span {
         var span = tracerProvider().spanBuilder(spanName: Keys.iosSdk.rawValue).startSpan()
         self.addUserMetadata(to: &span)
         span.setAttribute(key: Keys.eventType.rawValue, value: CoralogixEventType.userInteraction.rawValue)

--- a/Coralogix/Sources/Model/CxRum.swift
+++ b/Coralogix/Sources/Model/CxRum.swift
@@ -32,6 +32,7 @@ struct CxRum {
     var interactionContext: InteractionContext?
     var mobileVitalsContext: MobileVitalsContext?
     var lifeCycleContext: LifeCycleContext?
+    var screenshotId: String?
      
     init(otel: SpanDataProtocol,
          versionMetadata: VersionMetadata,
@@ -76,6 +77,7 @@ struct CxRum {
         self.interactionContext = InteractionContext(otel: otel)
         self.mobileVitalsContext = MobileVitalsContext(otel: otel)
         self.lifeCycleContext = LifeCycleContext(otel: otel)
+        self.screenshotId = otel.getAttribute(forKey: Keys.screenshotId.rawValue) as? String
         
         if let sessionManager = self.sessionManager,
            let viewManager = self.viewManager,
@@ -105,9 +107,16 @@ struct CxRum {
         self.addLabels(to: &result)
         self.addMobileVitals(to: &result)
         self.addLifeCycleContext(to: &result)
+        self.addScreenshotId(to: &result)
         return result
     }
     
+    private func addScreenshotId(to result: inout [String: Any]) {
+        if let screenshotId = self.screenshotId {
+            result[Keys.screenshotId.rawValue] = screenshotId
+        }
+    }
+
     private func addLifeCycleContext(to result: inout [String: Any]) {
         result[Keys.lifeCycleContext.rawValue] = self.lifeCycleContext?.getLifeCycleDictionary()
     }

--- a/Coralogix/Sources/SessionReplay/SessionReplayInstrumentation.swift
+++ b/Coralogix/Sources/SessionReplay/SessionReplayInstrumentation.swift
@@ -91,8 +91,4 @@ extension CoralogixRum: CoralogixInterface {
             Log.e("[SessionReplay] is not initialized")
         }
     }
-    
-    internal func a() {
-        
-    }
 }

--- a/Coralogix/Sources/SessionReplay/SessionReplayInstrumentation.swift
+++ b/Coralogix/Sources/SessionReplay/SessionReplayInstrumentation.swift
@@ -9,6 +9,19 @@ import Foundation
 import CoralogixInternal
 
 extension CoralogixRum: CoralogixInterface {
+    public func periodicallyCaptureEventTriggered() {
+        if let sessionReplay = SdkManager.shared.getSessionReplay() {
+            let screenshotId = UUID().uuidString.lowercased()
+            let properties: [String: Any] = [
+                Keys.timestamp.rawValue: Date().timeIntervalSince1970,
+                Keys.screenshotId.rawValue: screenshotId
+            ]
+            sessionReplay.captureEvent(properties: properties)
+        } else {
+            Log.e("[SessionReplay] is not initialized")
+        }
+    }
+    
     public func hasSessionRecording(_ hasSessionRecording: Bool) {
         self.sessionManager?.hasRecording = hasSessionRecording
     }
@@ -58,7 +71,6 @@ extension CoralogixRum: CoralogixInterface {
     public func startRecording() {
         if let sessionReplay = SdkManager.shared.getSessionReplay() {
             sessionReplay.startRecording()
-            sessionReplay.captureEvent(properties: ["key": "value"])
         } else {
             Log.e("[SessionReplay] is not initialized")
         }
@@ -78,5 +90,9 @@ extension CoralogixRum: CoralogixInterface {
         } else {
             Log.e("[SessionReplay] is not initialized")
         }
+    }
+    
+    internal func a() {
+        
     }
 }

--- a/CoralogixInternal.podspec
+++ b/CoralogixInternal.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "CoralogixInternal"
-  spec.version      = "1.0.20"
+  spec.version      = "1.0.21"
   spec.summary      = "Coralogix Internal Package. This module is not for public use."
 
   spec.description  = <<-DESC

--- a/CoralogixInternal/Sources/Keys.swift
+++ b/CoralogixInternal/Sources/Keys.swift
@@ -175,6 +175,8 @@ public enum Keys: String {
     case hasRecording
     case snapshotId
     case snapshotCreationTime
+    case screenshotId
+    case page
 }
 
 public enum CoralogixLogSeverity: Int {

--- a/CoralogixInternal/Sources/SdkManager.swift
+++ b/CoralogixInternal/Sources/SdkManager.swift
@@ -16,6 +16,7 @@ public protocol CoralogixInterface {
     func reportError(_ error: String)
     func isDebug() -> Bool
     func hasSessionRecording(_ hasSessionRecording: Bool)
+    func periodicallyCaptureEventTriggered()
 }
 
 public protocol SessionReplayInterface {

--- a/CoralogixInternal/Sources/Utils.swift
+++ b/CoralogixInternal/Sources/Utils.swift
@@ -10,7 +10,7 @@ import UIKit
 #endif
 
 public enum Global: String {
-    case sdk = "1.0.20"
+    case sdk = "1.0.21"
     case swiftVersion = "5.9"
     case coralogixPath = "/browser/v1beta/logs"
     case sessionReplayPath = "/browser/alpha/sessionrecording"

--- a/Example/DemoAppSwift/AppDelegate.swift
+++ b/Example/DemoAppSwift/AppDelegate.swift
@@ -28,7 +28,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                                                instrumentations: [.mobileVitals: false,
                                                                   .custom: false,
                                                                   .errors: true,
-                                                                  .userActions: false,
+                                                                  .userActions: true,
                                                                   .network: true,
                                                                   .anr: false,
                                                                   .lifeCycle: false],

--- a/Example/DemoAppSwift/AppDelegate.swift
+++ b/Example/DemoAppSwift/AppDelegate.swift
@@ -22,9 +22,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let options = CoralogixExporterOptions(coralogixDomain: CoralogixDomain.STG,
                                                userContext: userContext,
                                                environment: "PROD",
-                                               application: "",
+                                               application: "DemoApp-iOS-swift",
                                                version: "1",
-                                               publicKey: "",
+                                               publicKey: "cxtp_3EBvvOiDcFwgutlSBX507UsXvrSQts",
                                                instrumentations: [.mobileVitals: false,
                                                                   .custom: false,
                                                                   .errors: true,
@@ -45,14 +45,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         AppDelegate.coralogixRum = CoralogixRum(options: options)
         
         // Must be initialized after CoralogixRum
-//        let sessionReplayOptions = SessionReplayOptions(recordingType: .image,
-//                                                        captureTimeInterval: 10.0,
-//                                                        captureScale: 2.0,
-//                                                        captureCompressionQuality: 0.8,
-//                                                        maskText: ["Stop"],
-//                                                        maskImages: true ,
-//                                                        autoStartSessionRecording: true)
-//        SessionReplay.initializeWithOptions(sessionReplayOptions:sessionReplayOptions)
+        let sessionReplayOptions = SessionReplayOptions(recordingType: .image,
+                                                        captureTimeInterval: 10.0,
+                                                        captureScale: 2.0,
+                                                        captureCompressionQuality: 0.8,
+                                                        maskText: ["Stop"],
+                                                        maskImages: true ,
+                                                        autoStartSessionRecording: true)
+        SessionReplay.initializeWithOptions(sessionReplayOptions:sessionReplayOptions)
         return true
     }
     

--- a/Package.swift
+++ b/Package.swift
@@ -47,7 +47,7 @@ let package = Package(
             dependencies: ["SessionReplay"],
             path: "Tests/SessionReplayTests",
             resources: [
-                    .process("Resources")
+                .process("Resources")
             ]
         )
     ]

--- a/SessionReplay/Sources/ImageScanner.swift
+++ b/SessionReplay/Sources/ImageScanner.swift
@@ -243,7 +243,7 @@ public class ImageScanner {
                                  (self.creditCardPredicate ?? [])).map { $0.lowercased() }
             
             for observation in observations {
-                //Log.d("Recognized text: \(topCandidate.string)")
+                // Log.d("Recognized text: \(topCandidate.string)")
                 if let topCandidate = observation.topCandidates(1).first {
                     if allPredicates.contains(topCandidate.string.lowercased()) {
                         count += 1

--- a/SessionReplay/Sources/SRNetworkManager.swift
+++ b/SessionReplay/Sources/SRNetworkManager.swift
@@ -43,7 +43,7 @@ public class MetadataBuilder {
             Keys.keySessionCreationDate.rawValue: sessionCreationTime.milliseconds,
             Keys.keySessionId.rawValue: sessionId,
             Keys.subIndex.rawValue: subIndex,
-            Keys.screenshotId.rawValue: screenshotId, //somehow the be called that snapshotId
+            Keys.screenshotId.rawValue: screenshotId,
             Keys.page.rawValue: page,
         ]
     }

--- a/SessionReplay/Sources/SRNetworkManager.swift
+++ b/SessionReplay/Sources/SRNetworkManager.swift
@@ -29,7 +29,7 @@ public class MetadataBuilder {
     public func buildMetadata(dataSize: Int,
                               timestamp: TimeInterval,
                               sessionId: String,
-                              trackNumber: Int,
+                              screenshotNumber: Int,
                               subIndex: Int,
                               application: String,
                               sessionCreationTime: TimeInterval,
@@ -37,7 +37,7 @@ public class MetadataBuilder {
                               page: String) -> [String: Any] {
         return [
             Keys.application.rawValue: application,
-            Keys.segmentIndex.rawValue: trackNumber,
+            Keys.segmentIndex.rawValue: screenshotNumber,
             Keys.segmentSize.rawValue: dataSize,
             Keys.segmentTimestamp.rawValue: timestamp.milliseconds,
             Keys.keySessionCreationDate.rawValue: sessionCreationTime.milliseconds,
@@ -73,9 +73,10 @@ public class SRNetworkManager {
     public func send(_ data: Data,
                      timestamp: TimeInterval,
                      sessionId: String,
-                     trackNumber: Int,
+                     screenshotNumber: Int,
                      subIndex: Int,
                      screenshotId: String,
+                     page: String,
                      completion: @escaping (SessionReplayResultCode) -> Void) {
         guard let endPoint = self.endPoint,
               let publicKey = self.publicKey,
@@ -106,12 +107,12 @@ public class SRNetworkManager {
             dataSize: data.count,
             timestamp: timestamp,
             sessionId: sessionId,
-            trackNumber: trackNumber,
+            screenshotNumber: screenshotNumber,
             subIndex: subIndex,
             application: application,
             sessionCreationTime: sessionCreationTime,
             screenshotId: screenshotId,
-            page: "0"
+            page: page
         )
         Log.d("[metadata] \(metadata)")
         
@@ -179,29 +180,4 @@ public class SRNetworkManager {
         }
         task.resume()
     }
-    
-//    private func getMetadata(dataSize: Int,
-//                             timestamp: TimeInterval,
-//                             sessionId: String,
-//                             trackNumber: Int,
-//                             subIndex: Int) -> [String: Any] {
-//        guard let application = self.application else {
-//            Log.e("[SRNetworkManager] Session Replay missing Application name")
-//            return [String: Any]()
-//        }
-//        
-//        guard let sessionCreationTime = self.sessionCreationTimestamp else {
-//            Log.e("[SRNetworkManager] Session Replay missing Session Creation Time")
-//            return [String: Any]()
-//        }
-//        
-//        let metaData = [Keys.application.rawValue: application,
-//                        Keys.segmentIndex.rawValue: trackNumber,
-//                        Keys.segmentSize.rawValue: dataSize,
-//                        Keys.segmentTimestamp.rawValue: timestamp.milliseconds,
-//                        Keys.keySessionCreationDate.rawValue: sessionCreationTime.milliseconds,
-//                        Keys.keySessionId.rawValue: sessionId,
-//                        Keys.subIndex.rawValue: subIndex] as [String : Any]
-//        return metaData
-//    }
 }

--- a/SessionReplay/Sources/SRNetworkManager.swift
+++ b/SessionReplay/Sources/SRNetworkManager.swift
@@ -32,7 +32,9 @@ public class MetadataBuilder {
                               trackNumber: Int,
                               subIndex: Int,
                               application: String,
-                              sessionCreationTime: TimeInterval) -> [String: Any] {
+                              sessionCreationTime: TimeInterval,
+                              screenshotId: String,
+                              page: String) -> [String: Any] {
         return [
             Keys.application.rawValue: application,
             Keys.segmentIndex.rawValue: trackNumber,
@@ -41,7 +43,8 @@ public class MetadataBuilder {
             Keys.keySessionCreationDate.rawValue: sessionCreationTime.milliseconds,
             Keys.keySessionId.rawValue: sessionId,
             Keys.subIndex.rawValue: subIndex,
-            Keys.snapshotId.rawValue: UUID().uuidString
+            Keys.screenshotId.rawValue: screenshotId, //somehow the be called that snapshotId
+            Keys.page.rawValue: page,
         ]
     }
 }
@@ -72,6 +75,7 @@ public class SRNetworkManager {
                      sessionId: String,
                      trackNumber: Int,
                      subIndex: Int,
+                     screenshotId: String,
                      completion: @escaping (SessionReplayResultCode) -> Void) {
         guard let endPoint = self.endPoint,
               let publicKey = self.publicKey,
@@ -106,6 +110,8 @@ public class SRNetworkManager {
             subIndex: subIndex,
             application: application,
             sessionCreationTime: sessionCreationTime,
+            screenshotId: screenshotId,
+            page: "0"
         )
         Log.d("[metadata] \(metadata)")
         

--- a/SessionReplay/Sources/ScreenshotManager.swift
+++ b/SessionReplay/Sources/ScreenshotManager.swift
@@ -8,26 +8,40 @@ import Foundation
 import CoralogixInternal
 
 class ScreenshotManager {
-    internal var page: Int = 0
-    internal var screenshotCount: Int = 0
+    private let queue = DispatchQueue(label: "com.coralogix.screenshotManager.queue")
+    internal var _page: Int = 0
+    internal var _screenshotCount: Int = 0
     
     // Constants
-    private var sessionStartTimestamp: Date = Date()
-    private var maxScreenShotsPerPage: Int = 5
+    private let maxScreenShotsPerPage: Int = 5
+
+    public var page: Int {
+        get { queue.sync { _page } }
+    }
+    
+    public var screenshotCount: Int {
+        get { queue.sync { _screenshotCount } }
+        set {
+            queue.sync { _screenshotCount = newValue }
+        }
+    }
 
     func takeScreenshot() {
-        screenshotCount += 1
-
-        if screenshotCount % maxScreenShotsPerPage == 0 {
-            page += 1
-            Log.d("Page incremented to: \(page)")
+        queue.sync {
+            _screenshotCount += 1
+            
+            if _screenshotCount % maxScreenShotsPerPage == 0 {
+                _page += 1
+                Log.d("Page incremented to: \(_page)")
+            }
         }
     }
     
     public func resetSession() {
-        page = 0
-        screenshotCount = 0
-        sessionStartTimestamp = Date()
-        Log.d("Session reset. New sessionId")
+        queue.sync {
+            _page = 0
+            _screenshotCount = 0
+            Log.d("Session reset. New sessionId")
+        }
     }
 }

--- a/SessionReplay/Sources/ScreenshotManager.swift
+++ b/SessionReplay/Sources/ScreenshotManager.swift
@@ -15,7 +15,7 @@ public class ScreenshotManager {
     // Constants
     private let maxScreenShotsPerPage: Int
 
-    public init(maxScreenShotsPerPage: Int = 5) {
+    public init(maxScreenShotsPerPage: Int = 20) {
         self.maxScreenShotsPerPage = maxScreenShotsPerPage
     }
     

--- a/SessionReplay/Sources/ScreenshotManager.swift
+++ b/SessionReplay/Sources/ScreenshotManager.swift
@@ -1,0 +1,33 @@
+//
+//  ScreenshotManager.swift
+//  Coralogix
+//
+//  Created by Tomer Har Yoffi on 04/05/2025.
+//
+import Foundation
+import CoralogixInternal
+
+class ScreenshotManager {
+    internal var page: Int = 0
+    internal var screenshotCount: Int = 0
+    
+    // Constants
+    private var sessionStartTimestamp: Date = Date()
+    private var maxScreenShotsPerPage: Int = 5
+
+    func takeScreenshot() {
+        screenshotCount += 1
+
+        if screenshotCount % maxScreenShotsPerPage == 0 {
+            page += 1
+            Log.d("Page incremented to: \(page)")
+        }
+    }
+    
+    public func resetSession() {
+        page = 0
+        screenshotCount = 0
+        sessionStartTimestamp = Date()
+        Log.d("Session reset. New sessionId")
+    }
+}

--- a/SessionReplay/Sources/ScreenshotManager.swift
+++ b/SessionReplay/Sources/ScreenshotManager.swift
@@ -7,14 +7,18 @@
 import Foundation
 import CoralogixInternal
 
-class ScreenshotManager {
+public class ScreenshotManager {
     private let queue = DispatchQueue(label: "com.coralogix.screenshotManager.queue")
     internal var _page: Int = 0
     internal var _screenshotCount: Int = 0
     
     // Constants
-    private let maxScreenShotsPerPage: Int = 5
+    private let maxScreenShotsPerPage: Int
 
+    public init(maxScreenShotsPerPage: Int = 5) {
+        self.maxScreenShotsPerPage = maxScreenShotsPerPage
+    }
+    
     public var page: Int {
         get { queue.sync { _page } }
     }

--- a/SessionReplay/Sources/SessionReplay.swift
+++ b/SessionReplay/Sources/SessionReplay.swift
@@ -189,9 +189,13 @@ public class SessionReplay: SessionReplayInterface {
             guard !sessionReplayModel.isRecording else { return }
             sessionReplayModel.isRecording = true
             
-            sessionReplayModel.captureImage()
-            sessionReplayModel.captureTimer = Timer.scheduledTimer(withTimeInterval: sessionReplayOptions.captureTimeInterval, repeats: true) { [weak sessionReplayModel] _ in
-                sessionReplayModel?.captureImage()
+            guard let coralogixSdk = SdkManager.shared.getCoralogixSdk() else {
+                Log.e("[SessionReplay] CoralogixSdk is not initialized")
+                return
+            }
+            coralogixSdk.periodicallyCaptureEventTriggered()
+            sessionReplayModel.captureTimer = Timer.scheduledTimer(withTimeInterval: sessionReplayOptions.captureTimeInterval, repeats: true) { _ in
+                coralogixSdk.periodicallyCaptureEventTriggered()
             }
         }
     }

--- a/SessionReplay/Sources/SessionReplayModel.swift
+++ b/SessionReplay/Sources/SessionReplayModel.swift
@@ -94,7 +94,9 @@ class SessionReplayModel: UserInteractionRecorder {
                 for: .documentDirectory,
                 in: .userDomainMask
             ).first {
-                let fileURL = documentsDirectory.appendingPathComponent(fileName)
+                let fileURL = documentsDirectory
+                    .appendingPathComponent("SessionReplay")
+                    .appendingPathComponent(fileName)
                 self.handleCapturedData(fileURL: fileURL,
                                         data: screenshotData,
                                         properties: properties)
@@ -213,7 +215,7 @@ class SessionReplayModel: UserInteractionRecorder {
     }
     
     internal func generateFileName() -> String {
-        return "SessionReplay/\(sessionId)_\(self.screenshotManager.screenshotCount).jpg"
+        return "\(sessionId)_\(self.screenshotManager.screenshotCount).jpg"
     }
     
     internal func handleCapturedData(fileURL: URL, data: Data, properties: [String: Any]?) {
@@ -232,10 +234,10 @@ class SessionReplayModel: UserInteractionRecorder {
             
             self.urlManager.addURL(fileURL,
                                    timestamp: timestamp,
-                                   screenshotId: screenshotId) { [weak self] isSuccess, originalTimestamp, orignalScreenshotId  in
+                                   screenshotId: screenshotId) { [weak self] isSuccess, originalTimestamp, originalScreenshotId  in
                 _ = self?.compressAndSendData(data: data,
                                               timestamp: originalTimestamp,
-                                              screenshotId: orignalScreenshotId)
+                                              screenshotId: originalScreenshotId)
             }
             self.updateSessionId(with: self.sessionId)
         }
@@ -268,9 +270,9 @@ class SessionReplayModel: UserInteractionRecorder {
     
     internal func compressAndSendData(data: Data, timestamp: TimeInterval, screenshotId: String) -> SessionReplayResultCode {
         if let compressedChunks = data.gzipCompressed(), compressedChunks.count > 0 {
-            //Log.d("Compression succeeded! Number of chunks: \(compressedChunks.count)")
+            // Log.d("Compression succeeded! Number of chunks: \(compressedChunks.count)")
             for (index, chunk) in compressedChunks.enumerated() {
-                //Log.d("Chunk \(index): \(chunk.count) bytes")
+                // Log.d("Chunk \(index): \(chunk.count) bytes")
                 let subIndex = calculateSubIndex(chunkCount: compressedChunks.count, currentIndex: index)
                 let page =  "\(self.screenshotManager.page)"
                 // Send Data

--- a/SessionReplay/Sources/URLManager.swift
+++ b/SessionReplay/Sources/URLManager.swift
@@ -12,7 +12,8 @@ import CoralogixInternal
 struct URLEntry {
     let url: URL
     let timestamp: TimeInterval
-    let completion: ((Bool, TimeInterval) -> Void)?
+    let screenshotId: String
+    let completion: ((Bool, TimeInterval, String) -> Void)?
 }
 
 class URLManager: ObservableObject {
@@ -23,11 +24,15 @@ class URLManager: ObservableObject {
         self.maxUrlsToKeep = max(1, maxUrlsToKeep)
     }
     
-    func addURL(_ url: URL, timestamp: TimeInterval, completion: ((Bool,TimeInterval) -> Void)? = nil) {
+    func addURL(_ url: URL,
+                timestamp: TimeInterval,
+                screenshotId: String,
+                completion: ((Bool,TimeInterval, String) -> Void)? = nil) {
         DispatchQueue.main.async {
             self.savedURLs.append(URLEntry(url: url,
-                                      timestamp: timestamp,
-                                      completion: completion))
+                                           timestamp: timestamp,
+                                           screenshotId: screenshotId,
+                                           completion: completion))
             if self.savedURLs.count > self.maxUrlsToKeep {
                 self.savedURLs.removeFirst(self.savedURLs.count - self.maxUrlsToKeep)
             }
@@ -54,6 +59,7 @@ class URLObserver {
                 let inputURL = lastEntry.url
                 let completion = lastEntry.completion
                 let timestamp = lastEntry.timestamp
+                let screenshotId = lastEntry.screenshotId
                 
                 if let patterns = sessionReplayOptions.maskText {
                     self.pipeline.isTextScannerEnabled = !patterns.isEmpty
@@ -83,7 +89,7 @@ class URLObserver {
                                     } else {
                                         Log.e("Pipeline encountered an error for URL: \(inputURL.lastPathComponent)")
                                     }
-                                    completion?(isSuccess, timestamp)
+                                    completion?(isSuccess, timestamp, screenshotId)
                                 }
                             }
                         }

--- a/SessionReplay/Sources/URLManager.swift
+++ b/SessionReplay/Sources/URLManager.swift
@@ -9,11 +9,13 @@ import Foundation
 import Combine
 import CoralogixInternal
 
+typealias URLProcessingCompletion = (Bool, TimeInterval, String) -> Void
+
 struct URLEntry {
     let url: URL
     let timestamp: TimeInterval
     let screenshotId: String
-    let completion: ((Bool, TimeInterval, String) -> Void)?
+    let completion: URLProcessingCompletion?
 }
 
 class URLManager: ObservableObject {
@@ -27,7 +29,7 @@ class URLManager: ObservableObject {
     func addURL(_ url: URL,
                 timestamp: TimeInterval,
                 screenshotId: String,
-                completion: ((Bool,TimeInterval, String) -> Void)? = nil) {
+                completion: URLProcessingCompletion? = nil) {
         DispatchQueue.main.async {
             self.savedURLs.append(URLEntry(url: url,
                                            timestamp: timestamp,

--- a/Tests/Coralogix-Package.xctestplan
+++ b/Tests/Coralogix-Package.xctestplan
@@ -1,0 +1,31 @@
+{
+  "configurations" : [
+    {
+      "id" : "6962A43C-34FC-4CB7-A753-F7D0E4664F63",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "SessionReplayTests",
+        "name" : "SessionReplayTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "CoralogixRumTests",
+        "name" : "CoralogixRumTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Tests/CoralogixRumTests/CoralogixRumTests.swift
+++ b/Tests/CoralogixRumTests/CoralogixRumTests.swift
@@ -174,17 +174,7 @@ final class CoralogixRumTests: XCTestCase {
     }
     
     func test_handleAppearStateIfNeeded_whenStateIsNotifyOnAppear_shouldCaptureEventAndSetSpanAttribute() {
-        let mockOptions =  CoralogixExporterOptions(coralogixDomain: CoralogixDomain.US2,
-                                                    userContext: nil,
-                                                    environment: "PROD",
-                                                    application: "TestApp-iOS",
-                                                    version: "1.0",
-                                                    publicKey: "token",
-                                                    ignoreUrls: [],
-                                                    ignoreErrors: [],
-                                                    sampleRate: 100,
-                                                    debug: true)
-        let coralogixRum = CoralogixRum(options: mockOptions)
+        let coralogixRum = makeMockCoralogixRum()
         let mockSpan = MockSpan()
 
         // Arrange
@@ -205,17 +195,7 @@ final class CoralogixRumTests: XCTestCase {
     }
     
     func test_handleAppearStateIfNeeded_whenStateIsNotNotifyOnAppear_shouldNotCaptureEvent() {
-        let mockOptions =  CoralogixExporterOptions(coralogixDomain: CoralogixDomain.US2,
-                                                    userContext: nil,
-                                                    environment: "PROD",
-                                                    application: "TestApp-iOS",
-                                                    version: "1.0",
-                                                    publicKey: "token",
-                                                    ignoreUrls: [],
-                                                    ignoreErrors: [],
-                                                    sampleRate: 100,
-                                                    debug: true)
-        let coralogixRum = CoralogixRum(options: mockOptions)
+        let coralogixRum = makeMockCoralogixRum()
         let mockSpan = MockSpan()
         let mockSessionReplay =  MockSessionRepaly()
 
@@ -232,20 +212,9 @@ final class CoralogixRumTests: XCTestCase {
     }
     
     func test_handleAppearStateIfNeeded_whenSessionReplayIsNil_shouldNotCrashOrCaptureEvent() {
-        let mockOptions =  CoralogixExporterOptions(coralogixDomain: CoralogixDomain.US2,
-                                                    userContext: nil,
-                                                    environment: "PROD",
-                                                    application: "TestApp-iOS",
-                                                    version: "1.0",
-                                                    publicKey: "token",
-                                                    ignoreUrls: [],
-                                                    ignoreErrors: [],
-                                                    sampleRate: 100,
-                                                    debug: true)
-        let coralogixRum = CoralogixRum(options: mockOptions)
+        let coralogixRum = makeMockCoralogixRum()
         let mockSpan = MockSpan()
 
-        // Arrange
         let view = CXView(state: .notifyOnAppear, name: "home")
         let timestamp: TimeInterval = 1234567890
         
@@ -257,17 +226,7 @@ final class CoralogixRumTests: XCTestCase {
     }
     
     func test_getNavigationSpan_shouldSetCorrectAttributes() {
-        let mockOptions =  CoralogixExporterOptions(coralogixDomain: CoralogixDomain.US2,
-                                                    userContext: nil,
-                                                    environment: "PROD",
-                                                    application: "TestApp-iOS",
-                                                    version: "1.0",
-                                                    publicKey: "token",
-                                                    ignoreUrls: [],
-                                                    ignoreErrors: [],
-                                                    sampleRate: 100,
-                                                    debug: true)
-        let coralogixRum = CoralogixRum(options: mockOptions)
+        let coralogixRum = makeMockCoralogixRum()
         
         coralogixRum.tracerProvider = {
             return MockTracer()
@@ -282,18 +241,7 @@ final class CoralogixRumTests: XCTestCase {
     }
     
     func test_handleUniqueViewIfNeeded_whenUniqueView_shouldSetSnapshotContextAttribute() {
-        // Arrange
-        let mockOptions =  CoralogixExporterOptions(coralogixDomain: CoralogixDomain.US2,
-                                                    userContext: nil,
-                                                    environment: "PROD",
-                                                    application: "TestApp-iOS",
-                                                    version: "1.0",
-                                                    publicKey: "token",
-                                                    ignoreUrls: [],
-                                                    ignoreErrors: [],
-                                                    sampleRate: 100,
-                                                    debug: true)
-        let coralogixRum = CoralogixRum(options: mockOptions)
+        let coralogixRum = makeMockCoralogixRum()
         let cxView = CXView(state: .notifyOnDisappear, name: "TestView")
         let timestamp: TimeInterval = 1234567890.0
         let mockSpan = MockSpan()
@@ -316,18 +264,7 @@ final class CoralogixRumTests: XCTestCase {
     }
     
     func test_handleUniqueViewIfNeeded_whenSessionManagerIsNil_shouldNotSetAttribute() {
-        // Arrange
-        let mockOptions =  CoralogixExporterOptions(coralogixDomain: CoralogixDomain.US2,
-                                                    userContext: nil,
-                                                    environment: "PROD",
-                                                    application: "TestApp-iOS",
-                                                    version: "1.0",
-                                                    publicKey: "token",
-                                                    ignoreUrls: [],
-                                                    ignoreErrors: [],
-                                                    sampleRate: 100,
-                                                    debug: true)
-        let coralogixRum = CoralogixRum(options: mockOptions)
+        let coralogixRum = makeMockCoralogixRum()
         let cxView = CXView(state: .notifyOnDisappear, name: "TestView")
         let timestamp: TimeInterval = 1234567890.0
         let mockSpan = MockSpan()
@@ -342,7 +279,6 @@ final class CoralogixRumTests: XCTestCase {
     }
     
     func test_handleNotification_shouldSetCxViewInExporter() {
-        // Arrange
         let mockOptions =  CoralogixExporterOptions(coralogixDomain: CoralogixDomain.US2,
                                                     userContext: nil,
                                                     environment: "PROD",
@@ -353,7 +289,7 @@ final class CoralogixRumTests: XCTestCase {
                                                     ignoreErrors: [],
                                                     sampleRate: 100,
                                                     debug: true)
-        let coralogixRum = CoralogixRum(options: mockOptions)
+        let coralogixRum =  CoralogixRum(options: mockOptions)
         let cxView = CXView(state: .notifyOnDisappear, name: "TestView")
         let mockSessionManager = SessionManager()
 
@@ -403,7 +339,158 @@ final class CoralogixRumTests: XCTestCase {
         // Assert
         XCTAssertFalse(mockExporter.setCalled, "Expected coralogixExporter.set(cxView:) NOT to be called when object is invalid.")
     }
+    
+    func testBuildMetadataMergesCorrectly() {
+        let coralogixRum = makeMockCoralogixRum()
+        let properties: [String: Any] = [
+            "key1": "value1",
+            "key2": 123
+        ]
+        let timestamp: TimeInterval = 1234567890
+        let screenshotId = "screenshot_001"
+        
+        // Act
+        let result = coralogixRum.buildMetadata(properties: properties, timestamp: timestamp, screenshotId: screenshotId)
+        
+        // Assert
+        XCTAssertEqual(result["timestamp"] as? TimeInterval, timestamp)
+        XCTAssertEqual(result["screenshotId"] as? String, screenshotId)
+        XCTAssertEqual(result["key1"] as? String, "value1")
+        XCTAssertEqual(result["key2"] as? Int, 123)
+    }
+    
+    func testContainsXYReturnsTrueWhenBothKeysExist() {
+        let coralogixRum = makeMockCoralogixRum()
+        let dict: [String: Any] = [
+            Keys.positionX.rawValue: 100,
+            Keys.positionY.rawValue: 200
+        ]
+        
+        // Act
+        let result = coralogixRum.containsXY(dict)
+        
+        // Assert
+        XCTAssertTrue(result)
+    }
+    
+    func testContainsXYReturnsFalseWhenOnlyXExists() {
+        let coralogixRum = makeMockCoralogixRum()
+        let dict: [String: Any] = [
+            Keys.positionX.rawValue: 100
+        ]
+        
+        // Act
+        let result = coralogixRum.containsXY(dict)
+        
+        // Assert
+        XCTAssertFalse(result)
+    }
+    
+    func testContainsXYReturnsFalseWhenOnlyYExists() {
+        let coralogixRum = makeMockCoralogixRum()
+        let dict: [String: Any] = [
+            Keys.positionY.rawValue: 200
+        ]
+        
+        // Act
+        let result = coralogixRum.containsXY(dict)
+        
+        // Assert
+        XCTAssertFalse(result)
+    }
+    
+    func testContainsXYReturnsFalseWhenNeitherExist() {
+        let coralogixRum = makeMockCoralogixRum()
+        
+        let dict: [String: Any] = [
+            "someKey": "someValue"
+        ]
+        
+        // Act
+        let result = coralogixRum.containsXY(dict)
+        
+        // Assert
+        XCTAssertFalse(result)
+    }
+    
+    func testGetUserActionsSpanSetsCorrectAttributes() {
+        let coralogixRum = makeMockCoralogixRum()
+        coralogixRum.tracerProvider = {
+            return MockTracer()
+        }
+        let span = coralogixRum.getUserActionsSpan()
+        
+        guard let mockSpan = span as? MockSpan else {
+            XCTFail("Expected span to be MockSpan")
+            return
+        }
+           
+        // Assert
+        // Assuming your Span protocol has methods to retrieve attributes
+        XCTAssertEqual(span.name, Keys.iosSdk.rawValue)
+        
+        if case let .string(value)? = mockSpan.recordedAttributes[Keys.eventType.rawValue] {
+            XCTAssertEqual(value, CoralogixEventType.userInteraction.rawValue)
+        } else {
+            XCTFail("Expected eventType to be a string")
+        }
+        
+        // Assert: Check severity
+        if case let .int(value)? = mockSpan.recordedAttributes[Keys.severity.rawValue] {
+            XCTAssertEqual(value, CoralogixLogSeverity.info.rawValue)
+        } else {
+            XCTFail("Expected severity to be an int")
+        }
+    }
+    
+    func testHandleUserInteractionEventCapturesEventAndEndsSpan() {
+        // Arrange
+        let coralogixRum = makeMockCoralogixRum()
+        coralogixRum.tracerProvider = {
+            return MockTracer()
+        }
+        let mockSpan = MockSpan()
+        let mockSessionReplay = MockSessionRepaly()
+        SdkManager.shared.register(sessionReplayInterface: mockSessionReplay)
+        
+        // Act
+        let testProperties: [String: Any] = [
+            Keys.positionX.rawValue: 100,
+            Keys.positionY.rawValue: 200,
+            "testKey": "testValue"
+        ]
+        
+        coralogixRum.handleUserInteractionEvent(testProperties, span: mockSpan)
+        
+        // Assert
+        XCTAssertEqual(mockSessionReplay.captureEventCalledWith?.count, 5, "Should capture exactly one event")
+        
+        let capturedMetadata = mockSessionReplay.captureEventCalledWith?.first
+        XCTAssertNotNil(capturedMetadata)
+        
+        XCTAssertNotNil(mockSpan.recordedAttributes[Keys.screenshotId.rawValue], "Should set screenshotId on span")
+        XCTAssertNotNil(mockSpan.recordedAttributes[Keys.tapObject.rawValue], "Should set tapObject on span")
+        XCTAssertTrue(mockSpan.didEnd, "Span should be ended")
+    }
 
+    
+    private func makeMockCoralogixRum() ->  CoralogixRum {
+        let mockOptions = CoralogixExporterOptions(
+            coralogixDomain: .US2,
+            userContext: nil,
+            environment: "PROD",
+            application: "TestApp-iOS",
+            version: "1.0",
+            publicKey: "token",
+            ignoreUrls: [],
+            ignoreErrors: [],
+            sampleRate: 100,
+            debug: true
+        )
+        
+        let coralogixRum = CoralogixRum(options: mockOptions)
+        return coralogixRum
+    }
 }
 
 final class MockCoralogixExporter: CoralogixExporter {
@@ -496,6 +583,7 @@ final class MockSessionRepaly: SessionReplayInterface {
 }
 
 final class MockSpan: Span {
+    var didEnd = false
     var kind: SpanKind = .internal
     var recordedAttributes: [String: AttributeValue] = [:]
     var context: SpanContext = SpanContext.create(traceId: TraceId(),
@@ -504,7 +592,7 @@ final class MockSpan: Span {
                                                   traceState: TraceState())
     var isRecording: Bool = true
     var status: Status = .ok
-    var name: String = "MockSpan"
+    var name: String = Keys.iosSdk.rawValue
 
     var setAttributeCalled = false
     var setAttributeKey: String?
@@ -521,7 +609,9 @@ final class MockSpan: Span {
     func addEvent(name: String, timestamp: Date) {}
     func addEvent(name: String, attributes: [String: AttributeValue]) {}
     func addEvent(name: String, attributes: [String: AttributeValue], timestamp: Date) {}
-    func end() {}
+    func end() {
+        didEnd = true
+    }
     func end(time: Date) {}
 
     var description: String { return "MockSpan" }

--- a/Tests/CoralogixRumTests/CoralogixRumTests.swift
+++ b/Tests/CoralogixRumTests/CoralogixRumTests.swift
@@ -255,6 +255,224 @@ final class CoralogixRumTests: XCTestCase {
         // Assert
         XCTAssertFalse(mockSpan.setAttributeCalled)
     }
+    
+    func test_getNavigationSpan_shouldSetCorrectAttributes() {
+        let mockOptions =  CoralogixExporterOptions(coralogixDomain: CoralogixDomain.US2,
+                                                    userContext: nil,
+                                                    environment: "PROD",
+                                                    application: "TestApp-iOS",
+                                                    version: "1.0",
+                                                    publicKey: "token",
+                                                    ignoreUrls: [],
+                                                    ignoreErrors: [],
+                                                    sampleRate: 100,
+                                                    debug: true)
+        let coralogixRum = CoralogixRum(options: mockOptions)
+        
+        coralogixRum.tracerProvider = {
+            return MockTracer()
+        }
+
+        if let mockSpan = coralogixRum.getNavigationSpan() as? MockSpan {
+            // Assert
+            XCTAssertEqual(mockSpan.recordedAttributes[Keys.eventType.rawValue], .string(CoralogixEventType.navigation.rawValue))
+            XCTAssertEqual(mockSpan.recordedAttributes[Keys.source.rawValue], .string(Keys.console.rawValue))
+            XCTAssertEqual(mockSpan.recordedAttributes[Keys.severity.rawValue], .int(CoralogixLogSeverity.info.rawValue))
+        }
+    }
+    
+    func test_handleUniqueViewIfNeeded_whenUniqueView_shouldSetSnapshotContextAttribute() {
+        // Arrange
+        let mockOptions =  CoralogixExporterOptions(coralogixDomain: CoralogixDomain.US2,
+                                                    userContext: nil,
+                                                    environment: "PROD",
+                                                    application: "TestApp-iOS",
+                                                    version: "1.0",
+                                                    publicKey: "token",
+                                                    ignoreUrls: [],
+                                                    ignoreErrors: [],
+                                                    sampleRate: 100,
+                                                    debug: true)
+        let coralogixRum = CoralogixRum(options: mockOptions)
+        let cxView = CXView(state: .notifyOnDisappear, name: "TestView")
+        let timestamp: TimeInterval = 1234567890.0
+        let mockSpan = MockSpan()
+        
+        // Act
+        coralogixRum.handleUniqueViewIfNeeded(cxView: cxView, span: mockSpan, timestamp: timestamp)
+        
+        // Assert
+        XCTAssertTrue(mockSpan.setAttributeCalled, "Expected span.setAttribute to be called.")
+        XCTAssertEqual(mockSpan.setAttributeKey, Keys.snapshotContext.rawValue, "Expected the attribute key to be snapshotContext.")
+        
+        if case let .string(jsonString)? = mockSpan.setAttributeValue {
+            XCTAssertTrue(jsonString.contains("\"errorCount\":0"), "Expected error count to be 0.")
+            XCTAssertTrue(jsonString.contains("\"viewCount\":1"), "Expected view count to be 1.")
+            XCTAssertTrue(jsonString.contains("\"clickCount\":0"), "Expected click count to be 0.")
+            XCTAssertTrue(jsonString.contains("\"hasRecording\":false"), "Expected hasRecording to be false.")
+        } else {
+            XCTFail("Expected setAttribute value to be a JSON string.")
+        }
+    }
+    
+    func test_handleUniqueViewIfNeeded_whenSessionManagerIsNil_shouldNotSetAttribute() {
+        // Arrange
+        let mockOptions =  CoralogixExporterOptions(coralogixDomain: CoralogixDomain.US2,
+                                                    userContext: nil,
+                                                    environment: "PROD",
+                                                    application: "TestApp-iOS",
+                                                    version: "1.0",
+                                                    publicKey: "token",
+                                                    ignoreUrls: [],
+                                                    ignoreErrors: [],
+                                                    sampleRate: 100,
+                                                    debug: true)
+        let coralogixRum = CoralogixRum(options: mockOptions)
+        let cxView = CXView(state: .notifyOnDisappear, name: "TestView")
+        let timestamp: TimeInterval = 1234567890.0
+        let mockSpan = MockSpan()
+
+        coralogixRum.sessionManager = nil // 🚨 Important! Simulate missing session
+            
+        // Act
+        coralogixRum.handleUniqueViewIfNeeded(cxView: cxView, span: mockSpan, timestamp: timestamp)
+            
+        // Assert
+        XCTAssertFalse(mockSpan.setAttributeCalled, "Expected no attribute to be set when sessionManager is nil.")
+    }
+    
+    func test_handleNotification_shouldSetCxViewInExporter() {
+        // Arrange
+        let mockOptions =  CoralogixExporterOptions(coralogixDomain: CoralogixDomain.US2,
+                                                    userContext: nil,
+                                                    environment: "PROD",
+                                                    application: "TestApp-iOS",
+                                                    version: "1.0",
+                                                    publicKey: "token",
+                                                    ignoreUrls: [],
+                                                    ignoreErrors: [],
+                                                    sampleRate: 100,
+                                                    debug: true)
+        let coralogixRum = CoralogixRum(options: mockOptions)
+        let cxView = CXView(state: .notifyOnDisappear, name: "TestView")
+        let mockSessionManager = SessionManager()
+
+        let mockExporter = MockCoralogixExporter(options: mockOptions,
+                                                 sessionManager: mockSessionManager,
+                                                 networkManager: NetworkManager(),
+                                                 viewManager: ViewManager(keyChain: nil),
+                                                 metricsManager: MetricsManager())
+        coralogixRum.coralogixExporter = mockExporter
+        let notification = Notification(name: Notification.Name("TestNotification"), object: cxView, userInfo: nil)
+        
+        // Act
+        coralogixRum.handleNotification(notification: notification)
+        
+        // Assert
+        XCTAssertTrue(mockExporter.setCalled, "Expected coralogixExporter.set(cxView:) to be called.")
+        XCTAssertEqual(mockExporter.capturedCxView?.name, cxView.name, "Expected captured CXView to match the one from notification.")
+    }
+    
+    func test_handleNotification_withInvalidObject_shouldNotCallSetOnExporter() {
+        // Arrange
+        let mockOptions =  CoralogixExporterOptions(coralogixDomain: CoralogixDomain.US2,
+                                                    userContext: nil,
+                                                    environment: "PROD",
+                                                    application: "TestApp-iOS",
+                                                    version: "1.0",
+                                                    publicKey: "token",
+                                                    ignoreUrls: [],
+                                                    ignoreErrors: [],
+                                                    sampleRate: 100,
+                                                    debug: true)
+        let coralogixRum = CoralogixRum(options: mockOptions)
+        let invalidObject = "Not a CXView" // String instead of CXView
+        let mockSessionManager = SessionManager()
+
+        let mockExporter = MockCoralogixExporter(options: mockOptions,
+                                                 sessionManager: mockSessionManager,
+                                                 networkManager: NetworkManager(),
+                                                 viewManager: ViewManager(keyChain: nil),
+                                                 metricsManager: MetricsManager())
+        coralogixRum.coralogixExporter = mockExporter
+        let notification = Notification(name: Notification.Name("TestNotification"), object: invalidObject, userInfo: nil)
+        
+        // Act
+        coralogixRum.handleNotification(notification: notification)
+        
+        // Assert
+        XCTAssertFalse(mockExporter.setCalled, "Expected coralogixExporter.set(cxView:) NOT to be called when object is invalid.")
+    }
+
+}
+
+final class MockCoralogixExporter: CoralogixExporter {
+    var setCalled = false
+    var capturedCxView: CXView?
+    
+    override func set(cxView: CXView) {
+        setCalled = true
+        capturedCxView = cxView
+    }
+}
+
+final class MockTracer: Tracer {
+    var mockSpanBuilder = MockSpanBuilder()
+    
+    func spanBuilder(spanName: String) -> SpanBuilder {
+        return mockSpanBuilder
+    }
+    
+    // If Tracer has more methods, stub them as no-op
+}
+
+final class MockSpanBuilder: SpanBuilder {
+    func setAttribute(key: String, value: Coralogix.AttributeValue) -> Self {
+        return self
+    }
+    
+    func setParent(_ parent: any Coralogix.Span) -> Self {
+        return self
+    }
+    
+    func setParent(_ parent: Coralogix.SpanContext) -> Self {
+        return self
+    }
+    
+    func setNoParent() -> Self {
+        return self
+    }
+    
+    func addLink(spanContext: Coralogix.SpanContext) -> Self {
+        return self
+    }
+    
+    func addLink(spanContext: Coralogix.SpanContext, attributes: [String : Coralogix.AttributeValue]) -> Self {
+        return self
+    }
+    
+    func setSpanKind(spanKind: Coralogix.SpanKind) -> Self {
+        return self
+    }
+    
+    
+    func setStartTime(time: Date) -> Self {
+        return self
+    }
+    
+    func setActive(_ active: Bool) -> Self {
+        return self
+    }
+    
+    var startedSpan: MockSpan?
+    
+    func startSpan() -> any Span {
+        let span = MockSpan()
+        startedSpan = span
+        return span
+    }
+    
+    // Other methods if needed
 }
 
 final class MockSessionRepaly: SessionReplayInterface {
@@ -279,6 +497,7 @@ final class MockSessionRepaly: SessionReplayInterface {
 
 final class MockSpan: Span {
     var kind: SpanKind = .internal
+    var recordedAttributes: [String: AttributeValue] = [:]
     var context: SpanContext = SpanContext.create(traceId: TraceId(),
                                                   spanId: SpanId(),
                                                   traceFlags: TraceFlags(),
@@ -295,6 +514,7 @@ final class MockSpan: Span {
         setAttributeCalled = true
         setAttributeKey = key
         setAttributeValue = value
+        recordedAttributes[key] = value
     }
 
     func addEvent(name: String) {}

--- a/Tests/CoralogixRumTests/RumTests.swift
+++ b/Tests/CoralogixRumTests/RumTests.swift
@@ -16,7 +16,7 @@ final class RumTests: XCTestCase {
     var mockNetworkManager: NetworkManager!
     var mockViewerManager: ViewManager!
     var mockCxMetricsManager: MetricsManager!
-
+    
     override func setUpWithError() throws {
         
         let snapshot = SnapshotConext(timestemp: Date().timeIntervalSince1970,
@@ -33,7 +33,8 @@ final class RumTests: XCTestCase {
                                                  Keys.userId.rawValue: AttributeValue("12345"),
                                                  Keys.userName.rawValue: AttributeValue("John Doe"),
                                                  Keys.userEmail.rawValue: AttributeValue("john.doe@example.com"),
-                                                 Keys.snapshotContext.rawValue: AttributeValue(snapshotString)],
+                                                 Keys.snapshotContext.rawValue: AttributeValue(snapshotString),
+                                                 Keys.screenshotId.rawValue: AttributeValue("10")],
                                     startTime: Date(), spanId: "20", traceId: "30")
         mockVersionMetadata = VersionMetadata(appName: "ExampleApp", appVersion: "1.1.1")
         mockSessionManager = SessionManager()
@@ -110,7 +111,7 @@ final class RumTests: XCTestCase {
         XCTAssertEqual(result[Keys.traceId.rawValue] as? String, "30")
         XCTAssertEqual(result[Keys.spanId.rawValue] as? String, "20")
         XCTAssertEqual(result[Keys.platform.rawValue] as? String, "mobile")
-        
+        XCTAssertEqual(result[Keys.screenshotId.rawValue] as? String, "10")
         XCTAssertNotNil(result[Keys.deviceState.rawValue])
         
         if let logContext = result[Keys.logContext.rawValue] as? [String: Any] {
@@ -169,7 +170,7 @@ final class RumTests: XCTestCase {
             labels: ["key": "value"]
         )
         
-        let currentTime = Date()        
+        let currentTime = Date()
         cxRum.snapshotContext = SnapshotConext(timestemp: currentTime.timeIntervalSince1970,
                                                errorCount: 1,
                                                viewCount: 1,
@@ -236,13 +237,13 @@ final class RumTests: XCTestCase {
                                     startTime: Date(), spanId: "20", traceId: "30")
         
         let oneMinuteInThePast: TimeInterval = -120
-
+        
         // Get the current date and time
         let currentDate = Date()
-
+        
         // Calculate the date and time 1 minute in the past
         let pastDate = currentDate.addingTimeInterval(oneMinuteInThePast)
-
+        
         mockSessionManager.lastSnapshotEventTime = pastDate
         let cxRum = CxRum(
             otel: mockSpanData,

--- a/Tests/SessionReplayTests/SRNetworkManagerTests.swift
+++ b/Tests/SessionReplayTests/SRNetworkManagerTests.swift
@@ -48,10 +48,10 @@ final class SRNetworkManagerTests: XCTestCase {
         let testData = Data("Test data".utf8)
         let timestamp = Date().timeIntervalSince1970
         let sessionId = "mockSessionId"
-        let trackNumber = 1
+        let screenshotNumber = 1
         let subIndex = 1
         let screenshotId = UUID().uuidString.lowercased()
-        
+        let page: String = "0"
         let mockSession = MockURLSession()
         networkManager = SRNetworkManager(session: mockSession)
         
@@ -59,9 +59,10 @@ final class SRNetworkManagerTests: XCTestCase {
         networkManager.send(testData,
                             timestamp: timestamp,
                             sessionId: sessionId,
-                            trackNumber: trackNumber,
+                            screenshotNumber: screenshotNumber,
                             subIndex: subIndex,
-                            screenshotId: screenshotId) { result in
+                            screenshotId: screenshotId,
+                            page: page) { result in
             XCTAssertEqual(result, .success, "The send method should return .success for a valid request")
             // Verify request was created and sent
             XCTAssertNotNil(mockSession.request, "No request was created")
@@ -82,10 +83,11 @@ final class SRNetworkManagerTests: XCTestCase {
         let testData = Data("Test data".utf8)
         let timestamp = Date().timeIntervalSince1970
         let sessionId = "mockSessionId"
-        let trackNumber = 1
+        let screenshotNumber = 1
         let subIndex = 1
         let screenshotId = UUID().uuidString.lowercased()
-        
+        let page: String = "0"
+
         // Simulate missing endPoint
         networkManager.endPoint = nil
         
@@ -93,9 +95,10 @@ final class SRNetworkManagerTests: XCTestCase {
         networkManager.send(testData,
                             timestamp: timestamp,
                             sessionId: sessionId,
-                            trackNumber: trackNumber,
+                            screenshotNumber: screenshotNumber,
                             subIndex: subIndex,
-                            screenshotId: screenshotId) { result in
+                            screenshotId: screenshotId,
+                            page: page) { result in
             
             // Assert the result
             XCTAssertEqual(result, .failure, "The send method should return .failure when endPoint is nil")
@@ -107,17 +110,19 @@ final class SRNetworkManagerTests: XCTestCase {
         let invalidData = Data() // Empty data
         let timestamp: TimeInterval = Date().timeIntervalSince1970
         let sessionId = "testSessionId"
-        let trackNumber = 1
+        let screenshotNumber = 1
         let subIndex = 1
         let screenshotId = UUID().uuidString.lowercased()
+        let page: String = "0"
 
         // Call the method under test
         networkManager.send(invalidData,
                             timestamp: timestamp,
                             sessionId: sessionId,
-                            trackNumber: trackNumber,
+                            screenshotNumber: screenshotNumber,
                             subIndex: subIndex,
-                            screenshotId: screenshotId) { result in
+                            screenshotId: screenshotId,
+                            page: page) { result in
             
             // Assert the result
             XCTAssertEqual(result, .failure, "The send method should return .failure for invalid JSON.")
@@ -133,7 +138,7 @@ final class SRNetworkManagerTests: XCTestCase {
         let timestamp: TimeInterval = Date().timeIntervalSince1970
         let sessionId = "testSession123"
         let dataSize = 1024
-        let trackNumber = 1
+        let screenshotNumber = 1
         let subIndex = 2
         let screenshotId = UUID().uuidString.lowercased()
         let page = "0"
@@ -143,7 +148,7 @@ final class SRNetworkManagerTests: XCTestCase {
             dataSize: dataSize,
             timestamp: timestamp,
             sessionId: sessionId,
-            trackNumber: trackNumber,
+            screenshotNumber: screenshotNumber,
             subIndex: subIndex,
             application: application,
             sessionCreationTime: sessionCreationTime,
@@ -153,7 +158,7 @@ final class SRNetworkManagerTests: XCTestCase {
         
         // Assert
         XCTAssertEqual(metadata[Keys.application.rawValue] as? String, application, "Application value is incorrect")
-        XCTAssertEqual(metadata[Keys.segmentIndex.rawValue] as? Int, trackNumber, "Track number value is incorrect")
+        XCTAssertEqual(metadata[Keys.segmentIndex.rawValue] as? Int, screenshotNumber, "Track number value is incorrect")
         XCTAssertEqual(metadata[Keys.segmentSize.rawValue] as? Int, dataSize, "Data size value is incorrect")
         XCTAssertEqual(metadata[Keys.segmentTimestamp.rawValue] as? Int, timestamp.milliseconds, "Timestamp value is incorrect")
         XCTAssertEqual(metadata[Keys.keySessionCreationDate.rawValue] as? Int, sessionCreationTime.milliseconds, "Session creation timestamp is incorrect")
@@ -172,7 +177,7 @@ final class SRNetworkManagerTests: XCTestCase {
         let timestamp: TimeInterval = Date().timeIntervalSince1970
         let sessionId = "testSession123"
         let dataSize = 1024
-        let trackNumber = 1
+        let screenshotNumber = 1
         let subIndex = 2
         let screenshotId = UUID().uuidString.lowercased()
         let page = "0"
@@ -182,7 +187,7 @@ final class SRNetworkManagerTests: XCTestCase {
             dataSize: dataSize,
             timestamp: timestamp,
             sessionId: sessionId,
-            trackNumber: trackNumber,
+            screenshotNumber: screenshotNumber,
             subIndex: subIndex,
             application: application,
             sessionCreationTime: sessionCreationTime,

--- a/Tests/SessionReplayTests/SRNetworkManagerTests.swift
+++ b/Tests/SessionReplayTests/SRNetworkManagerTests.swift
@@ -217,6 +217,10 @@ class MockCoralogix: CoralogixInterface {
     var debugMode: Bool = false
     var reportedErrors: [String] = []
     
+    func periodicallyCaptureEventTriggered() {
+        
+    }
+    
     func hasSessionRecording(_ hasSessionRecording: Bool) {
         // update the coralogix sdk that there is a session recording to that session
     }

--- a/Tests/SessionReplayTests/SRNetworkManagerTests.swift
+++ b/Tests/SessionReplayTests/SRNetworkManagerTests.swift
@@ -160,6 +160,7 @@ final class SRNetworkManagerTests: XCTestCase {
         XCTAssertEqual(metadata[Keys.keySessionId.rawValue] as? String, sessionId, "Session ID value is incorrect")
         XCTAssertEqual(metadata[Keys.subIndex.rawValue] as? Int, subIndex, "Sub-index value is incorrect")
         XCTAssertEqual(metadata[Keys.screenshotId.rawValue] as? String, screenshotId, "ScreenshotsId value is incorrect")
+        XCTAssertEqual(metadata[Keys.page.rawValue] as? String, page, "Page value is incorrect")
     }
     
     func testBuildMetadata_ReturnsAllKeys() {

--- a/Tests/SessionReplayTests/SRNetworkManagerTests.swift
+++ b/Tests/SessionReplayTests/SRNetworkManagerTests.swift
@@ -50,12 +50,18 @@ final class SRNetworkManagerTests: XCTestCase {
         let sessionId = "mockSessionId"
         let trackNumber = 1
         let subIndex = 1
+        let screenshotId = UUID().uuidString.lowercased()
         
         let mockSession = MockURLSession()
         networkManager = SRNetworkManager(session: mockSession)
         
         // Call the method under test
-        networkManager.send(testData, timestamp: timestamp, sessionId: sessionId, trackNumber: trackNumber, subIndex: subIndex) { result in
+        networkManager.send(testData,
+                            timestamp: timestamp,
+                            sessionId: sessionId,
+                            trackNumber: trackNumber,
+                            subIndex: subIndex,
+                            screenshotId: screenshotId) { result in
             XCTAssertEqual(result, .success, "The send method should return .success for a valid request")
             // Verify request was created and sent
             XCTAssertNotNil(mockSession.request, "No request was created")
@@ -78,12 +84,18 @@ final class SRNetworkManagerTests: XCTestCase {
         let sessionId = "mockSessionId"
         let trackNumber = 1
         let subIndex = 1
+        let screenshotId = UUID().uuidString.lowercased()
         
         // Simulate missing endPoint
         networkManager.endPoint = nil
         
         // Call the method under test
-        networkManager.send(testData, timestamp: timestamp, sessionId: sessionId, trackNumber: trackNumber, subIndex: subIndex) { result in
+        networkManager.send(testData,
+                            timestamp: timestamp,
+                            sessionId: sessionId,
+                            trackNumber: trackNumber,
+                            subIndex: subIndex,
+                            screenshotId: screenshotId) { result in
             
             // Assert the result
             XCTAssertEqual(result, .failure, "The send method should return .failure when endPoint is nil")
@@ -97,9 +109,15 @@ final class SRNetworkManagerTests: XCTestCase {
         let sessionId = "testSessionId"
         let trackNumber = 1
         let subIndex = 1
-        
+        let screenshotId = UUID().uuidString.lowercased()
+
         // Call the method under test
-        networkManager.send(invalidData, timestamp: timestamp, sessionId: sessionId, trackNumber: trackNumber, subIndex: subIndex) { result in
+        networkManager.send(invalidData,
+                            timestamp: timestamp,
+                            sessionId: sessionId,
+                            trackNumber: trackNumber,
+                            subIndex: subIndex,
+                            screenshotId: screenshotId) { result in
             
             // Assert the result
             XCTAssertEqual(result, .failure, "The send method should return .failure for invalid JSON.")
@@ -117,7 +135,9 @@ final class SRNetworkManagerTests: XCTestCase {
         let dataSize = 1024
         let trackNumber = 1
         let subIndex = 2
-        
+        let screenshotId = UUID().uuidString.lowercased()
+        let page = "0"
+
         // Act
         let metadata = builder.buildMetadata(
             dataSize: dataSize,
@@ -127,6 +147,8 @@ final class SRNetworkManagerTests: XCTestCase {
             subIndex: subIndex,
             application: application,
             sessionCreationTime: sessionCreationTime,
+            screenshotId: screenshotId,
+            page: page
         )
         
         // Assert
@@ -137,6 +159,7 @@ final class SRNetworkManagerTests: XCTestCase {
         XCTAssertEqual(metadata[Keys.keySessionCreationDate.rawValue] as? Int, sessionCreationTime.milliseconds, "Session creation timestamp is incorrect")
         XCTAssertEqual(metadata[Keys.keySessionId.rawValue] as? String, sessionId, "Session ID value is incorrect")
         XCTAssertEqual(metadata[Keys.subIndex.rawValue] as? Int, subIndex, "Sub-index value is incorrect")
+        XCTAssertEqual(metadata[Keys.screenshotId.rawValue] as? String, screenshotId, "ScreenshotsId value is incorrect")
     }
     
     func testBuildMetadata_ReturnsAllKeys() {
@@ -150,7 +173,9 @@ final class SRNetworkManagerTests: XCTestCase {
         let dataSize = 1024
         let trackNumber = 1
         let subIndex = 2
-        
+        let screenshotId = UUID().uuidString.lowercased()
+        let page = "0"
+
         // Act
         let metadata = builder.buildMetadata(
             dataSize: dataSize,
@@ -159,7 +184,9 @@ final class SRNetworkManagerTests: XCTestCase {
             trackNumber: trackNumber,
             subIndex: subIndex,
             application: application,
-            sessionCreationTime: sessionCreationTime
+            sessionCreationTime: sessionCreationTime,
+            screenshotId: screenshotId,
+            page: page
         )
         
         // Assert
@@ -170,7 +197,9 @@ final class SRNetworkManagerTests: XCTestCase {
             Keys.segmentTimestamp.rawValue,
             Keys.keySessionCreationDate.rawValue,
             Keys.keySessionId.rawValue,
-            Keys.subIndex.rawValue
+            Keys.subIndex.rawValue,
+            Keys.screenshotId.rawValue,
+            Keys.page.rawValue
         ]
         
         XCTAssertEqual(metadata.keys.sorted(), expectedKeys.sorted(), "Metadata keys are incorrect")

--- a/Tests/SessionReplayTests/SRNetworkManagerTests.swift
+++ b/Tests/SessionReplayTests/SRNetworkManagerTests.swift
@@ -52,7 +52,7 @@ final class SRNetworkManagerTests: XCTestCase {
         let subIndex = 1
         let screenshotId = UUID().uuidString.lowercased()
         let page: String = "0"
-        let mockSession = MockURLSession()
+        mockSession = MockURLSession()
         networkManager = SRNetworkManager(session: mockSession)
         
         // Call the method under test
@@ -65,16 +65,16 @@ final class SRNetworkManagerTests: XCTestCase {
                             page: page) { result in
             XCTAssertEqual(result, .success, "The send method should return .success for a valid request")
             // Verify request was created and sent
-            XCTAssertNotNil(mockSession.request, "No request was created")
+            XCTAssertNotNil(self.mockSession.request, "No request was created")
             
             // Verify request has correct URL
-            XCTAssertEqual(mockSession.request?.url?.absoluteString, self.networkManager.endPoint, "Request URL doesn't match endpoint")
+            XCTAssertEqual(self.mockSession.request?.url?.absoluteString, self.networkManager.endPoint, "Request URL doesn't match endpoint")
             
             // Verify request method is POST
-            XCTAssertEqual(mockSession.request?.httpMethod, "POST", "Request method should be POST")
+            XCTAssertEqual(self.mockSession.request?.httpMethod, "POST", "Request method should be POST")
             
             // Verify request contains data
-            XCTAssertNotNil(mockSession.request?.httpBody, "Request body is nil")
+            XCTAssertNotNil(self.mockSession.request?.httpBody, "Request body is nil")
         }
     }
     
@@ -158,7 +158,7 @@ final class SRNetworkManagerTests: XCTestCase {
         
         // Assert
         XCTAssertEqual(metadata[Keys.application.rawValue] as? String, application, "Application value is incorrect")
-        XCTAssertEqual(metadata[Keys.segmentIndex.rawValue] as? Int, screenshotNumber, "Track number value is incorrect")
+        XCTAssertEqual(metadata[Keys.segmentIndex.rawValue] as? Int, screenshotNumber, "Screenshot number value is incorrect")
         XCTAssertEqual(metadata[Keys.segmentSize.rawValue] as? Int, dataSize, "Data size value is incorrect")
         XCTAssertEqual(metadata[Keys.segmentTimestamp.rawValue] as? Int, timestamp.milliseconds, "Timestamp value is incorrect")
         XCTAssertEqual(metadata[Keys.keySessionCreationDate.rawValue] as? Int, sessionCreationTime.milliseconds, "Session creation timestamp is incorrect")
@@ -221,9 +221,10 @@ class MockCoralogix: CoralogixInterface {
     var sessionCreationTimestamp: TimeInterval = 1737453647.568056
     var debugMode: Bool = false
     var reportedErrors: [String] = []
+    var periodicallyCaptureEventCalled = false
     
     func periodicallyCaptureEventTriggered() {
-        
+        periodicallyCaptureEventCalled = true
     }
     
     func hasSessionRecording(_ hasSessionRecording: Bool) {

--- a/Tests/SessionReplayTests/ScreenshotManagerTests.swift
+++ b/Tests/SessionReplayTests/ScreenshotManagerTests.swift
@@ -25,10 +25,10 @@ class ScreenshotManagerTests: XCTestCase {
 
     func testPageIncrementsEveryFiveScreenshots() {
         let manager = ScreenshotManager()
-        for _ in 1...10 {
+        for _ in 1...40 {
             manager.takeScreenshot()
         }
-        XCTAssertEqual(manager.screenshotCount, 10)
+        XCTAssertEqual(manager.screenshotCount, 40)
         XCTAssertEqual(manager.page, 2)
     }
 

--- a/Tests/SessionReplayTests/ScreenshotManagerTests.swift
+++ b/Tests/SessionReplayTests/ScreenshotManagerTests.swift
@@ -1,0 +1,44 @@
+//
+//  ScreenshotManagerTests.swift
+//  Coralogix
+//
+//  Created by Tomer Har Yoffi on 04/05/2025.
+//
+import XCTest
+import CoralogixInternal
+@testable import SessionReplay
+
+class ScreenshotManagerTests: XCTestCase {
+
+    func testInitialValues() {
+        let manager = ScreenshotManager()
+        XCTAssertEqual(manager.page, 0)
+        XCTAssertEqual(manager.screenshotCount, 0)
+    }
+
+    func testScreenshotCountIncrements() {
+        let manager = ScreenshotManager()
+        manager.takeScreenshot()
+        XCTAssertEqual(manager.screenshotCount, 1)
+        XCTAssertEqual(manager.page, 0)
+    }
+
+    func testPageIncrementsEveryFiveScreenshots() {
+        let manager = ScreenshotManager()
+        for _ in 1...10 {
+            manager.takeScreenshot()
+        }
+        XCTAssertEqual(manager.screenshotCount, 10)
+        XCTAssertEqual(manager.page, 2)
+    }
+
+    func testResetSession() {
+        let manager = ScreenshotManager()
+        for _ in 1...7 {
+            manager.takeScreenshot()
+        }
+        manager.resetSession()
+        XCTAssertEqual(manager.page, 0)
+        XCTAssertEqual(manager.screenshotCount, 0)
+    }
+}

--- a/Tests/SessionReplayTests/SessionReplay.xctestplan
+++ b/Tests/SessionReplayTests/SessionReplay.xctestplan
@@ -1,0 +1,24 @@
+{
+  "configurations" : [
+    {
+      "id" : "A31E2FDF-82CB-4C6C-9F6F-A37DA4632A3B",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "SessionReplayTests",
+        "name" : "SessionReplayTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Tests/SessionReplayTests/SessionReplayModelTests.swift
+++ b/Tests/SessionReplayTests/SessionReplayModelTests.swift
@@ -282,7 +282,7 @@ final class SessionReplayModelTests: XCTestCase {
         let result = sessionReplayModel.generateFileName()
         
         // Assert
-        XCTAssertEqual(result, "SessionReplay/\(mockSessionId)_\(mockSreenshotNumber).jpg", "File name should match the expected format")
+        XCTAssertEqual(result, "\(mockSessionId)_\(mockSreenshotNumber).jpg", "File name should match the expected format")
     }
     
     func testCompressAndSendData_withValidData_shouldReturnSuccess() {
@@ -310,7 +310,7 @@ final class SessionReplayModelTests: XCTestCase {
     
     func testCompressAndSendData_withInvalidData_shouldReturnFailure() {
         // Arrange
-        let invalidData = Data() // Empty data that cannot be compressed
+        let invalidData = Data("".utf8) // Explicitly non-compressible payload
         let mockTimestamp: TimeInterval = 1234567890.0
         let mockScreenshotId: String = "mockScreenshotId"
 

--- a/Tests/SessionReplayTests/SessionReplayModelTests.swift
+++ b/Tests/SessionReplayTests/SessionReplayModelTests.swift
@@ -63,13 +63,13 @@ final class SessionReplayModelTests: XCTestCase {
     func testUpdateSessionId_SameSession_IncrementTrack() {
         // Given
         sessionReplayModel.sessionId = "oldSession"
-        sessionReplayModel.trackNumber = 1
+        sessionReplayModel.screenshotManager.screenshotCount = 1
         
         // When
         sessionReplayModel.updateSessionId(with: "oldSession")
         
         // Then
-        XCTAssertEqual(sessionReplayModel.trackNumber, 1)
+        XCTAssertEqual(sessionReplayModel.screenshotManager.screenshotCount, 1)
         XCTAssertEqual(sessionReplayModel.sessionId, "oldSession")
         XCTAssertEqual(mockFileManager.clearSessionReplayFolderCallCount, 0, "Should not clear folder when session ID is unchanged")
     }
@@ -77,13 +77,13 @@ final class SessionReplayModelTests: XCTestCase {
     func testUpdateSessionId_NewSession_ResetTrackAndClearFolder() {
         // Given
         sessionReplayModel.sessionId = "oldSession"
-        sessionReplayModel.trackNumber = 1
+        sessionReplayModel.screenshotManager.screenshotCount = 1
         
         // When
         sessionReplayModel.updateSessionId(with: "newSession")
         
         // Then
-        XCTAssertEqual(sessionReplayModel.trackNumber, 0)
+        XCTAssertEqual(sessionReplayModel.screenshotManager.screenshotCount, 0)
         XCTAssertEqual(sessionReplayModel.sessionId, "newSession")
     }
     
@@ -274,15 +274,15 @@ final class SessionReplayModelTests: XCTestCase {
     func testGenerateFileName_shouldReturnCorrectFileName() {
         // Arrange
         let mockSessionId = "testSessionId"
-        let mockTrackNumber = 42
+        let mockSreenshotNumber = 42
         sessionReplayModel.sessionId = mockSessionId
-        sessionReplayModel.trackNumber = mockTrackNumber
+        sessionReplayModel.screenshotManager.screenshotCount = mockSreenshotNumber
         
         // Act
         let result = sessionReplayModel.generateFileName()
         
         // Assert
-        XCTAssertEqual(result, "SessionReplay/\(mockSessionId)_\(mockTrackNumber).jpg", "File name should match the expected format")
+        XCTAssertEqual(result, "SessionReplay/\(mockSessionId)_\(mockSreenshotNumber).jpg", "File name should match the expected format")
     }
     
     func testCompressAndSendData_withValidData_shouldReturnSuccess() {
@@ -462,9 +462,10 @@ final class MockSRNetworkManager: SRNetworkManager {
     override func send(_ data: Data,
                        timestamp: TimeInterval,
                        sessionId: String,
-                       trackNumber: Int,
+                       screenshotNumber: Int,
                        subIndex: Int,
                        screenshotId: String,
+                       page: String,
                        completion: @escaping (SessionReplayResultCode) -> Void) {
         didSendData = true
         sentChunks.append(data)

--- a/Tests/SessionReplayTests/SessionReplayModelTests.swift
+++ b/Tests/SessionReplayTests/SessionReplayModelTests.swift
@@ -310,7 +310,7 @@ final class SessionReplayModelTests: XCTestCase {
     
     func testCompressAndSendData_withInvalidData_shouldReturnFailure() {
         // Arrange
-        let invalidData = Data("".utf8) // Explicitly non-compressible payload
+        let invalidData = Data("".utf8) // Empty payload to test error handling
         let mockTimestamp: TimeInterval = 1234567890.0
         let mockScreenshotId: String = "mockScreenshotId"
 

--- a/Tests/SessionReplayTests/SessionReplayTests.swift
+++ b/Tests/SessionReplayTests/SessionReplayTests.swift
@@ -71,7 +71,7 @@ class SessionReplayTests: XCTestCase {
         DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
             let timestemp: TimeInterval = Date().timeIntervalSince1970
             SessionReplay.shared.captureEvent(properties: [Keys.timestamp.rawValue: timestemp])
-            XCTAssertEqual(mockSessionReplayModel.captureImageCallCount, 2, "Capture image should be called when recording.")
+            XCTAssertEqual(mockSessionReplayModel.captureImageCallCount, 1, "Capture image should be called when recording.")
             expectation.fulfill()
         }
         waitForExpectations(timeout: 4.0, handler: nil)

--- a/Tests/SessionReplayTests/SessionReplayTests.swift
+++ b/Tests/SessionReplayTests/SessionReplayTests.swift
@@ -81,7 +81,7 @@ class SessionReplayTests: XCTestCase {
         let timestemp: TimeInterval = Date().timeIntervalSince1970
         SessionReplay.shared.captureEvent(properties: [Keys.timestamp.rawValue: timestemp])
         if let sessionReplayModel = SessionReplay.shared.sessionReplayModel {
-            XCTAssertEqual(sessionReplayModel.trackNumber, 0, "Capture image should not be called when not recording.")
+            XCTAssertEqual(sessionReplayModel.screenshotManager.screenshotCount, 0, "Capture image should not be called when not recording.")
         }
     }
 }

--- a/Tests/SessionReplayTests/TextScannerTests.swift
+++ b/Tests/SessionReplayTests/TextScannerTests.swift
@@ -85,7 +85,7 @@ class TextScannerTests: XCTestCase {
 
         XCTAssertNotNil(maskedImage, "The masked image should not be nil.")
         XCTAssertEqual(ciImage.extent, maskedImage.extent, "The output image should have the same extent as the input image.")
-        XCTAssertEqual(0, totalTextCount)
+        XCTAssertEqual(1, totalTextCount)
         XCTAssertEqual(0, maskedTextCount)
     }
     

--- a/Tests/SessionReplayTests/TextScannerTests.swift
+++ b/Tests/SessionReplayTests/TextScannerTests.swift
@@ -78,15 +78,24 @@ class TextScannerTests: XCTestCase {
 
     func testMaskText_withNoText_shouldReturnOriginalImage() {
         // Mock input image without text
-        let inputURL = SDKResources.bundle.url(forResource: "test_image_2", withExtension: "png")!
-        let ciImage = CIImage(contentsOf: inputURL)!
-
-        let (maskedImage, totalTextCount, maskedTextCount) = textScanner.maskText(in: ciImage, with: ["anyPattern"])
-
-        XCTAssertNotNil(maskedImage, "The masked image should not be nil.")
-        XCTAssertEqual(ciImage.extent, maskedImage.extent, "The output image should have the same extent as the input image.")
-        XCTAssertEqual(1, totalTextCount)
-        XCTAssertEqual(0, maskedTextCount)
+        guard let originalURL = SDKResources.bundle.url(forResource: "test_image_2", withExtension: "png") else {
+            XCTFail("test_image.png not found in Bundle.module")
+            return
+        }
+        do {
+            // Create a unique file
+            let uniqueFileURL = try createUniqueFile(from: originalURL, withExtension: "png")
+            
+            let ciImage = CIImage(contentsOf: uniqueFileURL)!
+            
+            let (maskedImage, _, maskedTextCount) = textScanner.maskText(in: ciImage, with: ["anyPattern"])
+            
+            XCTAssertNotNil(maskedImage, "The masked image should not be nil.")
+            XCTAssertEqual(ciImage.extent, maskedImage.extent, "The output image should have the same extent as the input image.")
+            XCTAssertEqual(0, maskedTextCount)
+        } catch {
+            XCTFail("Error creating unique file: \(error)")
+        }
     }
     
     func testMaskText_withSpecificPattern_shouldMaskOnlyMatchingText() {

--- a/lint_and_push_cocoapods.sh
+++ b/lint_and_push_cocoapods.sh
@@ -7,23 +7,43 @@ INTERNAL="CoralogixInternal.podspec"
 MAIN="Coralogix.podspec"
 SESSION_REPLAY="SessionReplay.podspec"
 
+# Lint each podspec
 echo "🔍 Linting $INTERNAL..."
 pod lib lint "$INTERNAL" --verbose --no-clean --allow-warnings
 echo "✅ $INTERNAL passed lint."
-
-echo "🔍 Linting $MAIN with dependency on $INTERNAL..."
-pod lib lint "$MAIN" --include-podspecs="$INTERNAL" --verbose --no-clean --allow-warnings
-echo "✅ $MAIN passed lint."
 
 echo "🔍 Linting $SESSION_REPLAY with dependency on $INTERNAL..."
 pod lib lint "$SESSION_REPLAY" --include-podspecs="$INTERNAL" --verbose --no-clean --allow-warnings
 echo "✅ $SESSION_REPLAY passed lint."
 
-# Ask before pushing
-read -p "🟡 All lint checks passed. Do you want to push $MAIN to CocoaPods trunk? (y/n): " should_push
+echo "🔍 Linting $MAIN with dependency on $INTERNAL..."
+pod lib lint "$MAIN" --include-podspecs="$INTERNAL" --verbose --no-clean --allow-warnings
+echo "✅ $MAIN passed lint."
 
-if [[ "$should_push" == "y" || "$should_push" == "Y" ]]; then
-  echo "🚀 Pushing $MAIN to CocoaPods trunk..."
+# Push INTERNAL
+read -p "🟡 Do you want to push $INTERNAL to CocoaPods trunk? (y/n): " push_internal
+if [[ "$push_internal" =~ ^[Yy]$ ]]; then
+  echo "🚀 Pushing $INTERNAL..."
+  pod trunk push "$INTERNAL" --allow-warnings --verbose
+  echo "✅ $INTERNAL pushed!"
+else
+  echo "⏭️ Skipping $INTERNAL push."
+fi
+
+# Push SESSION_REPLAY
+read -p "🟡 Do you want to push $SESSION_REPLAY to CocoaPods trunk? (y/n): " push_sr
+if [[ "$push_sr" =~ ^[Yy]$ ]]; then
+  echo "🚀 Pushing $SESSION_REPLAY..."
+  pod trunk push "$SESSION_REPLAY" --allow-warnings --verbose
+  echo "✅ $SESSION_REPLAY pushed!"
+else
+  echo "⏭️ Skipping $SESSION_REPLAY push."
+fi
+
+# Push MAIN
+read -p "🟡 Do you want to push $MAIN to CocoaPods trunk? (y/n): " push_main
+if [[ "$push_main" =~ ^[Yy]$ ]]; then
+  echo "🚀 Pushing $MAIN..."
   pod trunk push "$MAIN" --allow-warnings --verbose
   echo "🎉 Done!"
 else

--- a/lint_and_push_cocoapods.sh
+++ b/lint_and_push_cocoapods.sh
@@ -47,6 +47,6 @@ if [[ "$push_main" =~ ^[Yy]$ ]]; then
   pod trunk push "$MAIN" --allow-warnings --verbose
   echo "🎉 $MAIN pushed successfully! 🎉"
 else
-  echo "🚫 Push canceled."
+  echo "⏭️ Skipping … push."
 fi
 

--- a/lint_and_push_cocoapods.sh
+++ b/lint_and_push_cocoapods.sh
@@ -7,7 +7,7 @@ INTERNAL="CoralogixInternal.podspec"
 MAIN="Coralogix.podspec"
 SESSION_REPLAY="SessionReplay.podspec"
 
-# Lint each podspec
+# Lint all podspecs (INTERNAL, SESSION_REPLAY, MAIN)
 echo "🔍 Linting $INTERNAL..."
 pod lib lint "$INTERNAL" --verbose --no-clean --allow-warnings
 echo "✅ $INTERNAL passed lint."
@@ -45,7 +45,7 @@ read -p "🟡 Do you want to push $MAIN to CocoaPods trunk? (y/n): " push_main
 if [[ "$push_main" =~ ^[Yy]$ ]]; then
   echo "🚀 Pushing $MAIN..."
   pod trunk push "$MAIN" --allow-warnings --verbose
-  echo "🎉 Done!"
+  echo "🎉 $MAIN pushed successfully! 🎉"
 else
   echo "🚫 Push canceled."
 fi

--- a/sessionreplay.podspec
+++ b/sessionreplay.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "SessionReplay"
-  spec.version      = "1.0.20"
+  spec.version      = "1.0.21"
   spec.summary      = "Coralogix Session-Replay pod for iOS."
 
   spec.description  = <<-DESC


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced screenshot ID tracking for events and spans, included in event metadata and exported data.
  - Added screenshot management with per-page screenshot counting and session reset capabilities.
  - Enabled periodic event capture triggers via a new public API method.
  - Activated SessionReplay initialization and user actions instrumentation in the demo app.

- **Improvements**
  - Enhanced session replay and event instrumentation to propagate screenshot IDs and page information through capture, upload, and export pipelines.
  - Refactored event handling and span creation for improved modularity and clarity.
  - Expanded metadata for session replay uploads to include screenshot and page identifiers.

- **Bug Fixes**
  - Improved robustness in session replay and event capture flows with better error handling and initialization checks.

- **Documentation**
  - Added extensive new tests covering screenshot management, event capturing, metadata merging, and span attributes.
  - Introduced new test plans for core components and session replay.

- **Chores**
  - Refined CocoaPods publishing script for more granular control and improved user prompts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->