### PR TITLE
 Disable Swizzeling ALPH-2246

### DIFF
--- a/Coralogix.podspec
+++ b/Coralogix.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |spec|
 
   spec.static_framework = true
   spec.dependency 'PLCrashReporter', '~> 1.11.1'
-  spec.dependency 'CoralogixInternal', '1.0.21'
+  spec.dependency 'CoralogixInternal', '1.0.22'
 
   spec.test_spec 'Tests' do |test|
     test.source_files = 'Tests/CoralogixRumTests/**/*.swift'

--- a/Coralogix.podspec
+++ b/Coralogix.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "Coralogix"
-  spec.version      = "1.0.21"
+  spec.version      = "1.0.22"
   spec.summary      = "Coralogix OpenTelemetry pod for iOS."
 
   spec.description  = <<-DESC

--- a/Coralogix/Sources/CoralogixRum.swift
+++ b/Coralogix/Sources/CoralogixRum.swift
@@ -275,53 +275,61 @@ public struct CoralogixExporterOptions {
         case lifeCycle
     }
 
-    // Configuration for user context.
+    /// Configuration for user context.
     var userContext: UserContext?
     
-    // Turns on/off internal debug logging
+    /// Turns on/off internal debug logging
     let debug: Bool
     
-    // Applies for Fetch URLs. URLs that match that regex will not be traced.
+    /// Applies for Fetch URLs. URLs that match that regex will not be traced.
     let ignoreUrls: [String]?
     
-    // A pattern for error messages which should not be sent to Coralogix. By default, all errors will be sent.
+    /// A pattern for error messages which should not be sent to Coralogix. By default, all errors will be sent.
     let ignoreErrors: [String]?
     
-    // Coralogix account domain
+    /// Coralogix account domain
     let coralogixDomain: CoralogixDomain
     
-    // Coralogix token
+    /// Coralogix token
     var publicKey: String
     
-    // Environment
+    /// Environment
     let environment: String
     
-    // Application name
+    /// Application name
     var application: String
     
-    // Appliaction version
+    /// Appliaction version
     var version: String
         
     var labels: [String: Any]?
     
-    // Number between 0-100 as a precentage of SDK should be init.
+    /// Number between 0-100 as a precentage of SDK should be init.
     var sdkSampler: SDKSampler
     
-    // The timeinterval the SDK will run the FPS sampling in an hour. default is every 1 minute.
+    /// The timeinterval the SDK will run the FPS sampling in an hour. default is every 1 minute.
     let mobileVitalsFPSSamplingRate: Int
     
-    // A list of instruments that you wish to switch off during runtime. all instrumentations are active by default.
+    /// A list of instruments that you wish to switch off during runtime. all instrumentations are active by default.
     var instrumentations: [InstrumentationType: Bool]?
     
-    // Determines whether the SDK should collect the user's IP address and corresponding geolocation data. Defaults to true.
+    /// Determines whether the SDK should collect the user's IP address and corresponding geolocation data. Defaults to true.
     var collectIPData: Bool
     
-    // Enable event access and modification before sending to Coralogix, supporting content modification, and event discarding.
+    /// Enable event access and modification before sending to Coralogix, supporting content modification, and event discarding.
     var beforeSend: (([String: Any]) -> [String: Any]?)?
     
-    // Alternative beforeSend for Other Platfoms.
+    /// Alternative beforeSend for Other Platfoms.
     public var beforeSendCallBack: (([[String: Any]]) -> Void)? = nil
-
+    
+    /// When set to `false`, disables Coralogix's automatic method swizzling.
+    ///
+    /// Swizzling is used to auto-instrument various system behaviors (e.g., view controller lifecycle,
+    /// app delegate events, network calls). Disabling it gives you full manual control over instrumentation.
+    ///
+    /// - Remark: As of the current Coralogix SDK version, `enableSwizzling = false` only disables `NSURLSession` instrumentation.
+    public var enableSwizzling: Bool
+    
     public init(coralogixDomain: CoralogixDomain,
                 userContext: UserContext? = nil,
                 environment: String,
@@ -336,6 +344,7 @@ public struct CoralogixExporterOptions {
                 instrumentations: [InstrumentationType: Bool]? = nil,
                 collectIPData: Bool = true,
                 beforeSend: (([String: Any]) -> [String: Any]?)? = nil,
+                enableSwizzling: Bool = true,
                 debug: Bool = false) {
         self.coralogixDomain = coralogixDomain
         self.userContext = userContext
@@ -352,6 +361,7 @@ public struct CoralogixExporterOptions {
         self.instrumentations = instrumentations
         self.collectIPData = collectIPData
         self.beforeSend = beforeSend
+        self.enableSwizzling = enableSwizzling
     }
     
     internal func shouldInitInstumentation(instumentation: InstrumentationType) -> Bool {

--- a/Coralogix/Sources/Instrumentation/NetworkInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/NetworkInstrumentation.swift
@@ -12,13 +12,22 @@ extension CoralogixRum {
     private static let exporterQueue = DispatchQueue(label: "com.coralogix.exporter.queue")
 
     public func initializeNetworkInstrumentation() {
-        let configuration = URLSessionInstrumentationConfiguration(spanCustomization: self.spanCustomization, shouldInjectTracingHeaders: { _ /*request*/ in
-            // TBD: need to implement the follow
-            // Received shouldInjectTracingHeaders from Coralogix options options
-            // To do this only on URL that are not internal
-            return true
-        }, receivedResponse: self.receivedResponse)
-        self.sessionInstrumentation = URLSessionInstrumentation(configuration: configuration)
+        guard let options = self.coralogixExporter?.getOptions() else {
+            Log.e("[Coralogix] missing coralogix options")
+            return
+        }
+        
+        if options.enableSwizzling == true {
+            let configuration = URLSessionInstrumentationConfiguration(spanCustomization: self.spanCustomization, shouldInjectTracingHeaders: { _ /*request*/ in
+                // TBD: need to implement the follow
+                // Received shouldInjectTracingHeaders from Coralogix options options
+                // To do this only on URL that are not internal
+                return true
+            }, receivedResponse: self.receivedResponse)
+            self.sessionInstrumentation = URLSessionInstrumentation(configuration: configuration)
+        } else {
+            Log.e("[Coralogix] Swizzling is disabled")
+        }
     }
     
     private func spanCustomization(request: URLRequest, spanBuilder: SpanBuilder) {

--- a/CoralogixInternal.podspec
+++ b/CoralogixInternal.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "CoralogixInternal"
-  spec.version      = "1.0.21"
+  spec.version      = "1.0.22"
   spec.summary      = "Coralogix Internal Package. This module is not for public use."
 
   spec.description  = <<-DESC

--- a/CoralogixInternal/Sources/Log.swift
+++ b/CoralogixInternal/Sources/Log.swift
@@ -64,8 +64,6 @@ public class Log {
     }
     
     public static func error(_ error: Error) {
-        if isDebug {
-            print("🟥 \(error.localizedDescription)")
-        }
+        print("🟥 \(error.localizedDescription)")
     }
 }

--- a/CoralogixInternal/Sources/Utils.swift
+++ b/CoralogixInternal/Sources/Utils.swift
@@ -16,7 +16,7 @@ public enum ImageFormat {
 }
 
 public enum Global: String {
-    case sdk = "1.0.21"
+    case sdk = "1.0.22"
     case swiftVersion = "5.9"
     case coralogixPath = "/browser/v1beta/logs"
     case sessionReplayPath = "/browser/alpha/sessionrecording"

--- a/Example/DemoAppSwift/AppDelegate.swift
+++ b/Example/DemoAppSwift/AppDelegate.swift
@@ -41,7 +41,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             }
             return editableCxRum
         },
-                                                debug: true)
+                                               enableSwizzling: true,
+                                               debug: true)
         AppDelegate.coralogixRum = CoralogixRum(options: options)
         
         // Must be initialized after CoralogixRum

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "Coralogix",
     platforms: [
-        .iOS(.v13),
+        .iOS(.v13)
     ],
     products: [
         .library(name: "Coralogix", targets: ["Coralogix"]),
@@ -20,7 +20,7 @@ let package = Package(
         ),
         .target(
             name: "CoralogixInternal",
-            path: "CoralogixInternal/Sources/",
+            path: "CoralogixInternal/Sources/"
         ),
         .target(
             name: "Coralogix",
@@ -33,7 +33,7 @@ let package = Package(
         .target(
             name: "SessionReplay",
             dependencies: [
-                .target(name: "CoralogixInternal"),
+                .target(name: "CoralogixInternal")
             ],
             path: "SessionReplay/Sources/"
         ),

--- a/SessionReplay.podspec
+++ b/SessionReplay.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |spec|
   spec.static_framework = true
 
   spec.source_files  = 'SessionReplay/Sources/**/*.swift'
-  spec.dependency 'CoralogixInternal', '1.0.21'
+  spec.dependency 'CoralogixInternal', '1.0.22'
   
     spec.test_spec 'Tests' do |test|
         test.source_files = 'Tests/SessionReplayTests/**/*.swift'

--- a/SessionReplay.podspec
+++ b/SessionReplay.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "SessionReplay"
-  spec.version      = "1.0.21"
+  spec.version      = "1.0.22"
   spec.summary      = "Coralogix Session-Replay pod for iOS."
 
   spec.description  = <<-DESC

--- a/version_bump.sh
+++ b/version_bump.sh
@@ -66,6 +66,14 @@ update_version_in_sr_podspec() {
   sed -i '' "s/spec.version.*=.*\"[0-9]*\.[0-9]*\.[0-9]*\"/spec.version      = \"$new_version\"/" "$podspec_sr_file"
 }
 
+# Function to update CoralogixInternal dependency version in a podspec file
+update_internal_dependency_version() {
+  local new_version=$1
+  local podspec_file=$2
+  echo "Updating dependency version in: $podspec_file"
+  sed -i '' "s/\(spec.dependency 'CoralogixInternal', '\)[0-9]*\.[0-9]*\.[0-9]*\('\)/\1$new_version\2/" "$podspec_file"
+}
+
 # Main script logic
 if [ $# -ne 1 ]; then
   echo "Usage: $0 {major|minor|patch}"
@@ -132,34 +140,58 @@ ci_result=$?
 update_version_in_sr_podspec "$new_version" "$podspec_sr_file"
 sr_result=$?
 
+# Update CoralogixInternal dependency version in Coralogix.podspec and SessionReplay.podspec
+update_internal_dependency_version "$new_version" "$podspec_c_file";
+dep_c_result=$?
+
+update_internal_dependency_version "$new_version" "$podspec_sr_file";
+dep_sr_result=$?
+
+
 # Check if the sed command was successful for the Swift file
 if [ $swift_result -eq 0 ]; then
-    echo "Version updated successfully to $new_version in $swift_file"
+    echo "✅ Version updated successfully to $new_version in $swift_file"
 else
-    echo "Failed to update the version in $swift_file"
+    echo "❌ Failed to update the version in $swift_file"
     exit 1
 fi
 
 # Check if the sed command was successful for the podspec file
 if [ $c_result -eq 0 ]; then
-    echo "Version updated successfully to $new_version in $podspec_c_file"
+    echo "✅ Version updated successfully to $new_version in $podspec_c_file"
 else
-    echo "Failed to update the version in $podspec_c_file"
+    echo "❌ Failed to update the version in $podspec_c_file"
     exit 1
 fi
 
 # Check if the sed command was successful for the podspec file
 if [ $ci_result -eq 0 ]; then
-    echo "Version updated successfully to $new_version in $podspec_ci_file"
+    echo "✅ Version updated successfully to $new_version in $podspec_ci_file"
 else
-    echo "Failed to update the version in $podspec_ci_file"
+    echo "❌ Failed to update the version in $podspec_ci_file"
     exit 1
 fi
 
 # Check if the sed command was successful for the podspec file
 if [ $sr_result -eq 0 ]; then
-    echo "Version updated successfully to $new_version in $podspec_sr_file"
+    echo "✅ Version updated successfully to $new_version in $podspec_sr_file"
 else
-    echo "Failed to update the version in $podspec_sr_file"
+    echo "❌ Failed to update the version in $podspec_sr_file"
+    exit 1
+fi
+
+# Check if the sed command was successful for the podspec file
+if [ $dep_c_result -eq 0 ]; then
+    echo "✅ Dependency version updated in Coralogix.podspec"
+else
+    echo "❌ Failed to update dependency in Coralogix.podspec"
+    exit 1
+fi
+
+# Check if the sed command was successful for the podspec file
+if [ $dep_sr_result -eq 0 ]; then
+    echo "✅ Dependency version updated in SessionReplay.podspec"
+else
+    echo "❌ Failed to update dependency in SessionReplay.podspec"
     exit 1
 fi


### PR DESCRIPTION
Feat: 
* Add new options feature "enableSwizzling"
When set to `false`, disables Coralogix's automatic method swizzling.
Swizzling is used to auto-instrument various system behaviors (e.g., view controller lifecycle,
app delegate events, network calls). Disabling it gives you full manual control over instrumentation.

* Removed a trailing comma in configuration to improve code formatting.
* Version bump 1.0.22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new configuration option to enable or disable automatic method swizzling for network instrumentation.

- **Bug Fixes**
  - Error messages are now always printed, regardless of debug mode.

- **Documentation**
  - Improved and standardized documentation comments for configuration options.

- **Chores**
  - Updated version numbers to 1.0.22 across multiple modules.
  - Updated internal version references for consistency.
  - Enhanced version update scripts with improved feedback and dependency version synchronization.

- **Style**
  - Minor formatting improvements in package manifest files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->