### PR TITLE
ALPH-2914 crash of SessionMetaDataManager

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,6 @@ jobs:
       - name: Select Xcode version
         run: sudo xcode-select -s /Applications/Xcode_15.3.app
 
-      - name: Install CocoaPods (if needed)
-        run: |
-          cd Example
-          pod install
-
       - name: Run Unit Tests
         run: |
           cd Example

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: iOS SDK CI
 on:
   push:
     branches:
-      - main  # Change if your default branch is different
+      - main
   pull_request:
 
 jobs:
@@ -17,14 +17,7 @@ jobs:
       - name: Select Xcode version
         run: sudo xcode-select -s /Applications/Xcode_15.3.app
 
-      - name: Run Unit Tests
+      - name: Build & Run iOS SDK Tests
         run: |
-          cd Example
-          xcodebuild test -workspace DemoApp.xcworkspace -scheme DemoApp -destination 'platform=iOS Simulator,name=iPhone 15,OS=17.4' | xcpretty
+          xcodebuild clean build test -scheme Coralogix-Package -destination 'platform=iOS Simulator,name=iPhone 15,OS=17.4' | xcpretty
 
-      - name: Upload Test Results (optional)
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: Test Results
-          path: ~/Library/Developer/Xcode/DerivedData

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: iOS SDK CI
+
+on:
+  push:
+    branches:
+      - main  # Change if your default branch is different
+  pull_request:
+
+jobs:
+  test:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Select Xcode version
+        run: sudo xcode-select -s /Applications/Xcode_15.3.app
+
+      - name: Install CocoaPods (if needed)
+        run: |
+          cd Example
+          pod install
+
+      - name: Run Unit Tests
+        run: |
+          cd Example
+          xcodebuild test -workspace DemoApp.xcworkspace -scheme DemoApp -destination 'platform=iOS Simulator,name=iPhone 15,OS=17.4' | xcpretty
+
+      - name: Upload Test Results (optional)
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: Test Results
+          path: ~/Library/Developer/Xcode/DerivedData

--- a/Coralogix/Sources/Otel/URLSession/URLSessionInstrumentation.swift
+++ b/Coralogix/Sources/Otel/URLSession/URLSessionInstrumentation.swift
@@ -378,7 +378,7 @@ public class URLSessionInstrumentation {
         }
 
         
-        for (cls, selector, method) in methodsToSwizzle {
+        for (_, selector, method) in methodsToSwizzle {
             
             // ✅ Safety check: ensure method signature is void-return, no args
             guard let typeEncoding = method_getTypeEncoding(method),

--- a/Coralogix/Sources/Utils/SessionManager.swift
+++ b/Coralogix/Sources/Utils/SessionManager.swift
@@ -85,7 +85,7 @@ public class SessionManager {
     public func shutdown() {
         self.sessionMetadata = SessionMetadata(sessionId: "",
                                                sessionCreationDate: 0,
-                                               keychain: KeychainManager())
+                                               using: KeychainManager())
         self.idleTimer?.invalidate()
         self.hasRecording = false
     }
@@ -120,7 +120,7 @@ public class SessionManager {
         self.prevSessionMetadata = self.sessionMetadata
         self.sessionMetadata = SessionMetadata(sessionId: NSUUID().uuidString,
                                                sessionCreationDate: Date().timeIntervalSince1970,
-                                               keychain: KeychainManager())
+                                               using: KeychainManager())
         // Publish the new session Id
         if let sessionId = self.sessionMetadata?.sessionId {
             self.sessionChangedCallback?(sessionId)

--- a/Example/DemoApp.xcodeproj/project.pbxproj
+++ b/Example/DemoApp.xcodeproj/project.pbxproj
@@ -48,9 +48,6 @@
 		E68681D72BFA300800B127E7 /* ErrorSim.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6320FB32BE7CE6800A4547E /* ErrorSim.swift */; };
 		E68681D82BFA300C00B127E7 /* NetworkSim.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6320FB42BE7CE6800A4547E /* NetworkSim.swift */; };
 		E68681DA2BFC739C00B127E7 /* ModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E68681D92BFC739C00B127E7 /* ModalViewController.swift */; };
-		E6941B812D4F9E5D0037AD9B /* AFNetworking in Frameworks */ = {isa = PBXBuildFile; productRef = E6941B802D4F9E5D0037AD9B /* AFNetworking */; };
-		E6941B832D5148650037AD9B /* AFNetworking in Frameworks */ = {isa = PBXBuildFile; productRef = E6941B822D5148650037AD9B /* AFNetworking */; };
-		E6941B852D51488D0037AD9B /* AFNetworking in Frameworks */ = {isa = PBXBuildFile; productRef = E6941B842D51488D0037AD9B /* AFNetworking */; };
 		E6B60A002DB4E531003AD35D /* SessionReplay in Frameworks */ = {isa = PBXBuildFile; productRef = E6B609FF2DB4E531003AD35D /* SessionReplay */; };
 		E6B60A022DB4E53F003AD35D /* SessionReplay in Frameworks */ = {isa = PBXBuildFile; productRef = E6B60A012DB4E53F003AD35D /* SessionReplay */; };
 		E6B60A042DB4E544003AD35D /* SessionReplay in Frameworks */ = {isa = PBXBuildFile; productRef = E6B60A032DB4E544003AD35D /* SessionReplay */; };
@@ -143,7 +140,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E6941B832D5148650037AD9B /* AFNetworking in Frameworks */,
 				E66E3B6C2DA7FB6400FBC86B /* Coralogix in Frameworks */,
 				E6B60A022DB4E53F003AD35D /* SessionReplay in Frameworks */,
 			);
@@ -153,7 +149,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E6941B852D51488D0037AD9B /* AFNetworking in Frameworks */,
 				E66E3B6A2DA7FAE900FBC86B /* Coralogix in Frameworks */,
 				E6B60A002DB4E531003AD35D /* SessionReplay in Frameworks */,
 			);
@@ -163,7 +158,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E6941B812D4F9E5D0037AD9B /* AFNetworking in Frameworks */,
 				E66E3B682DA7F76C00FBC86B /* Coralogix in Frameworks */,
 				E6B60A042DB4E544003AD35D /* SessionReplay in Frameworks */,
 			);
@@ -306,7 +300,6 @@
 			);
 			name = DemoAppSwiftUI;
 			packageProductDependencies = (
-				E6941B822D5148650037AD9B /* AFNetworking */,
 				E66E3B6B2DA7FB6400FBC86B /* Coralogix */,
 				E6B60A012DB4E53F003AD35D /* SessionReplay */,
 			);
@@ -329,7 +322,6 @@
 			);
 			name = DemoAppTvOS;
 			packageProductDependencies = (
-				E6941B842D51488D0037AD9B /* AFNetworking */,
 				E66E3B692DA7FAE900FBC86B /* Coralogix */,
 				E6B609FF2DB4E531003AD35D /* SessionReplay */,
 			);
@@ -352,7 +344,6 @@
 			);
 			name = DemoAppSwift;
 			packageProductDependencies = (
-				E6941B802D4F9E5D0037AD9B /* AFNetworking */,
 				E66E3B672DA7F76C00FBC86B /* Coralogix */,
 				E6B60A032DB4E544003AD35D /* SessionReplay */,
 			);
@@ -391,7 +382,6 @@
 			);
 			mainGroup = E6320F792BE7C94F00A4547E;
 			packageReferences = (
-				E6941B7F2D4F9E5D0037AD9B /* XCRemoteSwiftPackageReference "AFNetworking" */,
 				E66E3B662DA7F76C00FBC86B /* XCLocalSwiftPackageReference "../../cx-ios-sdk" */,
 			);
 			productRefGroup = E6320F832BE7C94F00A4547E /* Products */;
@@ -876,17 +866,6 @@
 		};
 /* End XCLocalSwiftPackageReference section */
 
-/* Begin XCRemoteSwiftPackageReference section */
-		E6941B7F2D4F9E5D0037AD9B /* XCRemoteSwiftPackageReference "AFNetworking" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/AFNetworking/AFNetworking.git";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 4.0.1;
-			};
-		};
-/* End XCRemoteSwiftPackageReference section */
-
 /* Begin XCSwiftPackageProductDependency section */
 		E66E3B672DA7F76C00FBC86B /* Coralogix */ = {
 			isa = XCSwiftPackageProductDependency;
@@ -901,21 +880,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = E66E3B662DA7F76C00FBC86B /* XCLocalSwiftPackageReference "../../cx-ios-sdk" */;
 			productName = Coralogix;
-		};
-		E6941B802D4F9E5D0037AD9B /* AFNetworking */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = E6941B7F2D4F9E5D0037AD9B /* XCRemoteSwiftPackageReference "AFNetworking" */;
-			productName = AFNetworking;
-		};
-		E6941B822D5148650037AD9B /* AFNetworking */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = E6941B7F2D4F9E5D0037AD9B /* XCRemoteSwiftPackageReference "AFNetworking" */;
-			productName = AFNetworking;
-		};
-		E6941B842D51488D0037AD9B /* AFNetworking */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = E6941B7F2D4F9E5D0037AD9B /* XCRemoteSwiftPackageReference "AFNetworking" */;
-			productName = AFNetworking;
 		};
 		E6B609FF2DB4E531003AD35D /* SessionReplay */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Example/Shared/SimulateFolder/NetworkSim.swift
+++ b/Example/Shared/SimulateFolder/NetworkSim.swift
@@ -9,7 +9,7 @@ import Foundation
 import  UIKit
 import Coralogix
 //import Alamofire
-import AFNetworking
+//import AFNetworking
 
 class NetworkSim {
     static func failureNetworkRequest() {
@@ -39,22 +39,22 @@ class NetworkSim {
     }
     
     static func semdAFNetworkingRequest() {
-        let urlString = "https://jsonplaceholder.typicode.com/posts111"
-        let manager = AFHTTPSessionManager()
-        
-        // Set response serializer (JSON in this case)
-        manager.responseSerializer = AFJSONResponseSerializer()
-        
-        // Perform GET request
-        manager.get(urlString, parameters: nil, headers: nil, progress: nil, success: { task, responseObject in
-            // Success block
-            if let response = responseObject {
-                print("Response: \(response)")
-            }
-        }) { task, error in
-            // Failure block
-            print("Error: \(error.localizedDescription)")
-        }
+//        let urlString = "https://jsonplaceholder.typicode.com/posts111"
+//        let manager = AFHTTPSessionManager()
+//        
+//        // Set response serializer (JSON in this case)
+//        manager.responseSerializer = AFJSONResponseSerializer()
+//        
+//        // Perform GET request
+//        manager.get(urlString, parameters: nil, headers: nil, progress: nil, success: { task, responseObject in
+//            // Success block
+//            if let response = responseObject {
+//                print("Response: \(response)")
+//            }
+//        }) { task, error in
+//            // Failure block
+//            print("Error: \(error.localizedDescription)")
+//        }
     }
     
     static func setNetworkRequestContextSuccsess() {

--- a/Tests/CoralogixRumTests/SessionContextTests.swift
+++ b/Tests/CoralogixRumTests/SessionContextTests.swift
@@ -23,7 +23,7 @@ final class SessionContextTests: XCTestCase {
                                                  Keys.userEmail.rawValue: AttributeValue("john.doe@example.com")])
         sessionMetadata = SessionMetadata(sessionId: "session_001",
                                           sessionCreationDate: TimeInterval(1609459200),
-                                          keychain: MockKeyschainManager())
+                                          using: MockKeyschainManager())
         versionMetadata = VersionMetadata(appName: "test-app", appVersion: "1.1.1")
     }
 

--- a/Tests/CoralogixRumTests/SpanTests.swift
+++ b/Tests/CoralogixRumTests/SpanTests.swift
@@ -332,7 +332,7 @@ class VersionMetadataTests: XCTestCase {
 class SessionMetadataTests: XCTestCase {
     func testSessionMetadataInitializationNoPrevSession() {
         let mockKeyschainManager = MockKeyschainManager()
-        let metadata = SessionMetadata(sessionId: "sessionId123", sessionCreationDate: 1622505600, keychain: mockKeyschainManager)
+        let metadata = SessionMetadata(sessionId: "sessionId123", sessionCreationDate: 1622505600, using: mockKeyschainManager)
         XCTAssertEqual(metadata.sessionId, "sessionId123")
         XCTAssertEqual(metadata.sessionCreationDate, 1622505600)
     }
@@ -345,7 +345,7 @@ class SessionMetadataTests: XCTestCase {
         mockKeyschainManager.writeStringToKeychain(service: "com.coralogix.sdk", key: "sessionId", value: "session12345")
         mockKeyschainManager.writeStringToKeychain(service: "com.coralogix.sdk", key: "sessionTimeInterval", value: String(timeInterval))
         
-        let metadata = SessionMetadata(sessionId: "sessionId123", sessionCreationDate: 1622505600, keychain: mockKeyschainManager)
+        let metadata = SessionMetadata(sessionId: "sessionId123", sessionCreationDate: 1622505600, using: mockKeyschainManager)
         
         XCTAssertEqual(metadata.sessionId, "sessionId123")
         XCTAssertEqual(metadata.sessionCreationDate, 1622505600)
@@ -356,7 +356,7 @@ class SessionMetadataTests: XCTestCase {
     
     func testResetSessionMetadata() {
         let mockKeyschainManager = MockKeyschainManager()
-        var metadata = SessionMetadata(sessionId: "sessionId123", sessionCreationDate: 1622505600, keychain: mockKeyschainManager)
+        var metadata = SessionMetadata(sessionId: "sessionId123", sessionCreationDate: 1622505600, using: mockKeyschainManager)
         metadata.resetSessionMetadata()
         
         XCTAssertEqual(metadata.sessionId, "")


### PR DESCRIPTION
fix: first crash of UrlSessionInstrumentation
fix: second crash of SessionMetaDataManager
feat: add ci to run test on each push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added a continuous integration workflow for automated testing on iOS.
  - Removed all references to the AFNetworking package from the project configuration.
- **Refactor**
  - Improved internal handling of keychain usage and logging in session metadata management.
  - Enhanced the reliability and clarity of network instrumentation logic, including better method detection and swizzling.
- **Style**
  - Disabled AFNetworking-related code in network simulation for clarity and maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->