### PR TITLE
 Fix the following Crashes ALPH-2498

### DIFF
--- a/Coralogix.podspec
+++ b/Coralogix.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "Coralogix"
-  spec.version      = "1.1.0"
+  spec.version      = "1.1.1"
   spec.summary      = "Coralogix OpenTelemetry pod for iOS."
 
   spec.description  = <<-DESC
@@ -29,7 +29,7 @@ Pod::Spec.new do |spec|
 
   spec.static_framework = true
   spec.dependency 'PLCrashReporter', '~> 1.11.1'
-  spec.dependency 'CoralogixInternal', '1.1.0'
+  spec.dependency 'CoralogixInternal', '1.1.1'
 
   spec.test_spec 'Tests' do |test|
     test.source_files = 'Tests/CoralogixRumTests/**/*.swift'

--- a/Coralogix/Sources/Instrumentation/NetworkInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/NetworkInstrumentation.swift
@@ -18,14 +18,28 @@ extension CoralogixRum {
         }
         
         if options.enableSwizzling == true {
-            let configuration = URLSessionInstrumentationConfiguration(spanCustomization: self.spanCustomization, shouldInjectTracingHeaders: { [weak self] request in
-                return self?.shouldAddTraceParent(to: request, options: options) ?? false
-            }, receivedResponse: self.receivedResponse)
-            self.sessionInstrumentation = URLSessionInstrumentation(configuration: configuration)
-            self.sessionInstrumentation?.enableNetworkInstrumentation()
+            if Thread.isMainThread {
+                initializeInstrumentation(options: options)
+            } else {
+                DispatchQueue.main.sync {
+                    initializeInstrumentation(options: options)
+                }
+            }
         } else {
             Log.e("[Coralogix] Swizzling is disabled")
         }
+    }
+    
+    internal func initializeInstrumentation(options: CoralogixExporterOptions) {
+        let configuration = URLSessionInstrumentationConfiguration(
+            spanCustomization: self.spanCustomization,
+            shouldInjectTracingHeaders: { [weak self] request in
+                return self?.shouldAddTraceParent(to: request, options: options) ?? false
+            },
+            receivedResponse: self.receivedResponse,
+            ignoredClassPrefixes: options.ignoredClassPrefixes
+        )
+        self.sessionInstrumentation = URLSessionInstrumentation(configuration: configuration)
     }
     
     internal func shouldAddTraceParent(to request: URLRequest, options: CoralogixExporterOptions) -> Bool {

--- a/Coralogix/Sources/Model/CoralogixExporterOptions.swift
+++ b/Coralogix/Sources/Model/CoralogixExporterOptions.swift
@@ -78,6 +78,9 @@ public struct CoralogixExporterOptions {
     
     public var traceParentInHeader: [String: Any]?
     
+    /// The Array of Prefixes you can avoid in swizzle process (Network)
+    public let ignoredClassPrefixes: [String]?
+    
     public init(coralogixDomain: CoralogixDomain,
                 userContext: UserContext? = nil,
                 environment: String,
@@ -95,6 +98,7 @@ public struct CoralogixExporterOptions {
                 enableSwizzling: Bool = true,
                 proxyUrl: String? = nil,
                 traceParentInHeader: [String: Any]? = nil,
+                ignoredClassPrefixes: [String]? = nil,
                 debug: Bool = false) {
         self.coralogixDomain = coralogixDomain
         self.userContext = userContext
@@ -114,6 +118,7 @@ public struct CoralogixExporterOptions {
         self.enableSwizzling = enableSwizzling
         self.proxyUrl = proxyUrl
         self.traceParentInHeader = traceParentInHeader
+        self.ignoredClassPrefixes = ignoredClassPrefixes
     }
     
     internal func shouldInitInstrumentation(instrumentation: InstrumentationType) -> Bool {

--- a/Coralogix/Sources/Otel/OpenTelemetryApi/Internal/SwiftExtensions.swift
+++ b/Coralogix/Sources/Otel/OpenTelemetryApi/Internal/SwiftExtensions.swift
@@ -46,7 +46,51 @@ private extension FixedWidthInteger {
 }
 
 extension Array where Element == [String: Any] {
+    /// Returns a full deep copy of self, recursively copying any nested
+    /// [String: Any] dictionaries or [Any] arrays.
     func deepCopy() -> [[String: Any]] {
-        return self.map { $0.mapValues { $0 } }
+        return self.map { dict in
+            return dict.deepCopy()
+        }
+    }
+}
+
+extension Dictionary where Key == String, Value == Any {
+    /// Recursively deep‐copies this dictionary
+    func deepCopy() -> [String: Any] {
+        var copy: [String: Any] = [:]
+        for (key, value) in self {
+            copy[key] = deepCopy(value: value)
+        }
+        return copy
+    }
+
+    /// Helper that inspects a value and copies dicts / arrays recursively
+    private func deepCopy(value: Any) -> Any {
+        switch value {
+        case let dict as [String: Any]:
+            return dict.deepCopy()
+        case let array as [Any]:
+            return array.deepCopyAnyArray()
+        default:
+            // Primitives (String, Int, Double, Bool, etc.) are value types
+            return value
+        }
+    }
+}
+
+extension Array where Element == Any {
+    /// Recursively deep‐copies this array
+    func deepCopyAnyArray() -> [Any] {
+        return self.map { element in
+            switch element {
+            case let dict as [String: Any]:
+                return dict.deepCopy()
+            case let array as [Any]:
+                return array.deepCopyAnyArray()
+            default:
+                return element
+            }
+        }
     }
 }

--- a/Coralogix/Sources/Otel/OpenTelemetryApi/Internal/SwiftExtensions.swift
+++ b/Coralogix/Sources/Otel/OpenTelemetryApi/Internal/SwiftExtensions.swift
@@ -44,3 +44,9 @@ private extension FixedWidthInteger {
         self = converted
     }
 }
+
+extension Array where Element == [String: Any] {
+    func deepCopy() -> [[String: Any]] {
+        return self.map { $0.mapValues { $0 } }
+    }
+}

--- a/Coralogix/Sources/Otel/URLSession/InstrumentationUtils.swift
+++ b/Coralogix/Sources/Otel/URLSession/InstrumentationUtils.swift
@@ -24,6 +24,25 @@ enum InstrumentationUtils {
         allClasses.deallocate()
         return classes
     }
+    
+    static func objc_getSafeClassList(ignoredPrefixes: [String]? = nil) -> [AnyClass] {
+        let allClasses = objc_getClassList()
+        var safeClasses: [AnyClass] = []
+        
+        for cls in allClasses {
+            let className = NSStringFromClass(cls)
+            if let ignoredPrefixes = ignoredPrefixes {
+                if ignoredPrefixes.contains(where: { className.hasPrefix($0) }) {
+                    //Log.d("[URLSessionInstrumentation] Skipping class \(className) due to ignored prefix")
+                    continue
+                }
+            }
+            
+            safeClasses.append(cls)
+        }
+        Log.d("[URLSessionInstrumentation] Found \(safeClasses.count) safe classes for swizzling")
+        return safeClasses
+    }
 
     static func instanceRespondsAndImplements(cls: AnyClass, selector: Selector) -> Bool {
         var implements = false

--- a/Coralogix/Sources/Otel/URLSession/URLSessionInstrumentationConfiguration.swift
+++ b/Coralogix/Sources/Otel/URLSession/URLSessionInstrumentationConfiguration.swift
@@ -19,7 +19,8 @@ public struct URLSessionInstrumentationConfiguration {
                 createdRequest: ((URLRequest, any Span) -> Void)? = nil,
                 receivedResponse: ((URLResponse, DataOrFile?, any Span) -> Void)? = nil,
                 receivedError: ((Error, DataOrFile?, HTTPStatus, any Span) -> Void)? = nil,
-                delegateClassesToInstrument: [AnyClass]? = nil) {
+                delegateClassesToInstrument: [AnyClass]? = nil,
+                ignoredClassPrefixes: [String]? = nil) {
         self.shouldRecordPayload = shouldRecordPayload
         self.shouldInstrument = shouldInstrument
         self.shouldInjectTracingHeaders = shouldInjectTracingHeaders
@@ -30,6 +31,7 @@ public struct URLSessionInstrumentationConfiguration {
         self.receivedResponse = receivedResponse
         self.receivedError = receivedError
         self.delegateClassesToInstrument = delegateClassesToInstrument
+        self.ignoredClassPrefixes = ignoredClassPrefixes
     }
 
     // Instrumentation Callbacks
@@ -67,4 +69,7 @@ public struct URLSessionInstrumentationConfiguration {
     
     ///  The array of URLSession delegate classes that will be instrumented by the library, will autodetect if nil is passed.
     public var delegateClassesToInstrument: [AnyClass]?
+    
+    /// The Array of Prefixes you can avoid in swizzle process
+    public let ignoredClassPrefixes: [String]?
 }

--- a/CoralogixInternal.podspec
+++ b/CoralogixInternal.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "CoralogixInternal"
-  spec.version      = "1.1.0"
+  spec.version      = "1.1.1"
   spec.summary      = "Coralogix Internal Package. This module is not for public use."
 
   spec.description  = <<-DESC

--- a/CoralogixInternal/Sources/Keys.swift
+++ b/CoralogixInternal/Sources/Keys.swift
@@ -185,7 +185,7 @@ public enum Keys: String {
     case queueUrlProcessing = "com.coralogix.urlProcessing"
     case queueMediaInput = "com.coralogix.mediainput"
     case queueSpanProcessingQueue = "com.coralogix.spanProcessingQueue"
-    case undefined = "N/A"
+    case undefined = ""
     case cxforward
     case enable
     case options

--- a/CoralogixInternal/Sources/Keys.swift
+++ b/CoralogixInternal/Sources/Keys.swift
@@ -185,6 +185,7 @@ public enum Keys: String {
     case queueUrlProcessing = "com.coralogix.urlProcessing"
     case queueMediaInput = "com.coralogix.mediainput"
     case queueSpanProcessingQueue = "com.coralogix.spanProcessingQueue"
+    case queueViewManagerQueue = "com.coralogix.viewManagerQueue"
     case undefined = ""
     case cxforward
     case enable

--- a/CoralogixInternal/Sources/Utils.swift
+++ b/CoralogixInternal/Sources/Utils.swift
@@ -16,7 +16,7 @@ public enum ImageFormat {
 }
 
 public enum Global: String {
-    case sdk = "1.1.0"
+    case sdk = "1.1.1"
     case swiftVersion = "5.9"
     case coralogixPath = "/browser/v1beta/logs"
     case sessionReplayPath = "/browser/alpha/sessionrecording"

--- a/Example/Shared/SimulateFolder/NetworkSim.swift
+++ b/Example/Shared/SimulateFolder/NetworkSim.swift
@@ -86,7 +86,7 @@ class NetworkSim {
     static func performGetRequest() {
            let url = URL(string: "https://jsonplaceholder.typicode.com/posts/1")! // Example API
            
-           var request = URLRequest(url: url)
+           var request = URLRequest(url: url, cachePolicy: .reloadIgnoringLocalCacheData)
            request.httpMethod = "GET"
 
            let task = URLSession.shared.dataTask(with: request) { data, response, error in

--- a/SessionReplay.podspec
+++ b/SessionReplay.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "SessionReplay"
-  spec.version      = "1.1.0"
+  spec.version      = "1.1.1"
   spec.summary      = "Coralogix Session-Replay pod for iOS."
 
   spec.description  = <<-DESC
@@ -23,7 +23,7 @@ Pod::Spec.new do |spec|
   spec.static_framework = true
 
   spec.source_files  = 'SessionReplay/Sources/**/*.swift'
-  spec.dependency 'CoralogixInternal', '1.1.0'
+  spec.dependency 'CoralogixInternal', '1.1.1'
   
     spec.test_spec 'Tests' do |test|
         test.source_files = 'Tests/SessionReplayTests/**/*.swift'

--- a/Tests/CoralogixRumTests/CoralogixRumTests.swift
+++ b/Tests/CoralogixRumTests/CoralogixRumTests.swift
@@ -635,10 +635,17 @@ final class CoralogixRumTests: XCTestCase {
             traceParentInHeader: ["enable": true],
             debug: true
         )
-        
         let coralogixRum = CoralogixRum(options: mockOptions)
+        let expectation = XCTestExpectation(description: "Wait for async setView to complete")
         coralogixRum.setView(name: "TestView")
-        XCTAssertNotNil(coralogixRum.coralogixExporter?.getViewManager().visibleView)
+
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.2) {
+            let visibleView = coralogixRum.coralogixExporter?.getViewManager().visibleView
+            XCTAssertNotNil(visibleView)
+            XCTAssertEqual(visibleView?.name, "TestView")
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
     }
     
     func testSetupTracer_registersTracerWithCorrectExporter() {


### PR DESCRIPTION
* Crash - specialized CoralogixExporter.export
* Crashed: com.coralogix.spanProcessingQueue
* Prevent crash during class swizzling by filtering unsafe or irrelevant classes
* network provoke a Hang


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for specifying class name prefixes to exclude from network instrumentation.
  * Introduced deep copy functionality for arrays of dictionaries.

* **Bug Fixes**
  * Improved thread safety for view management to prevent race conditions.
  * Enhanced error handling and logging for span encoding and network instrumentation.
  * Ensured network instrumentation setup occurs on the main thread for stability.

* **Refactor**
  * Updated network instrumentation initialization and configuration for better flexibility.
  * Streamlined method signatures and internal logic for improved maintainability.

* **Chores**
  * Bumped SDK and dependency versions to 1.1.1.
  * Updated test to handle asynchronous view state changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->