### PR TITLE
Bug: Session Replay wrong page (30)

### DIFF
--- a/Coralogix/Docs/ANRDetector.md
+++ b/Coralogix/Docs/ANRDetector.md
@@ -1,22 +1,54 @@
-## Overview
+# ANRDetector
 
-`ANRDetector` is a utility class designed to monitor the application's main thread and detect Application Not Responding (ANR) incidents. If the main thread becomes unresponsive for longer than a specified threshold, the detector will trigger a predefined action (e.g., logging or notifying the user). This class is particularly useful for debugging and performance monitoring in mobile applications.
-
-### Key Features
-- **Customizable Monitoring**: The class allows you to specify the time interval for checking ANR and the maximum allowable time for the main thread to be blocked.
-- **Automatic Monitoring**: The class uses a timer to periodically check for main thread responsiveness.
-- **ANR Handling**: Provides a closure for handling ANR incidents, which can be customized for specific actions like logging or sending notifications.
+The `ANRDetector` is a Swift class designed to detect "Application Not Responding" (ANR) events on the main thread of an iOS application. An ANR occurs when the main thread is blocked for an extended period, making the user interface unresponsive.
 
 ---
 
-```swift
-let anrDetector = ANRDetector(checkInterval: 1.0, maxBlockTime: 5.0)
-anrDetector.startMonitoring()
+## How It Works
 
-// Custom ANR handler
-anrDetector.handleANRClosure = {
-    print("ANR detected! Custom handling logic goes here.")
-}
+1.  **Monitoring Start**: When `startMonitoring()` is called, a `Timer` is scheduled on a background thread. This timer fires repeatedly at a specified `checkInterval`.
+2.  **Responsiveness Check**: Each time the timer fires, the `checkForANR()` method is executed.
+    * It sets a flag, `isMainThreadResponsive`, to `false`.
+    * It then asynchronously dispatches a block of code to the main thread.
+3.  **Main Thread Task**: The task dispatched to the main thread, if executed promptly, will:
+    * Set the `isMainThreadResponsive` flag back to `true`.
+    * Update the `lastCheckTimestamp` to the current time.
+4.  **ANR Detection**: If the main thread is blocked, it won't execute its dispatched task in time. On a subsequent check, the `checkForANR()` method will find that `isMainThreadResponsive` is still `false`. If the time elapsed since `lastCheckTimestamp` also exceeds `maxBlockTime`, the detector concludes that an ANR has occurred and calls the `handleANR()` method.
 
-// Stop monitoring when needed
-anrDetector.stopMonitoring()
+---
+
+## Properties
+
+* `timer: Timer?`
+    * The timer instance that triggers the responsiveness checks at regular intervals.
+
+* `checkInterval: TimeInterval`
+    * The time interval in seconds between each check. **Default**: `1.0` second.
+
+* `maxBlockTime: TimeInterval`
+    * The maximum duration in seconds the main thread can be unresponsive before an ANR is declared. **Default**: `5.0` seconds.
+
+* `handleANRClosure: (([String: Any]) -> Void)?`
+    * An optional closure that is executed when an ANR is detected. This is primarily useful for testing and custom handling logic.
+
+---
+
+## Methods
+
+### `init(checkInterval: TimeInterval = 1.0, maxBlockTime: TimeInterval = 5.0)`
+
+Initializes a new instance of the `ANRDetector` with a specified check interval and maximum block time.
+
+### `startMonitoring()`
+
+Starts the ANR detection process by creating and scheduling the background timer.
+
+### `stopMonitoring()`
+
+Stops the ANR detection by invalidating and releasing the timer.
+
+### `handleANR()`
+
+This method is called when an ANR event is detected. It logs a message to the console and invokes the `handleANRClosure` if one is provided.
+
+---

--- a/Coralogix/Docs/CPUDetector.md
+++ b/Coralogix/Docs/CPUDetector.md
@@ -1,0 +1,60 @@
+
+# CPUDetector
+
+The `CPUDetector` is a sophisticated utility class for monitoring and analyzing the CPU performance of a Swift application. It periodically samples CPU usage and provides detailed statistics for both the entire application process and the main thread specifically. 🖥️
+
+---
+
+## How It Works
+
+The detector uses a timer-based approach combined with low-level system calls to gather precise performance data.
+
+1.  **Periodic Sampling**: A `Timer` fires at a configurable `checkInterval` (e.g., every 1 second).
+2.  **Low-Level APIs**: At each "tick," the detector uses the **Mach kernel APIs** (`task_info` for the process, `thread_info` for the main thread) to get the cumulative CPU time consumed.
+3.  **Delta Calculation**: It calculates the change (delta) in real-world "wall clock" time and the delta in CPU time since the last tick.
+4.  **Metric Computation**: Using these deltas, it computes key metrics for that interval and appends them to internal sample arrays.
+5.  **Lifecycle Management**: The detector automatically pauses the timer when the app enters the background (`willResignActive`) and cleanly resumes when it becomes active again. This prevents measuring long periods of inactivity and ensures the collected data is relevant to the user-facing experience.
+
+---
+
+## Key Metrics Collected
+
+For each sample interval, the detector calculates and stores three primary metrics:
+
+* **CPU Usage (%)**: The app's total CPU consumption as a percentage of the device's total CPU capacity (all cores combined). This is calculated as `(CPU Time Delta / (Wall Clock Time Delta * Number of Cores)) * 100`.
+* **Total Process CPU Time (ms)**: The raw amount of time, in milliseconds, that the CPU spent executing code for the *entire application process* during the interval.
+* **Main Thread CPU Time (ms)**: The raw amount of CPU time, in milliseconds, spent executing code *specifically on the main thread*. This is critical for identifying UI stutters and performance bottlenecks.
+
+---
+
+## Computed Statistics
+
+Instead of just providing raw data points, the `CPUDetector` automatically calculates and exposes a rich set of statistical summaries for all collected samples over a monitoring period:
+
+* **Minimum** (`min`)
+* **Maximum** (`max`)
+* **Average** (`avg`)
+* **95th Percentile** (`p95`)
+
+These statistics are available for all three of the key metrics listed above.
+
+---
+
+## Methods
+
+### `init(checkInterval: TimeInterval = 1.0)`
+Initializes the detector with a specific sampling interval in seconds.
+
+### `startMonitoring()`
+Starts the periodic sampling process and registers for app lifecycle notifications.
+
+### `stopMonitoring()`
+Stops the sampling timer, removes notification observers, and clears all collected data.
+
+### `reset()`
+Clears all stored sample arrays (`usageSamples`, `totalCpuDeltaMsSamples`, `mainThreadDeltaMsSamples`) without stopping the timer. This is useful for starting a new measurement window.
+
+### `statsDictionary() -> [String: Any]`
+Returns a dictionary containing the latest computed statistics (`min`, `max`, `avg`, `p95`) for all three key metrics, formatted and ready for logging or serialization.
+
+---

--- a/Coralogix/Docs/ColdDetector.md
+++ b/Coralogix/Docs/ColdDetector.md
@@ -1,0 +1,48 @@
+# ColdDetector
+
+The `ColdDetector` is a Swift class designed to measure the **cold start time** of an application. A cold start occurs when the application is launched from a terminated state (i.e., not from the background). This metric is crucial for performance monitoring, as it measures the time from the initial launch process until the first user interface is displayed.
+
+---
+
+## How It Works
+
+The detector's mechanism relies on observing a specific point in the application's launch sequence.
+
+1.  **Initiation**: The `startMonitoring()` method is called at the earliest possible point in the application's lifecycle, typically within the `AppDelegate`'s `application(_:didFinishLaunchingWithOptions:)`. It immediately records the current time as `launchStartTime`.
+2.  **Listening**: The detector registers as an observer for a custom `Notification` named `.cxViewDidAppear`.
+3.  **Completion Signal**: Another part of the application is responsible for posting the `.cxViewDidAppear` notification when the first view controller's UI becomes visible to the user (e.g., in its `viewDidAppear(_:)` method). This notification must contain the timestamp of the event.
+4.  **Calculation**: Upon receiving the notification, the `handleNotification(notification:)` method is triggered. It retrieves the end timestamp from the notification's payload, calculates the total duration in milliseconds, and ensures this calculation is performed only once per launch.
+5.  **Handling**: The final cold start duration is packaged into a dictionary and passed to the `handleColdClosure` for custom processing, such as sending the metric to an analytics service.
+6.  **Cleanup**: The `deinit` method properly removes the notification observer to prevent memory leaks and dangling references.
+
+---
+
+## Properties
+
+* `launchStartTime: CFAbsoluteTime?`
+    * Stores the timestamp when monitoring begins. This marks the start of the cold launch measurement.
+
+* `launchEndTime: CFAbsoluteTime?`
+    * Stores the timestamp when the first UI is displayed. It also acts as a flag to ensure the cold start duration is calculated only once.
+
+* `handleColdClosure: (([String: Any]) -> Void)?`
+    * An optional closure that is executed with the cold start data once the measurement is complete. This allows for flexible handling of the result.
+
+---
+
+## Methods
+
+### `startMonitoring()`
+
+Begins the cold start measurement process. It records the start time and sets up the listener for the `.cxViewDidAppear` notification.
+
+### `handleNotification(notification: Notification)`
+
+The function executed when the `.cxViewDidAppear` notification is received. It finalizes the measurement, calculates the duration, and calls the handler closure.
+
+### `calculateTime(start: Double, stop: Double) -> Double`
+
+A helper function that computes the difference between two epoch timestamps, ensuring the result is non-negative.
+
+---
+

--- a/Coralogix/Docs/FPSDetector.md
+++ b/Coralogix/Docs/FPSDetector.md
@@ -25,7 +25,7 @@ Starts monitoring the FPS periodically. The method calculates the time interval 
 
 ### `private func monitorFPS()`
 
-Logs a message and starts monitoring the FPS for 5 seconds. Once the monitoring period is over, the average FPS is logged and sent via `NotificationCenter` as a `cxRumNotificationMetrics` event.
+Logs a message and starts monitoring the FPS for 5 seconds. Once the monitoring period is over, the average FPS post Mobile vital event.
 
 ### `func stopMonitoring()`
 

--- a/Coralogix/Docs/MemoryDetector.md
+++ b/Coralogix/Docs/MemoryDetector.md
@@ -1,0 +1,57 @@
+
+# MemoryDetector
+
+The `MemoryDetector` is a powerful class for monitoring an application's memory consumption. It periodically samples memory usage using low-level system APIs and provides a detailed statistical analysis, helping developers identify memory leaks, excessive usage, and overall performance characteristics. 🧠
+
+---
+
+## How It Works
+
+The detector operates by sampling memory usage at regular intervals and aggregating the results.
+
+1.  **Periodic Sampling**: A `Timer` fires at a regular interval, triggering a memory reading via the `sampleOnce()` method.
+2.  **Low-Level Data Fetching**: Each sample uses the **Mach kernel API** (`task_info` with `TASK_VM_INFO`) to get precise, low-level memory data directly from the operating system.
+3.  **Metric Calculation**: The raw data from the kernel is processed into three distinct, high-level metrics (Footprint, Resident Size, and Utilization).
+4.  **Data Aggregation**: These metrics are stored in sample arrays to build a history of memory usage over time.
+5.  **Lifecycle Awareness**: The detector intelligently pauses monitoring when the app is in the background (`willResignActive`) and resumes when it returns to the foreground (`didBecomeActive`), ensuring efficiency and data relevance.
+
+---
+
+## Key Metrics Collected
+
+The detector captures and analyzes three different aspects of memory usage:
+
+* **Memory Footprint (MB)**: This is the most accurate and recommended metric for measuring memory usage on modern iOS. It represents the physical memory (RAM) being used by the app that is not shared with other processes. This is the primary value to watch for memory pressure and potential leaks.
+* **Resident Size (MB)**: This is the traditional Resident Set Size (RSS), which includes memory from shared libraries. It's provided for reference and comparison but is generally less precise for diagnostics than the footprint.
+* **Memory Utilization (%)**: This metric calculates the app's memory footprint as a percentage of the total physical RAM available on the device, providing context for how much of the system's resources the app is consuming.
+
+---
+
+## Computed Statistics
+
+The `MemoryDetector` provides more than just raw data. It automatically calculates and exposes a rich set of statistical summaries for all collected samples over a monitoring period:
+
+* **Minimum** (`min`)
+* **Maximum** (`max`)
+* **Average** (`avg`)
+* **95th Percentile** (`p95`)
+
+These statistics are available for all three of the key metrics listed above.
+
+---
+
+## Methods
+
+### `startMonitoring()`
+Starts the periodic memory sampling process and registers for app lifecycle notifications.
+
+### `stopMonitoring()`
+Stops the sampling timer, removes notification observers, and clears all collected data.
+
+### `reset()`
+Clears all stored sample arrays without stopping the timer. This is useful for starting a new measurement window (e.g., after a user completes a specific task).
+
+### `statsDictionary() -> [String: Any]`
+Returns a dictionary containing the latest computed statistics (`min`, `max`, `avg`, `p95`) for all three key metrics, formatted and ready for logging or serialization.
+
+---

--- a/Coralogix/Docs/SlowFrozenFramesDetector.md
+++ b/Coralogix/Docs/SlowFrozenFramesDetector.md
@@ -1,0 +1,56 @@
+# SlowFrozenFramesDetector
+
+The `SlowFrozenFramesDetector` is an advanced performance monitoring tool designed to identify UI unresponsiveness by detecting and quantifying "slow" and "frozen" frames. It provides a statistical summary of UI performance over time using a unique windowed reporting approach, making it ideal for understanding the frequency and severity of UI stutters. 📱💨
+
+---
+
+## Key Concepts
+
+To understand this detector, it's important to grasp three core concepts:
+
+* **Slow Frame**: A frame that takes longer to render than the ideal time budget determined by the screen's refresh rate. For a 60Hz screen, the budget is ~16.7ms; for a 120Hz ProMotion screen, it's ~8.3ms. A slow frame causes minor, often perceptible, stutters or "jank" in animations and scrolling.
+* **Frozen Frame**: A frame that takes a significantly long time to render (by default, > 700ms). This indicates a major blockage on the main thread and results in a noticeable, prolonged freeze of the UI.
+* **Reporting Window**: Instead of reporting every single bad frame, the detector groups data into configurable time windows (e.g., 60 seconds). At the end of each window, it reports the **total number** of slow and frozen frames that occurred during that period.
+
+---
+
+## How It Works
+
+The detector uses a sophisticated two-timer system to measure and report frame performance.
+
+1.  **Frame Synchronization**: It uses a `CADisplayLink`, a high-precision timer synchronized with the display's refresh rate. This link executes a callback function (`onFrame`) every time the screen is about to be redrawn.
+2.  **Per-Frame Analysis**: In the `onFrame` callback, it calculates the time elapsed since the *previous* frame. It then compares this duration against the calculated slow and frozen frame thresholds.
+3.  **Real-Time Counting**: If a frame is identified as slow or frozen, a thread-safe counter (`slowCount` or `frozenCount`) is incremented. These counters accumulate all bad frames within the current reporting window.
+4.  **Windowed Reporting**: A separate, lower-precision background timer (`DispatchSourceTimer`) fires periodically based on the `reportIntervalMs` (e.g., every 60 seconds). This triggers the `emitWindow` function.
+5.  **Data Aggregation**: `emitWindow` takes a snapshot of the current `slowCount` and `frozenCount`, appends these totals to the `windowSlow` and `windowFrozen` arrays, and then resets the counters to zero for the next window.
+6.  **Dynamic Adaptation**: The detector automatically adjusts its "slow frame" budget based on the device's screen refresh rate, correctly handling standard 60Hz displays, 120Hz ProMotion displays, and external monitors.
+
+---
+
+## Computed Statistics
+
+The detector provides statistical analysis (`min`, `max`, `avg`, `p95`) over the collected reporting windows. This is a powerful feature that provides high-level insights. For example:
+
+* **`avgSlow`** represents the **average number of slow frames per window**, giving you a baseline for typical UI stuttering.
+* **`maxFrozen`** shows the **worst-case number of frozen frames** observed in any single window during the session.
+
+---
+
+## Methods
+
+### `init(frozenThresholdMs:reportIntervalMs:tolerancePercentage:)`
+Initializes the detector with custom thresholds.
+
+### `startMonitoring()`
+Starts the `CADisplayLink` to begin monitoring frame times and schedules the periodic reporter.
+
+### `stopMonitoring()`
+Stops both the display link and the reporter timer, and flushes any remaining data from the current window.
+
+### `reset()`
+Clears all stored window data (`windowSlow`, `windowFrozen`) to begin a new measurement session.
+
+### `statsDictionary() -> [String: Any]`
+Returns a dictionary containing the latest computed statistics (`min`, `max`, `avg`, `p95`) for both slow and frozen frame counts, ready for logging.
+
+---

--- a/Coralogix/Docs/WarmDetector.md
+++ b/Coralogix/Docs/WarmDetector.md
@@ -1,0 +1,52 @@
+# WarmDetector
+
+The `WarmDetector` is a Swift class that measures the **warm start time** of an application. A warm start occurs when a user returns to the app while it's still resident in memory (i.e., suspended in the background). This detector measures the time elapsed from when the app begins its transition to the foreground until it becomes fully active and ready for user interaction. ⏱️
+
+---
+
+## How It Works
+
+The detector hooks into the standard `UIApplication` lifecycle notifications to measure the duration accurately. The process is as follows:
+
+1.  **Arming**: When the app moves to the background (`UIApplication.didEnterBackgroundNotification`), the detector sets an internal flag, `warmMetricIsActive`, to `true`. This "arms" the detector, indicating that the next foreground event should be measured as a warm start.
+2.  **Start Measurement**: As the app begins returning to the foreground (`UIApplication.willEnterForegroundNotification`), the detector checks the flag. If it's armed, it records the current time as `foregroundStartTime`.
+3.  **End Measurement**: When the app has finished its transition and is fully active (`UIApplication.didBecomeActiveNotification`), the detector captures the `foregroundEndTime`.
+4.  **Calculation**: The duration between the start and end times is calculated, converted to milliseconds, and passed to the `handleWarmClosure` for reporting. This logic is designed to run only once per foregrounding event.
+5.  **Cleanup**: The `deinit` method automatically removes all notification observers to prevent memory leaks.
+
+### Framework-Specific Behavior
+
+This detector is designed specifically for native Swift applications. It includes logic to disable its `willEnterForeground` and `didBecomeActive` observers if the encompassing SDK is identified as running in a **Flutter** or **React Native** environment, as those frameworks manage their lifecycle events differently.
+
+---
+
+## Properties
+
+* `foregroundStartTime: CFAbsoluteTime?`
+    * Stores the timestamp when the app begins to enter the foreground.
+
+* `foregroundEndTime: CFAbsoluteTime?`
+    * Stores the timestamp when the app becomes fully active. It also serves as a flag to prevent duplicate calculations.
+
+* `warmMetricIsActive: Bool`
+    * A flag that is set to `true` when the app enters the background, arming the detector to measure the next foreground transition.
+
+* `handleWarmClosure: (([String: Any]) -> Void)?`
+    * An optional closure that is executed with the warm start data once the measurement is complete.
+
+---
+
+## Methods
+
+### `startMonitoring()`
+
+Initializes the detector by adding observers for the necessary `UIApplication` lifecycle notifications (`didEnterBackground`, `willEnterForeground`, `didBecomeActive`).
+
+### `@objc` Notification Handlers
+
+* `appDidEnterBackgroundNotification()`: Arms the detector for the next warm start measurement.
+* `appWillEnterForegroundNotification()`: Captures the start time for the measurement.
+* `appDidBecomeActiveNotification()`: Captures the end time, performs the calculation, and triggers the handler closure.
+
+---
+

--- a/Coralogix/Sources/CoralogixRum.swift
+++ b/Coralogix/Sources/CoralogixRum.swift
@@ -7,9 +7,7 @@ import UIKit
 
 extension Notification.Name {
     static let cxRumNotification = Notification.Name("cxRumNotification")
-    static let cxRumNotificationSessionEnded = Notification.Name("cxRumNotificationSessionEnded")
     static let cxRumNotificationUserActions = Notification.Name("cxRumNotificationUserActions")
-    static let cxRumNotificationMetrics = Notification.Name("cxRumNotificationMetrics")
     static let cxViewDidAppear = Notification.Name("cxViewDidAppear")
 }
 
@@ -59,7 +57,6 @@ public class CoralogixRum {
     private func removeNotification() {
         NotificationCenter.default.removeObserver(self, name: .cxRumNotification, object: nil)
         NotificationCenter.default.removeObserver(self, name: .cxRumNotificationUserActions, object: nil)
-        NotificationCenter.default.removeObserver(self, name: .cxRumNotificationSessionEnded, object: nil)
         NotificationCenter.default.removeObserver(self, name: UIApplication.didFinishLaunchingNotification, object: nil)
         NotificationCenter.default.removeObserver(self, name: UIApplication.didBecomeActiveNotification, object: nil)
         NotificationCenter.default.removeObserver(self, name: UIApplication.didEnterBackgroundNotification, object: nil)

--- a/Coralogix/Sources/Exporter/CoralogixExporter.swift
+++ b/Coralogix/Sources/Exporter/CoralogixExporter.swift
@@ -29,9 +29,11 @@ public class CoralogixExporter: SpanExporter {
         self.viewManager = viewManager
         self.metricsManager = metricsManager
         
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(handleNotification(notification:)),
-                                               name: .cxRumNotificationSessionEnded, object: nil)
+        self.sessionManager.sessionEndedCallback = { [weak self] in
+            self?.viewManager.reset()
+            self?.sessionManager.reset()
+            self?.screenshotManager.reset()
+        }
     }
     
     var pendingSpans: [SpanData] = []
@@ -147,13 +149,7 @@ public class CoralogixExporter: SpanExporter {
         group.wait()
         return encodedSpans
     }
-    
-    @objc func handleNotification(notification: Notification) {
-        self.viewManager.reset()
-        self.sessionManager.reset()
-        self.screenshotManager.reset()
-    }
-    
+ 
     private func spanDatatoCxSpan(otelSpan: SpanData) -> [String: Any]? {
         guard otelSpan.spanId.isValid, !otelSpan.attributes.isEmpty else {
             Log.e("Invalid otelSpan: \(otelSpan)")

--- a/Coralogix/Sources/Utils/SessionManager.swift
+++ b/Coralogix/Sources/Utils/SessionManager.swift
@@ -23,7 +23,6 @@ import UIKit
  *    ```swift
  *    if timeSinceLastActivity > idleInterval {
  *        self.setupSessionMetadata()
- *        NotificationCenter.default.post(name: .cxRumNotificationSessionEnded, object: nil)
  *        Log.d("Function has been idle for 15 minutes.")
  *    }
  *    ```
@@ -52,6 +51,7 @@ public class SessionManager {
     private var errorCount: Int = 0
     private var clickCount: Int = 0
     public var sessionChangedCallback: ((String) -> Void)?
+    public var sessionEndedCallback: (() -> Void)?
     public var hasRecording: Bool = false
     
     public var lastSnapshotEventTime: Date?
@@ -100,7 +100,7 @@ public class SessionManager {
         if let sessionCreationDate = self.sessionMetadata?.sessionCreationDate,
            self.isIdle == false,
             self.hasAnHourPassed(since: sessionCreationDate) == true {
-            NotificationCenter.default.post(name: .cxRumNotificationSessionEnded, object: nil)
+            self.sessionEndedCallback?()
             self.setupSessionMetadata()
         }
         return self.sessionMetadata
@@ -158,8 +158,8 @@ public class SessionManager {
     internal func updateActivityTime() {
         if isIdle {
             Log.d("[SDK] transitioning from idle to active state")
+            self.sessionEndedCallback?()
             setupSessionMetadata()
-            NotificationCenter.default.post(name: .cxRumNotificationSessionEnded, object: nil)
         }
         lastActivity = Date()
     }


### PR DESCRIPTION
fix: now to add closure so the reset not relay on the notification center

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a session-ended callback for consumers to react to session lifecycle changes without NotificationCenter.

- Refactor
  - Replaced NotificationCenter-based session end handling with a callback across the exporter and session management.
  - Removed legacy session and metrics notifications.

- Documentation
  - Added/expanded docs for ANR, CPU, Memory, Cold Start, Warm Start, and Slow/Frozen Frames detectors, including how they work, key metrics, usage, and APIs.
  - Updated FPS monitoring docs to post as a Mobile vital event.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->