### PR TITLE
Native iOS cpu tracking ALPH-2579

### DIFF
--- a/Coralogix/Sources/CoralogixRum.swift
+++ b/Coralogix/Sources/CoralogixRum.swift
@@ -141,6 +141,7 @@ public class CoralogixRum {
         if options.shouldInitInstrumentation(instrumentation: .mobileVitals) {
             self.metricsManager.startFPSSamplingMonitoring(mobileVitalsFPSSamplingRate: options.mobileVitalsFPSSamplingRate)
             self.metricsManager.startColdStartMonitoring()
+            self.metricsManager.startCPUMonitoring()
         }
         
         if options.shouldInitInstrumentation(instrumentation: .anr) {

--- a/Coralogix/Sources/Instrumentation/MobileVitalsInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/MobileVitalsInstrumentation.swift
@@ -54,6 +54,10 @@ extension CoralogixRum {
         for (key, value) in cxMobileVitals.type.specificAttributes(for: cxMobileVitals.value) {
             span.setAttribute(key: key, value: value)
         }
+        
+        if let uuid = cxMobileVitals.uuid as? String {
+            span.setAttribute(key: Keys.mobileVitalsUuid.rawValue, value: uuid)
+        }
         span.end()
     }
     

--- a/Coralogix/Sources/Instrumentation/MobileVitalsInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/MobileVitalsInstrumentation.swift
@@ -55,7 +55,7 @@ extension CoralogixRum {
             span.setAttribute(key: key, value: value)
         }
         
-        if let uuid = cxMobileVitals.uuid as? String {
+        if let uuid = cxMobileVitals.uuid, !uuid.isEmpty {
             span.setAttribute(key: Keys.mobileVitalsUuid.rawValue, value: uuid)
         }
         span.end()

--- a/Coralogix/Sources/Model/MobileVitalsContext.swift
+++ b/Coralogix/Sources/Model/MobileVitalsContext.swift
@@ -11,16 +11,19 @@ import CoralogixInternal
 struct MobileVitalsContext {
     let mobileVitalsType: String
     let mobileVitalsValue: String
+    let mobileVitalsUuid: String?
     
     init(otel: SpanDataProtocol) {
         self.mobileVitalsType = otel.getAttribute(forKey: Keys.mobileVitalsType.rawValue) as? String ?? ""
         self.mobileVitalsValue = otel.getAttribute(forKey: Keys.mobileVitalsValue.rawValue) as? String ?? ""
+        self.mobileVitalsUuid = otel.getAttribute(forKey: Keys.mobileVitalsUuid.rawValue) as? String ?? ""
     }
     
     func getMobileVitalsDictionary() -> [String: Any] {
         var result = [String: Any]()
         result[Keys.type.rawValue] = self.mobileVitalsType
         result[Keys.value.rawValue] = self.mobileVitalsValue
+        result[Keys.mobileVitalsUuid.rawValue] = self.mobileVitalsUuid
         return result
     }
 }

--- a/Coralogix/Sources/Model/MobileVitalsContext.swift
+++ b/Coralogix/Sources/Model/MobileVitalsContext.swift
@@ -16,14 +16,16 @@ struct MobileVitalsContext {
     init(otel: SpanDataProtocol) {
         self.mobileVitalsType = otel.getAttribute(forKey: Keys.mobileVitalsType.rawValue) as? String ?? ""
         self.mobileVitalsValue = otel.getAttribute(forKey: Keys.mobileVitalsValue.rawValue) as? String ?? ""
-        self.mobileVitalsUuid = otel.getAttribute(forKey: Keys.mobileVitalsUuid.rawValue) as? String ?? ""
+        self.mobileVitalsUuid = otel.getAttribute(forKey: Keys.mobileVitalsUuid.rawValue) as? String
     }
     
     func getMobileVitalsDictionary() -> [String: Any] {
         var result = [String: Any]()
         result[Keys.type.rawValue] = self.mobileVitalsType
         result[Keys.value.rawValue] = self.mobileVitalsValue
-        result[Keys.mobileVitalsUuid.rawValue] = self.mobileVitalsUuid
+        if let uuid = self.mobileVitalsUuid, !uuid.isEmpty {
+            result[Keys.mobileVitalsUuid.rawValue] = uuid
+        }
         return result
     }
 }

--- a/Coralogix/Sources/Utils/CPUDetector.swift
+++ b/Coralogix/Sources/Utils/CPUDetector.swift
@@ -19,8 +19,9 @@ public final class CPUDetector {
     private let cpuCount = Double(ProcessInfo.processInfo.activeProcessorCount)
     private var timebase = mach_timebase_info_data_t()
     private let minInterval: TimeInterval = 0.1
+    var handleANRClosure: (() -> Void)?
 
-    public init(checkInterval: TimeInterval = 1.0) {
+    public init(checkInterval: TimeInterval = 60.0) {
         mach_timebase_info(&timebase)
         var interval = checkInterval
         if interval < minInterval {
@@ -44,6 +45,7 @@ public final class CPUDetector {
     
     @objc private func checkForCPU() {
         if let cpuUsageMeasurement = self.samplePercent() {
+            self.handleANRClosure?()
             Log.d(String(format: "[Metric] App CPU: %.3f%% | Total CPU Time: %.3f ms | Main Thread Time: %.3f ms",
                          cpuUsageMeasurement.usagePercent,
                          cpuUsageMeasurement.totalCpuTimeMs,

--- a/Coralogix/Sources/Utils/CPUDetector.swift
+++ b/Coralogix/Sources/Utils/CPUDetector.swift
@@ -50,8 +50,7 @@ final class CPUDetector {
     }
     
     deinit {
-        // Defensive: ensure it’s cleaned up if the owner forgets to call stop.
-        timer?.invalidate()
+        self.stopMonitoring()
     }
     
     @objc private func checkForCPU() {

--- a/Coralogix/Sources/Utils/CPUDetector.swift
+++ b/Coralogix/Sources/Utils/CPUDetector.swift
@@ -1,0 +1,126 @@
+//
+//  CPUDetector.swift
+//  Coralogix
+//
+//  Created by Tomer Har Yoffi on 12/08/2025.
+//
+
+import Foundation
+import Darwin.Mach
+
+/// CPU usage of *your app* as a % of total device CPU (all cores).
+public final class CPUDetector {
+    private var timer: Timer?
+    
+    // Time interval to check for CPU (e.g., every 1 second)
+    private let checkInterval: TimeInterval
+    private var lastProcSeconds: Double?
+    private var lastWallSeconds: Double?
+    private let cpuCount = Double(ProcessInfo.processInfo.activeProcessorCount)
+    private var timebase = mach_timebase_info_data_t()
+    private let minInterval: TimeInterval = 0.1
+
+    public init(checkInterval: TimeInterval = 1.0) {
+        mach_timebase_info(&timebase)
+        var interval = checkInterval
+        if interval < minInterval {
+            interval = minInterval
+        }
+        self.checkInterval = interval
+    }
+    
+    func startMonitoring() {
+        timer = Timer.scheduledTimer(timeInterval: checkInterval,
+                                     target: self,
+                                     selector: #selector(checkForCPU),
+                                     userInfo: nil,
+                                     repeats: true)
+    }
+
+    func stopMonitoring() {
+        timer?.invalidate()
+        timer = nil
+    }
+    
+    @objc private func checkForCPU() {
+        if let sample = self.samplePercent() {
+            Log.d(String(format: "[Metric] App CPU: %.3f%% | Total CPU Time: %.3f ms | Main Thread Time: %.3f ms",
+                         sample.usagePercent,
+                         sample.totalCpuTimeMs,
+                         sample.mainThreadTimeMs))
+        }
+    }
+
+    public func samplePercent() -> (usagePercent: Double, totalCpuTimeMs: Double, mainThreadTimeMs: Double)? {
+        guard let proc = currentProcessCPUSeconds(),
+                let mainMs = mainThreadCpuTimeMs() else { return nil }
+        let wall = nowSeconds()
+
+        defer {
+            lastProcSeconds = proc
+            lastWallSeconds = wall
+        }
+        guard let lp = lastProcSeconds, let lw = lastWallSeconds else { return nil }
+
+        let dProc = max(0, proc - lp)
+        let dWall = max(1e-6, wall - lw)
+
+        // % of total CPU across all cores
+        let pct = (dProc / (dWall * cpuCount)) * 100.0
+        
+        // Convert total process CPU time (seconds) → ms
+        let totalCpuTimeMs = proc * 1000.0
+
+        let usagePercent = min(max(pct, 0), 100) // clamp to [0,100]
+        return (usagePercent: usagePercent, totalCpuTimeMs: totalCpuTimeMs, mainThreadTimeMs: mainMs)
+    }
+
+    // MARK: - Internals
+
+    private func nowSeconds() -> Double {
+        let t = mach_absolute_time()
+        let nanos = (t &* UInt64(timebase.numer)) / UInt64(timebase.denom)
+        return Double(nanos) / 1_000_000_000.0
+    }
+
+    private func currentProcessCPUSeconds() -> Double? {
+        var count = mach_msg_type_number_t(MemoryLayout<task_basic_info_data_t>.size / MemoryLayout<integer_t>.size)
+        var info = task_basic_info_data_t()
+
+        let kr = withUnsafeMutablePointer(to: &info) {
+            $0.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+                task_info(mach_task_self_, task_flavor_t(TASK_BASIC_INFO), $0, &count)
+            }
+        }
+        guard kr == KERN_SUCCESS else { return nil }
+
+        let user = Double(info.user_time.seconds) + Double(info.user_time.microseconds) / 1_000_000
+        let sys  = Double(info.system_time.seconds) + Double(info.system_time.microseconds) / 1_000_000
+        return user + sys
+    }
+    
+    /// Returns main thread CPU time in milliseconds
+    func mainThreadCpuTimeMs() -> Double? {
+        var info = thread_basic_info_data_t()
+        var count = mach_msg_type_number_t(THREAD_INFO_MAX)
+
+        let kr = withUnsafeMutablePointer(to: &info) {
+            $0.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+                thread_info(mach_thread_self(),
+                            thread_flavor_t(THREAD_BASIC_INFO),
+                            $0,
+                            &count)
+            }
+        }
+
+        guard kr == KERN_SUCCESS else { return nil }
+
+        let userSec = Double(info.user_time.seconds)
+        let userMicro = Double(info.user_time.microseconds)
+        let sysSec = Double(info.system_time.seconds)
+        let sysMicro = Double(info.system_time.microseconds)
+
+        let totalMs = (userSec + sysSec) * 1000.0 + (userMicro + sysMicro) / 1000.0
+        return totalMs
+    }
+}

--- a/Coralogix/Sources/Utils/MetricsManager.swift
+++ b/Coralogix/Sources/Utils/MetricsManager.swift
@@ -18,6 +18,7 @@ public class MetricsManager {
     var foregroundStartTime: CFAbsoluteTime?
     var foregroundEndTime: CFAbsoluteTime?
     var anrDetector: ANRDetector?
+    var cpuDetector: CPUDetector?
     var fpsTrigger = FPSTrigger()
     let mobileVitalsFPSSamplingRate = 300 // 5 min
     var warmMetricIsActive = false
@@ -105,6 +106,11 @@ public class MetricsManager {
         self.anrDetector?.startMonitoring()
     }
     
+    func startCPUMonitoring() {
+        self.cpuDetector = CPUDetector()
+        self.cpuDetector?.startMonitoring()
+    }
+    
     @objc func handleNotification(notification: Notification) {
         if let metrics = notification.object as? [String: Any] {
             if let launchStartTime = self.launchStartTime,
@@ -183,6 +189,7 @@ public class MetricsManager {
         
         self.anrDetector?.stopMonitoring()
         self.fpsTrigger.stopMonitoring()
+        self.cpuDetector?.stopMonitoring()
         self.launchEndTime = 0
     }
 }

--- a/Coralogix/Sources/Utils/MetricsManager.swift
+++ b/Coralogix/Sources/Utils/MetricsManager.swift
@@ -56,6 +56,8 @@ public class MetricsManager {
     
     public func removeObservers() {
         MXMetricManager.shared.remove(MyMetricSubscriber.shared)
+        self.cpuDetector?.stopMonitoring()
+        self.anrDetector?.stopMonitoring()
     }
     
     func startFPSSamplingMonitoring(mobileVitalsFPSSamplingRate: Int) {
@@ -64,6 +66,8 @@ public class MetricsManager {
     
     @objc func appDidEnterBackgroundNotification() {
         self.fpsTrigger.stopMonitoring()
+        self.cpuDetector?.stopMonitoring()
+        self.anrDetector?.stopMonitoring()
         self.warmMetricIsActive = true
     }
     
@@ -107,8 +111,10 @@ public class MetricsManager {
     }
     
     func startCPUMonitoring() {
-        self.cpuDetector = CPUDetector()
-        self.cpuDetector?.startMonitoring()
+        guard cpuDetector == nil else { return }
+        let detector = CPUDetector()
+        detector.startMonitoring()
+        self.cpuDetector = detector
     }
     
     @objc func handleNotification(notification: Notification) {

--- a/Coralogix/Sources/Utils/RenderingDetector.swift
+++ b/Coralogix/Sources/Utils/RenderingDetector.swift
@@ -88,11 +88,21 @@ enum CXMobileVitalsType: String {
     case fps
     case anr
     case metricKit
+    case cpuUsagePercent
+    case totalCpuTimeMs
+    case mainThreadCpuTimeMs
 }
 
 struct CXMobileVitals {
     let type: CXMobileVitalsType
     let value: String
+    let uuid: String?
+    
+    init(type: CXMobileVitalsType, value: String, uuid: String? = nil) {
+        self.type = type
+        self.value = value
+        self.uuid = uuid
+    }
 }
 
 extension CXMobileVitalsType {

--- a/CoralogixInternal/Sources/Keys.swift
+++ b/CoralogixInternal/Sources/Keys.swift
@@ -150,6 +150,7 @@ public enum Keys: String {
     case fps = "fps"
     case mobileVitalsType
     case mobileVitalsValue
+    case mobileVitalsUuid = "uuid"
     case value
     case anr = "application_not_responding"
     case skipEnrichmentWithIp = "skip_enrichment_with_ip"

--- a/Tests/CoralogixRumTests/CPUDetectorTests.swift
+++ b/Tests/CoralogixRumTests/CPUDetectorTests.swift
@@ -1,0 +1,137 @@
+//
+//  CPUDetectorTests.swift
+//  Coralogix
+//
+//  Created by Tomer Har Yoffi on 13/08/2025.
+//
+import XCTest
+@testable import Coralogix
+
+final class CPUDetectorTests: XCTestCase {
+    var cpuDetector: CPUDetector!
+    var cpuDetected = false
+    
+    override func setUp() {
+        super.setUp()
+        // Initialize with a short maxBlockTime for faster tests
+        cpuDetector = CPUDetector(checkInterval: 0.1)
+        
+        // Override the handleANR with a closure to test ANR detection
+        cpuDetector.handleANRClosure = { [weak self] in
+            self?.cpuDetected = true
+        }
+    }
+    
+    override func tearDown() {
+        cpuDetector.stopMonitoring()
+        cpuDetector = nil
+        cpuDetected = false
+        super.tearDown()
+    }
+    
+    func testEmitsThreeMetricsForSingleTick() {
+        // Expect to receive exactly 3 metrics in one sampling round:
+        // .cpuUsagePercent, .totalCpuTimeMs, .mainThreadCpuTimeMs sharing the same uuid
+        let expect = expectation(description: "Received three CPU metrics (same UUID)")
+        expect.expectedFulfillmentCount = 1
+        
+        // Storage for first observed tick, keyed by uuid
+        var firstTickUUID: String?
+        var receivedTypes = Set<CXMobileVitalsType>()
+        var receivedCount = 0
+        
+        let obs = NotificationCenter.default.addObserver(
+            forName: .cxRumNotificationMetrics,
+            object: nil,
+            queue: .main
+        ) { note in
+            guard let payload = note.object as? CXMobileVitals else { return }
+            
+            // 1) For the first tick, remember UUID; subsequent notifications must match it
+            if firstTickUUID == nil {
+                firstTickUUID = payload.uuid
+            } else if payload.uuid != firstTickUUID {
+                // Ignore metrics from other ticks
+                return
+            }
+            
+            // 2) Validate type & value are well-formed
+            XCTAssertTrue(
+                payload.type == .cpuUsagePercent ||
+                payload.type == .totalCpuTimeMs ||
+                payload.type == .mainThreadCpuTimeMs,
+                "Unexpected metric type: \(payload.type)"
+            )
+            
+            // Value is formatted as a String — ensure it’s numeric
+            XCTAssertNotNil(Double(payload.value), "Metric value is not a number: \(payload.value)")
+            
+            // Track which types we got for this uuid
+            if receivedTypes.insert(payload.type).inserted {
+                receivedCount += 1
+            }
+            
+            if receivedCount == 3 {
+                expect.fulfill()
+            }
+        }
+        
+        // Start the monitor
+        cpuDetector.startMonitoring()
+        
+        wait(for: [expect], timeout: 3.0)
+        NotificationCenter.default.removeObserver(obs)
+    }
+    
+    func testStopMonitoringPreventsFurtherEmissions() {
+        // We’ll capture the first 3 metrics (one tick), then stop, then assert we don’t get more.
+        let firstTick = expectation(description: "Got first tick (3 metrics)")
+        firstTick.expectedFulfillmentCount = 1
+        
+        let noFurther = expectation(description: "No further metrics after stop")
+        noFurther.isInverted = true // We expect NOT to be fulfilled
+        
+        var firstTickUUID: String?
+        var receivedTypes = Set<CXMobileVitalsType>()
+        var totalNotificationsAfterStop = 0
+        
+        let obs = NotificationCenter.default.addObserver(
+            forName: .cxRumNotificationMetrics,
+            object: nil,
+            queue: .main
+        ) { note in
+            guard let payload = note.object as? CXMobileVitals else { return }
+            
+            if firstTickUUID == nil {
+                firstTickUUID = payload.uuid
+            }
+            
+            if payload.uuid == firstTickUUID {
+                _ = receivedTypes.insert(payload.type)
+                if receivedTypes.count == 3 {
+                    // We’ve completed one tick; stop monitoring immediately.
+                    self.cpuDetector.stopMonitoring()
+                    firstTick.fulfill()
+                }
+                return
+            }
+            
+            // Any notifications with a different UUID would indicate another tick — should not happen after stop.
+            totalNotificationsAfterStop += 1
+            if totalNotificationsAfterStop > 0 {
+                noFurther.fulfill() // This will fail because it's inverted
+            }
+        }
+        
+        cpuDetector.startMonitoring()
+        
+        // Wait for first tick to complete (3 metrics), then ensure no more arrive within a grace window
+        wait(for: [firstTick], timeout: 3.0)
+        
+        // Allow a small window to detect stray posts after stop
+        wait(for: [noFurther], timeout: 0.6)
+        
+        NotificationCenter.default.removeObserver(obs)
+    }
+}
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CPU monitoring now starts when Mobile Vitals are enabled and emits three metrics: CPU usage %, total CPU time (ms), and main‑thread CPU time (ms).
  * Metric payloads may include an optional UUID to group samples from the same tick; UUID is included only when present.

* **Tests**
  * New unit tests validate the three-metric emission, numeric formatting, and that stopping monitoring halts further emissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->