### PR TITLE
Prevent crash during class swizzling by filtering unsafe or irrelevant classes

### DIFF
--- a/Coralogix/Sources/Otel/URLSession/InstrumentationUtils.swift
+++ b/Coralogix/Sources/Otel/URLSession/InstrumentationUtils.swift
@@ -24,6 +24,45 @@ enum InstrumentationUtils {
         allClasses.deallocate()
         return classes
     }
+    
+    static func objc_getSafeClassList() -> [AnyClass] {
+        let ignoredPrefixes = [
+            "SVG",     // SVGKit
+            "SK",      // SpriteKit
+            "CN",      // Contacts
+            "AV",      // AVFoundation
+            "UI",      // UIKit
+            "NS",      // Foundation
+            "CA",      // CoreAnimation
+            "WK",      // WebKit
+        ]
+
+        let safePrefixes = [
+            "AF",          // AFNetworking
+            "NSURL",       // Foundation
+            "Coralogix"    // SDK internal
+        ]
+        
+        let allClasses = objc_getClassList()
+        var safeClasses: [AnyClass] = []
+        
+        for cls in allClasses {
+            let className = NSStringFromClass(cls)
+
+            // Skip problematic or irrelevant classes
+            if ignoredPrefixes.contains(where: { className.hasPrefix($0) }) {
+                continue
+            }
+
+            // Focus only on known targets (e.g., AFNetworking)
+            if !safePrefixes.contains(where: { className.hasPrefix($0) }) {
+                continue
+            }
+            
+            safeClasses.append(cls)
+        }
+        return safeClasses
+    }
 
     static func instanceRespondsAndImplements(cls: AnyClass, selector: Selector) -> Bool {
         var implements = false

--- a/Coralogix/Sources/Otel/URLSession/URLSessionInstrumentation.swift
+++ b/Coralogix/Sources/Otel/URLSession/URLSessionInstrumentation.swift
@@ -376,7 +376,7 @@ public class URLSessionInstrumentation {
         
         // Swizzle AFNetworking (if used)
         if NSClassFromString("AFURLSessionManager") != nil {
-            let classes = InstrumentationUtils.objc_getClassList()
+            let classes = InstrumentationUtils.objc_getSafeClassList()
             for cls in classes {
                 appendMethodIfExists(for: cls, selector: NSSelectorFromString("af_resume"))
             }


### PR DESCRIPTION
📝 General:
This PR improves the robustness of the URLSession instrumentation by filtering the list of classes before applying swizzling via appendMethodIfExists.

🚨 Problem
In some projects, class swizzling via InstrumentationUtilities.getAllClasses() leads to crashes when +initialize is triggered on third-party classes that are not safe to introspect. A common example is SVGLength from SVGKit, which crashes when +[SVGLength initialize] accesses UIScreen.mainScreen.bounds too early in the app lifecycle.

This is triggered indirectly when iterating over all loaded classes and performing method lookups for swizzling, which causes +initialize to run on classes that were never intended to be inspected.

✅ Solution
To prevent this:

We now filter out classes with known unsafe or irrelevant prefixes, such as "SVG", "UI", "CNContact", etc.

We limit inspection to classes with known relevant prefixes like "AF" (AFNetworking), "NSURL", and "Coralogix".

This ensures that only classes likely involved in networking instrumentation are swizzled, avoiding side effects from unrelated SDKs.

🔒 Safety
NSStringFromClass() is used to safely evaluate class names without triggering +initialize.

All filtering happens before any method reflection or swizzling is attempted.

🧪 Impact
This change prevents hard crashes during app startup when instrumentation is initialized — particularly in complex projects with large dependency graphs (e.g., 50,000+ classes loaded).