### PR TITLE
Initialize segmentIndex When Page Is Incremented ALPH-2286

### DIFF
--- a/Example/DemoAppSwiftUI/DemoAppSwiftUIApp.swift
+++ b/Example/DemoAppSwiftUI/DemoAppSwiftUIApp.swift
@@ -12,16 +12,6 @@ import Coralogix
 struct DemoAppSwiftUIApp: App {
     @State private var coralogixRum: CoralogixRum
     init() {
-        let options = CoralogixExporterOptions(coralogixDomain: CoralogixDomain.US2,
-                                               userContext: nil,
-                                               environment: "PROD",
-                                               application: "Application",
-                                               version: "1",
-                                               publicKey:"PublicKey",
-                                               ignoreUrls: [],
-                                               ignoreErrors: [],
-                                               labels: ["item" : "playstation 5", "itemPrice" : 1000],
-                                               debug: true)
         CoralogixRumManager.shared.initialize()
         self.coralogixRum = CoralogixRumManager.shared.sdk
     }

--- a/SessionReplay/Sources/SRNetworkManager.swift
+++ b/SessionReplay/Sources/SRNetworkManager.swift
@@ -43,7 +43,7 @@ public class MetadataBuilder {
             Keys.keySessionCreationDate.rawValue: sessionCreationTime.milliseconds,
             Keys.keySessionId.rawValue: sessionId,
             Keys.subIndex.rawValue: subIndex,
-            Keys.screenshotId.rawValue: screenshotId,
+            Keys.snapshotId.rawValue: screenshotId,
             Keys.page.rawValue: page,
         ]
     }

--- a/SessionReplay/Sources/ScreenshotManager.swift
+++ b/SessionReplay/Sources/ScreenshotManager.swift
@@ -36,6 +36,7 @@ public class ScreenshotManager {
             
             if _screenshotCount % maxScreenShotsPerPage == 0 {
                 _page += 1
+                _screenshotCount = 1
                 Log.d("Page incremented to: \(_page)")
             }
         }

--- a/Tests/SessionReplayTests/SRNetworkManagerTests.swift
+++ b/Tests/SessionReplayTests/SRNetworkManagerTests.swift
@@ -164,7 +164,7 @@ final class SRNetworkManagerTests: XCTestCase {
         XCTAssertEqual(metadata[Keys.keySessionCreationDate.rawValue] as? Int, sessionCreationTime.milliseconds, "Session creation timestamp is incorrect")
         XCTAssertEqual(metadata[Keys.keySessionId.rawValue] as? String, sessionId, "Session ID value is incorrect")
         XCTAssertEqual(metadata[Keys.subIndex.rawValue] as? Int, subIndex, "Sub-index value is incorrect")
-        XCTAssertEqual(metadata[Keys.screenshotId.rawValue] as? String, screenshotId, "ScreenshotsId value is incorrect")
+        XCTAssertEqual(metadata[Keys.snapshotId.rawValue] as? String, screenshotId, "snapshotId value is incorrect")
         XCTAssertEqual(metadata[Keys.page.rawValue] as? String, page, "Page value is incorrect")
     }
     
@@ -204,7 +204,7 @@ final class SRNetworkManagerTests: XCTestCase {
             Keys.keySessionCreationDate.rawValue,
             Keys.keySessionId.rawValue,
             Keys.subIndex.rawValue,
-            Keys.screenshotId.rawValue,
+            Keys.snapshotId.rawValue,
             Keys.page.rawValue
         ]
         

--- a/Tests/SessionReplayTests/ScreenshotManagerTests.swift
+++ b/Tests/SessionReplayTests/ScreenshotManagerTests.swift
@@ -25,11 +25,11 @@ class ScreenshotManagerTests: XCTestCase {
 
     func testPageIncrementsEveryFiveScreenshots() {
         let manager = ScreenshotManager()
-        for _ in 1...40 {
+        for _ in 1...38 {
             manager.takeScreenshot()
         }
-        XCTAssertEqual(manager.screenshotCount, 40)
-        XCTAssertEqual(manager.page, 2)
+        XCTAssertEqual(manager.screenshotCount, 19)
+        XCTAssertEqual(manager.page, 1)
     }
 
     func testResetSession() {


### PR DESCRIPTION
fix: Ensure segmentIndex is properly initialized when the page is inremented to avoid stale or incorrect indexing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected screenshot count reset logic to restart from 1 when a new page begins during screenshot capture.
  - Updated a metadata key name from "screenshotId" to "snapshotId" for improved consistency.

- **Chores**
  - Simplified initialization in the demo app by removing explicit configuration options for the monitoring SDK.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->