### PR TITLE
Fix set sessionId to lowercase ALPH-2523

### DIFF
--- a/Coralogix/Sources/Model/SessionContext.swift
+++ b/Coralogix/Sources/Model/SessionContext.swift
@@ -49,7 +49,7 @@ struct SessionContext {
     func getDictionary() -> [String: Any] {
         var result = [String: Any]()
         
-        result[Keys.sessionId.rawValue] = self.sessionId.lowercased()
+        result[Keys.sessionId.rawValue] = self.sessionId
         result[Keys.sessionCreationDate.rawValue] = self.sessionCreationDate.milliseconds
         result[Keys.operatingSystem.rawValue] = self.operatingSystem
         result[Keys.osVersion.rawValue] = self.osVersion
@@ -66,7 +66,7 @@ struct SessionContext {
     
     func getPrevSessionDictionary() -> [String: Any] {
         var result = [String: Any]()
-        result[Keys.sessionId.rawValue] = self.sessionId.lowercased()
+        result[Keys.sessionId.rawValue] = self.sessionId
         result[Keys.sessionCreationDate.rawValue] = self.sessionCreationDate.milliseconds
         return result
     }

--- a/Coralogix/Sources/Utils/SessionManager.swift
+++ b/Coralogix/Sources/Utils/SessionManager.swift
@@ -139,7 +139,7 @@ public class SessionManager {
     
     internal func setupSessionMetadata() {
         self.prevSessionMetadata = self.sessionMetadata
-        self.sessionMetadata = SessionMetadata(sessionId: NSUUID().uuidString.lowercased(),
+        self.sessionMetadata = SessionMetadata(sessionId: UUID().uuidString.lowercased(),
                                                sessionCreationDate: Date().timeIntervalSince1970,
                                                using: KeychainManager())
 

--- a/Coralogix/Sources/Utils/SessionManager.swift
+++ b/Coralogix/Sources/Utils/SessionManager.swift
@@ -139,7 +139,7 @@ public class SessionManager {
     
     internal func setupSessionMetadata() {
         self.prevSessionMetadata = self.sessionMetadata
-        self.sessionMetadata = SessionMetadata(sessionId: NSUUID().uuidString,
+        self.sessionMetadata = SessionMetadata(sessionId: NSUUID().uuidString.lowercased(),
                                                sessionCreationDate: Date().timeIntervalSince1970,
                                                using: KeychainManager())
 

--- a/Example/DemoAppSwift/SessionReplayViewController.swift
+++ b/Example/DemoAppSwift/SessionReplayViewController.swift
@@ -112,7 +112,7 @@ class SessionReplayViewController: UITableViewController {
             CoralogixRumManager.shared.sdk.captureEvent()
         } else if item == Keys.updateSessionId.rawValue {
             if let sessionReplay = SdkManager.shared.getSessionReplay() {
-               sessionReplay.update(sessionId: NSUUID().uuidString)
+                sessionReplay.update(sessionId: NSUUID().uuidString.lowercased())
            }
         }
 

--- a/Example/DemoAppSwift/SessionReplayViewController.swift
+++ b/Example/DemoAppSwift/SessionReplayViewController.swift
@@ -112,7 +112,7 @@ class SessionReplayViewController: UITableViewController {
             CoralogixRumManager.shared.sdk.captureEvent()
         } else if item == Keys.updateSessionId.rawValue {
             if let sessionReplay = SdkManager.shared.getSessionReplay() {
-                sessionReplay.update(sessionId: NSUUID().uuidString.lowercased())
+                sessionReplay.update(sessionId: UUID().uuidString.lowercased())
            }
         }
 


### PR DESCRIPTION
fix: set sessionId to lowercase

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Session IDs now consistently use lowercase formatting when generated or updated, ensuring uniformity across the app.
  * Preserved the original casing of session IDs when displaying or processing existing session data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->