### PR TITLE
Add Slow / Freeze frame + add test ALPH-2588

### DIFF
--- a/Coralogix/Sources/Utils/MobileVitals/MetricsManager.swift
+++ b/Coralogix/Sources/Utils/MobileVitals/MetricsManager.swift
@@ -103,7 +103,7 @@ public class MetricsManager {
         self.startANRMonitoring()
         self.startCPUMonitoring()
         self.startMemoryMonitoring()
-        self.startslowFrozenFramesMonitoring()
+        self.startSlowFrozenFramesMonitoring()
         self.startFPSSamplingMonitoring(mobileVitalsFPSSamplingRate: mobileVitalsFPSSamplingRate)
     }
     
@@ -130,7 +130,7 @@ public class MetricsManager {
         self.memoryDetector = detector
     }
     
-    func startslowFrozenFramesMonitoring() {
+    func startSlowFrozenFramesMonitoring() {
         guard slowFrozenFramesDetector == nil else { return }
         let detector = SlowFrozenFramesDetector()
         detector.startMonitoring()

--- a/Coralogix/Sources/Utils/MobileVitals/MetricsManager.swift
+++ b/Coralogix/Sources/Utils/MobileVitals/MetricsManager.swift
@@ -20,6 +20,7 @@ public class MetricsManager {
     var anrDetector: ANRDetector?
     var cpuDetector: CPUDetector?
     var memoryDetector: MemoryDetector?
+    var slowFrozenFramesDetector: SlowFrozenFramesDetector?
     var fpsTrigger = FPSTrigger()
     let mobileVitalsFPSSamplingRate = 300 // 5 min
     var warmMetricIsActive = false
@@ -102,6 +103,7 @@ public class MetricsManager {
         self.startANRMonitoring()
         self.startCPUMonitoring()
         self.startMemoryMonitoring()
+        self.startslowFrozenFramesMonitoring()
         self.startFPSSamplingMonitoring(mobileVitalsFPSSamplingRate: mobileVitalsFPSSamplingRate)
     }
     
@@ -126,6 +128,13 @@ public class MetricsManager {
         let detector = MemoryDetector()
         detector.startMonitoring()
         self.memoryDetector = detector
+    }
+    
+    func startslowFrozenFramesMonitoring() {
+        guard slowFrozenFramesDetector == nil else { return }
+        let detector = SlowFrozenFramesDetector()
+        detector.startMonitoring()
+        self.slowFrozenFramesDetector = detector
     }
     
     @objc func handleNotification(notification: Notification) {
@@ -205,6 +214,8 @@ public class MetricsManager {
         cpuDetector = nil
         memoryDetector?.stopMonitoring()
         memoryDetector = nil
+        slowFrozenFramesDetector?.stopMonitoring()
+        slowFrozenFramesDetector = nil
         fpsTrigger.stopMonitoring()
     }
     

--- a/Coralogix/Sources/Utils/MobileVitals/RenderingDetector.swift
+++ b/Coralogix/Sources/Utils/MobileVitals/RenderingDetector.swift
@@ -93,7 +93,8 @@ enum CXMobileVitalsType: String {
     case mainThreadCpuTimeMs
     case residentMemoryMb
     case memoryUtilizationPercent
-    
+    case slowFramesCount
+    case frozenFramesCount
 }
 
 struct CXMobileVitals {

--- a/Coralogix/Sources/Utils/MobileVitals/SlowFrozenFramesDetector.swift
+++ b/Coralogix/Sources/Utils/MobileVitals/SlowFrozenFramesDetector.swift
@@ -106,6 +106,10 @@ final class SlowFrozenFramesDetector {
 
     // MARK: - Frame callback
     @objc private func onFrame(_ link: CADisplayLink) {
+        guard running else {
+            lastFrameTimestamp = link.timestamp
+            return
+        }
         let ts = link.timestamp // seconds
         if lastFrameTimestamp != 0 {
             let dtMs = (ts - lastFrameTimestamp) * 1000.0

--- a/Coralogix/Sources/Utils/MobileVitals/SlowFrozenFramesDetector.swift
+++ b/Coralogix/Sources/Utils/MobileVitals/SlowFrozenFramesDetector.swift
@@ -1,0 +1,194 @@
+//
+//  SlowFrozenFramesDetector.swift
+//  Coralogix
+//
+//  Created by Tomer Har Yoffi on 14/08/2025.
+//
+
+import Foundation
+import UIKit
+
+final class SlowFrozenFramesDetector {
+  
+    // MARK: - Configuration
+    private let frozenThresholdMs: Double         // e.g. 700ms
+    private let reportIntervalMs: Int64           // e.g. 60_000
+    private let tolerancePercentage: Double       // e.g. 0.03 (3%)
+
+    // MARK: - State
+    private var displayLink: CADisplayLink?
+    private var lastFrameTimestamp: CFTimeInterval = 0
+    private var refreshRateHz: Double = 60.0      // dynamic; updated on start / app active
+    private var slowBudgetMs: Double = 16.7       // computed from refresh rate
+
+    private let statsLock = NSLock()
+    private var slowCount: Int = 0
+    private var frozenCount: Int = 0
+    private var sumFrameMs: Double = 0.0
+    private var frameSamples: Int = 0
+
+    private var reporterTimer: DispatchSourceTimer?
+    private let reporterQueue = DispatchQueue(label: Keys.queueSlowFrozenReporterQueue.rawValue, qos: .utility)
+    private var running = false
+    private let lifecycleCenter = NotificationCenter.default
+    
+    // MARK: - Init
+    init(
+        frozenThresholdMs: Double = 700.0,
+        reportIntervalMs: Int64 = 60_000,
+        tolerancePercentage: Double = 0.03
+    ) {
+        self.frozenThresholdMs = frozenThresholdMs
+        self.reportIntervalMs = reportIntervalMs
+        self.tolerancePercentage = tolerancePercentage
+        updateRefreshRateAndBudget()
+    }
+
+    // MARK: - Public API
+    public func startMonitoring() {
+        guard !running else { return }
+        running = true
+
+        // Observe app becoming active to refresh Hz if ProMotion / external display changes.
+        lifecycleCenter.addObserver(self,
+                                    selector: #selector(appBecameActive),
+                                    name: UIApplication.didBecomeActiveNotification,
+                                    object: nil)
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            self.updateRefreshRateAndBudget()
+            let link = CADisplayLink(target: self, selector: #selector(self.onFrame(_:)))
+            // Keep true-to-native frame pacing; on iOS 15+ you could set preferredFrameRateRange.
+            // link.preferredFramesPerSecond = 0 // default: use native
+            link.add(to: .main, forMode: .common) // fire during scrolling/gestures
+            self.displayLink = link
+            self.lastFrameTimestamp = 0
+            Log.d("[Metric] slow/frozen frames monitor started @ \(self.refreshRateHz)Hz (budget=\(String(format: "%.2f", self.slowBudgetMs))ms)")
+        }
+
+        // Start periodic reporter on background queue
+        let timer = DispatchSource.makeTimerSource(flags: [], queue: reporterQueue)
+        timer.schedule(deadline: .now() + .milliseconds(Int(reportIntervalMs)),
+                       repeating: .milliseconds(Int(reportIntervalMs)))
+        timer.setEventHandler { [weak self] in
+            self?.emitWindow()
+        }
+        timer.resume()
+        reporterTimer = timer
+    }
+
+    public func stopMonitoring() {
+        guard running else { return }
+        running = false
+
+        lifecycleCenter.removeObserver(self,
+                                       name: UIApplication.didBecomeActiveNotification,
+                                       object: nil)
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            self.displayLink?.invalidate()
+            self.displayLink = nil
+            Log.d("slow/frozen frames monitor stopped")
+        }
+
+        reporterTimer?.cancel()
+        reporterTimer = nil
+
+        // Optional: flush remaining counts once on stop
+        emitWindow()
+    }
+
+    deinit {
+        stopMonitoring()
+    }
+
+    // MARK: - Frame callback
+    @objc private func onFrame(_ link: CADisplayLink) {
+        let ts = link.timestamp // seconds
+        if lastFrameTimestamp != 0 {
+            let dtMs = (ts - lastFrameTimestamp) * 1000.0
+
+            statsLock.lock()
+            sumFrameMs += dtMs
+            frameSamples += 1
+            let allowedDeviation = slowBudgetMs * tolerancePercentage
+            if dtMs >= frozenThresholdMs {
+                frozenCount &+= 1
+            } else if dtMs > (slowBudgetMs + allowedDeviation) {
+                slowCount &+= 1
+                // Log.d("slow frame detected: \(dtMs)")
+            }
+            statsLock.unlock()
+        }
+        lastFrameTimestamp = ts
+    }
+
+    // MARK: - Reporting (grouped window)
+    /// Snapshot & reset counts, then post metrics (skip if both zero).
+    private func emitWindow() {
+        var slow = 0
+        var frozen = 0
+        var avg: Double = 0
+        var samples = 0
+
+        statsLock.lock()
+        slow = slowCount
+        frozen = frozenCount
+        if frameSamples > 0 {
+            avg = sumFrameMs / Double(frameSamples)
+        }
+        // reset window
+        slowCount = 0
+        frozenCount = 0
+        sumFrameMs = 0
+        samples = frameSamples
+        frameSamples = 0
+        statsLock.unlock()
+
+        if slow == 0 && frozen == 0 { return }
+
+        let uuid = UUID().uuidString.lowercased()
+
+        // Post two metrics with same UUID (mirrors Android grouped emission)
+        func post(type: CXMobileVitalsType, value: Double) {
+            let payload = CXMobileVitals(
+                type: type,
+                value: String(format: "%.0f", value), // counts are integers
+                uuid: uuid
+            )
+            if Thread.isMainThread {
+                NotificationCenter.default.post(name: .cxRumNotificationMetrics, object: payload)
+            } else {
+                DispatchQueue.main.async {
+                    NotificationCenter.default.post(name: .cxRumNotificationMetrics, object: payload)
+                }
+            }
+        }
+
+        if slow > 0 { post(type: .slowFramesCount, value: Double(slow)) }
+        if frozen > 0 { post(type: .frozenFramesCount, value: Double(frozen)) }
+
+        Log.d("[Metric] avg frame: \(String(format: "%.2f", avg))ms from \(samples) samples, slow: \(slow), frozen: \(frozen), budget: \(String(format: "%.2f", slowBudgetMs))ms")
+    }
+
+    // MARK: - Refresh rate
+    @objc private func appBecameActive() {
+        // Display characteristics may change (external display, ProMotion changes)
+        updateRefreshRateAndBudget()
+    }
+
+    private func updateRefreshRateAndBudget() {
+        // Prefer UIScreen.main.maximumFramesPerSecond for the active display
+        let hz: Int
+        if #available(iOS 10.3, *) {
+            hz = max(UIScreen.main.maximumFramesPerSecond, 60)
+        } else {
+            hz = 60
+        }
+        refreshRateHz = Double(hz)
+        slowBudgetMs = 1000.0 / refreshRateHz
+    }
+}
+

--- a/Coralogix/Sources/Utils/MobileVitals/SlowFrozenFramesDetector.swift
+++ b/Coralogix/Sources/Utils/MobileVitals/SlowFrozenFramesDetector.swift
@@ -115,9 +115,9 @@ final class SlowFrozenFramesDetector {
             frameSamples += 1
             let allowedDeviation = slowBudgetMs * tolerancePercentage
             if dtMs >= frozenThresholdMs {
-                frozenCount &+= 1
+                frozenCount += 1
             } else if dtMs > (slowBudgetMs + allowedDeviation) {
-                slowCount &+= 1
+                slowCount += 1
                 // Log.d("slow frame detected: \(dtMs)")
             }
             statsLock.unlock()
@@ -177,6 +177,8 @@ final class SlowFrozenFramesDetector {
     @objc private func appBecameActive() {
         // Display characteristics may change (external display, ProMotion changes)
         updateRefreshRateAndBudget()
+        // Reset baseline to avoid counting one large idle gap as slow/frozen.
+        lastFrameTimestamp = 0
     }
 
     private func updateRefreshRateAndBudget() {

--- a/CoralogixInternal/Sources/Keys.swift
+++ b/CoralogixInternal/Sources/Keys.swift
@@ -188,6 +188,7 @@ public enum Keys: String {
     case queueMediaInput = "com.coralogix.mediainput"
     case queueSpanProcessingQueue = "com.coralogix.spanProcessingQueue"
     case queueViewManagerQueue = "com.coralogix.viewManagerQueue"
+    case queueSlowFrozenReporterQueue = "com.coralogix.vitals.slowfrozen.reporter"
     case undefined = ""
     case cxforward
     case enable

--- a/Tests/CoralogixRumTests/SlowFrozenFramesDetectorTests.swift
+++ b/Tests/CoralogixRumTests/SlowFrozenFramesDetectorTests.swift
@@ -9,6 +9,7 @@ import XCTest
 @testable import Coralogix
 
 final class SlowFrozenFramesDetectorTests: XCTestCase {
+    @discardableResult
     private func addObserver(_ handler: @escaping (CXMobileVitals) -> Void) -> NSObjectProtocol {
         NotificationCenter.default.addObserver(
             forName: .cxRumNotificationMetrics,
@@ -41,6 +42,11 @@ final class SlowFrozenFramesDetectorTests: XCTestCase {
             emitted.fulfill()
         }
         
+        defer {
+            monitor.stopMonitoring()
+            NotificationCenter.default.removeObserver(obs)
+        }
+        
         monitor.startMonitoring()
         wait(for: [emitted], timeout: 3.0)
         monitor.stopMonitoring()
@@ -65,6 +71,11 @@ final class SlowFrozenFramesDetectorTests: XCTestCase {
             XCTAssertNotNil(Double(payload.value), "Value should be numeric")
             XCTAssertGreaterThan(Double(payload.value) ?? 0, 0, "Count should be > 0")
             emitted.fulfill()
+        }
+        
+        defer {
+            monitor.stopMonitoring()
+            NotificationCenter.default.removeObserver(obs)
         }
         
         monitor.startMonitoring()
@@ -114,6 +125,11 @@ final class SlowFrozenFramesDetectorTests: XCTestCase {
         // Wait for the first window to emit, then stop and ensure silence
         wait(for: [firstWindow], timeout: 3.0)
         monitor.stopMonitoring()
+        
+        defer {
+            monitor.stopMonitoring()
+            NotificationCenter.default.removeObserver(obs)
+        }
         
         // Give a small grace period to catch stray next-window posts
         wait(for: [noMore], timeout: 0.7)

--- a/Tests/CoralogixRumTests/SlowFrozenFramesDetectorTests.swift
+++ b/Tests/CoralogixRumTests/SlowFrozenFramesDetectorTests.swift
@@ -1,0 +1,124 @@
+//
+//  SlowFrozenFramesDetectorTests.swift
+//  Coralogix
+//
+//  Created by Tomer Har Yoffi on 14/08/2025.
+//
+
+import XCTest
+@testable import Coralogix
+
+final class SlowFrozenFramesDetectorTests: XCTestCase {
+    private func addObserver(_ handler: @escaping (CXMobileVitals) -> Void) -> NSObjectProtocol {
+        NotificationCenter.default.addObserver(
+            forName: .cxRumNotificationMetrics,
+            object: nil,
+            queue: .main
+        ) { note in
+            guard let payload = note.object as? CXMobileVitals else { return }
+            handler(payload)
+        }
+    }
+    
+    // MARK: - Tests
+    
+    /// Forces frozen frames by making the threshold tiny so normal 60Hz frames (≈16.6ms) count as frozen.
+    func testFrozenFramesAreEmitted() {
+        let emitted = expectation(description: "Emitted frozenFramesCount")
+        emitted.expectedFulfillmentCount = 1
+        
+        // reportInterval small so we don't wait long for a window flush
+        let monitor = SlowFrozenFramesDetector(
+            frozenThresholdMs: 1.0,         // everything ≥ 1ms is "frozen"
+            reportIntervalMs: 200,          // 0.2s window
+            tolerancePercentage: 0.03
+        )
+        
+        let obs = addObserver { payload in
+            guard payload.type == .frozenFramesCount else { return }
+            XCTAssertNotNil(Double(payload.value), "Value should be numeric")
+            XCTAssertGreaterThan(Double(payload.value) ?? 0, 0, "Count should be > 0")
+            emitted.fulfill()
+        }
+        
+        monitor.startMonitoring()
+        wait(for: [emitted], timeout: 3.0)
+        monitor.stopMonitoring()
+        NotificationCenter.default.removeObserver(obs)
+    }
+    
+    /// Forces slow frames by making "slow" threshold easier:
+    /// - frozen impossible (very high threshold)
+    /// - negative tolerance shrinks the allowed budget so ~16.6ms qualifies as slow
+    func testSlowFramesAreEmitted() {
+        let emitted = expectation(description: "Emitted slowFramesCount")
+        emitted.expectedFulfillmentCount = 1
+        
+        let monitor = SlowFrozenFramesDetector(
+            frozenThresholdMs: 10_000.0,    // effectively never frozen
+            reportIntervalMs: 200,
+            tolerancePercentage: -0.5       // lowers slow threshold below ~16.6ms
+        )
+        
+        let obs = addObserver { payload in
+            guard payload.type == .slowFramesCount else { return }
+            XCTAssertNotNil(Double(payload.value), "Value should be numeric")
+            XCTAssertGreaterThan(Double(payload.value) ?? 0, 0, "Count should be > 0")
+            emitted.fulfill()
+        }
+        
+        monitor.startMonitoring()
+        wait(for: [emitted], timeout: 3.0)
+        monitor.stopMonitoring()
+        NotificationCenter.default.removeObserver(obs)
+    }
+    
+    /// After first window emission, stopMonitoring() should prevent any further ticks (new UUID).
+    func testStopPreventsFurtherEmissions() {
+        let firstWindow = expectation(description: "First window emitted (any of slow/frozen)")
+        let noMore = expectation(description: "No further windows after stop")
+        noMore.isInverted = true
+        
+        // Use frozen path to guarantee at least one emission quickly
+        let monitor = SlowFrozenFramesDetector(
+            frozenThresholdMs: 1.0,
+            reportIntervalMs: 200,
+            tolerancePercentage: 0.03
+        )
+        
+        var firstUUID: String?
+        var windowTypes = Set<CXMobileVitalsType>()
+        var sawNewUUIDAfterStop = false
+        
+        let obs = addObserver { payload in
+            if firstUUID == nil {
+                firstUUID = payload.uuid
+            }
+            
+            if payload.uuid == firstUUID {
+                // First window (both metrics could arrive, we just need at least one)
+                windowTypes.insert(payload.type)
+                // If we've seen both, great; but even one proves the window emitted
+                if windowTypes.count >= 1 {
+                    firstWindow.fulfill()
+                }
+            } else {
+                // Any metric with a different UUID after we stop would indicate a new window
+                sawNewUUIDAfterStop = true
+                noMore.fulfill()
+            }
+        }
+        
+        monitor.startMonitoring()
+        
+        // Wait for the first window to emit, then stop and ensure silence
+        wait(for: [firstWindow], timeout: 3.0)
+        monitor.stopMonitoring()
+        
+        // Give a small grace period to catch stray next-window posts
+        wait(for: [noMore], timeout: 0.7)
+        NotificationCenter.default.removeObserver(obs)
+        
+        XCTAssertFalse(sawNewUUIDAfterStop, "Received metrics from another window after stopMonitoring()")
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added monitoring for slow and frozen frames with windowed, periodic reporting as mobile vitals; detector starts on app activation, updates with activity/refresh rate, and stops on background/teardown.
  - Introduced new mobile vitals types for slowFramesCount and frozenFramesCount; metrics are emitted periodically and include window identifiers.

- **Tests**
  - Added tests validating slow/frozen emissions, windowing behavior, and that stopping prevents further emissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->