### PR TITLE
BUGV2-5379: Fix beforeSend error count when severity changes

### DIFF
--- a/Coralogix/Sources/Exporter/CoralogixExporter.swift
+++ b/Coralogix/Sources/Exporter/CoralogixExporter.swift
@@ -14,7 +14,7 @@ public class CoralogixExporter: SpanExporter {
     private var networkManager: NetworkProtocol
     private var metricsManager: MetricsManager
     private var screenshotManager = ScreenshotManager()
-    lazy var spanUploader = SpanUploader(options: self.options)
+    lazy var spanUploader: SpanUploading = SpanUploader(options: self.options)
 
     private let spanProcessingQueue = DispatchQueue(label: Keys.queueSpanProcessingQueue.rawValue)
     

--- a/Coralogix/Sources/Exporter/SpanUploader.swift
+++ b/Coralogix/Sources/Exporter/SpanUploader.swift
@@ -8,7 +8,12 @@
 import Foundation
 import CoralogixInternal
 
-final class SpanUploader {
+protocol SpanUploading {
+    @discardableResult
+    func upload(_ spans: [[String: Any]], endPoint: String) -> SpanExporterResultCode
+}
+
+final class SpanUploader: SpanUploading {
     private let options: CoralogixExporterOptions
     
     init(options: CoralogixExporterOptions) {

--- a/Coralogix/Sources/Instrumentation/NetworkInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/NetworkInstrumentation.swift
@@ -241,15 +241,15 @@ extension CoralogixRum {
         let raw: Int
         if let i = value as? Int {
             raw = i
-        } else if let d = value as? Double, d.isFinite {
-            raw = Int(d)
+        } else if let d = value as? Double, let i = Int(exactly: d) {
+            raw = i
         } else if let n = value as? NSNumber {
             raw = n.intValue
         } else if let s = value as? String {
             if let i = Int(s) {
                 raw = i
-            } else if let d = Double(s), d.isFinite {
-                raw = Int(d)
+            } else if let d = Double(s), let i = Int(exactly: d) {
+                raw = i
             } else {
                 return nil
             }

--- a/Coralogix/Sources/Instrumentation/NetworkInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/NetworkInstrumentation.swift
@@ -236,15 +236,15 @@ extension CoralogixRum {
 
     /// Coerces hybrid payload value (Int, Double, NSNumber, String) to Int for status_code.
     /// Returns nil for non-numeric or out-of-range (outside 100...599) values.
-    private func coerceToInt(_ value: Any?) -> Int? {
+    internal func coerceToInt(_ value: Any?) -> Int? {
         guard let value else { return nil }
         let raw: Int
         if let i = value as? Int {
             raw = i
         } else if let d = value as? Double, let i = Int(exactly: d) {
             raw = i
-        } else if let n = value as? NSNumber {
-            raw = n.intValue
+        } else if let n = value as? NSNumber, let i = Int(exactly: n.doubleValue) {
+            raw = i
         } else if let s = value as? String {
             if let i = Int(s) {
                 raw = i

--- a/Coralogix/Sources/Model/CxSpan.swift
+++ b/Coralogix/Sources/Model/CxSpan.swift
@@ -65,10 +65,10 @@ public class CxSpan {
         if beforeSend != nil {
             let subsetOfCxRum = self.createSubsetOfCxRum(from: originalCxRum)
             if let editableCxRum = self.beforeSend?(subsetOfCxRum) {
-                let mergedDict = mergeDictionaries(original: originalCxRum, editable: editableCxRum)
-                result[Keys.text.rawValue] = [Keys.cxRum.rawValue: mergedDict]
+                var mergedDict = mergeDictionaries(original: originalCxRum, editable: editableCxRum)
 
-                // Sync severity from editableCxRum to CxSpan's top-level severity.
+                // Sync severity from editableCxRum to both the top-level field and
+                // mergedDict[eventContext][severity] so they remain consistent.
                 // parseSeverity accepts Int or numeric String (matching the OTEL init path)
                 // and falls back to the original value so a missing/unparseable severity
                 // is treated as "no change" rather than silently skipping reconciliation.
@@ -78,6 +78,15 @@ public class CxSpan {
                         fallback: self.cxRum.eventContext.severity
                     )
                     result[Keys.severity.rawValue] = newSeverity
+
+                    // Write the normalised Int back into mergedDict so that
+                    // text.cxRum.eventContext.severity matches the top-level severity.
+                    if var ecDict = mergedDict[Keys.eventContext.rawValue] as? [String: Any] {
+                        ecDict[Keys.severity.rawValue] = newSeverity
+                        mergedDict[Keys.eventContext.rawValue] = ecDict
+                    }
+
+                    result[Keys.text.rawValue] = [Keys.cxRum.rawValue: mergedDict]
 
                     // BUGV2-5379: adjust errorCount when beforeSend changes severity across the Error boundary
                     let errorSeverity = CoralogixLogSeverity.error.rawValue
@@ -90,6 +99,8 @@ public class CxSpan {
                         sessionManager?.incrementErrorCounter()
                         updateSnapshotErrorCount(in: &result)
                     }
+                } else {
+                    result[Keys.text.rawValue] = [Keys.cxRum.rawValue: mergedDict]
                 }
             } else {
                 // BUGV2-5379: span dropped by beforeSend — undo error increment if it was an Error

--- a/Coralogix/Sources/Model/CxSpan.swift
+++ b/Coralogix/Sources/Model/CxSpan.swift
@@ -68,9 +68,15 @@ public class CxSpan {
                 let mergedDict = mergeDictionaries(original: originalCxRum, editable: editableCxRum)
                 result[Keys.text.rawValue] = [Keys.cxRum.rawValue: mergedDict]
 
-                // Sync severity from editableCxRum to CxSpan's top-level severity
-                if let eventContext = editableCxRum[Keys.eventContext.rawValue] as? [String: Any],
-                   let newSeverity = eventContext[Keys.severity.rawValue] as? Int {
+                // Sync severity from editableCxRum to CxSpan's top-level severity.
+                // parseSeverity accepts Int or numeric String (matching the OTEL init path)
+                // and falls back to the original value so a missing/unparseable severity
+                // is treated as "no change" rather than silently skipping reconciliation.
+                if let eventContext = editableCxRum[Keys.eventContext.rawValue] as? [String: Any] {
+                    let newSeverity = CxSpan.parseSeverity(
+                        eventContext[Keys.severity.rawValue],
+                        fallback: self.cxRum.eventContext.severity
+                    )
                     result[Keys.severity.rawValue] = newSeverity
 
                     // BUGV2-5379: adjust errorCount when beforeSend changes severity across the Error boundary
@@ -137,6 +143,15 @@ public class CxSpan {
         return mergedDict
     }
     
+    /// Normalizes a severity value supplied by beforeSend into an Int.
+    /// Accepts Int directly or a numeric String (matching the OTEL attribute initializer path).
+    /// Returns `fallback` when the value is nil, non-numeric, or an unrecognised type.
+    private static func parseSeverity(_ value: Any?, fallback: Int) -> Int {
+        if let intVal = value as? Int { return intVal }
+        if let strVal = value as? String, let parsed = Int(strVal) { return parsed }
+        return fallback
+    }
+
     private func updateSnapshotErrorCount(in result: inout [String: Any]) {
         guard var textDict = result[Keys.text.rawValue] as? [String: Any],
               var cxRumDict = textDict[Keys.cxRum.rawValue] as? [String: Any] else {

--- a/Coralogix/Sources/Model/CxSpan.swift
+++ b/Coralogix/Sources/Model/CxSpan.swift
@@ -67,6 +67,13 @@ public class CxSpan {
             if let editableCxRum = self.beforeSend?(subsetOfCxRum) {
                 var mergedDict = mergeDictionaries(original: originalCxRum, editable: editableCxRum)
 
+                // snapshotContext is stripped from the editable subset before beforeSend is called,
+                // but a callback could still inject it into the returned dict, causing mergeDictionaries
+                // to deep-merge corrupted counts into our internal value.
+                // Always restore from originalCxRum so errorCount/viewCount cannot be tampered with.
+                // Assigning nil removes the key when the original had no snapshot (no-snapshot spans).
+                mergedDict[Keys.snapshotContext.rawValue] = originalCxRum[Keys.snapshotContext.rawValue]
+
                 // Sync severity from editableCxRum to both the top-level field and
                 // mergedDict[eventContext][severity] so they remain consistent.
                 // parseSeverity accepts Int or numeric String (matching the OTEL init path)

--- a/Coralogix/Sources/Model/CxSpan.swift
+++ b/Coralogix/Sources/Model/CxSpan.swift
@@ -17,6 +17,7 @@ public class CxSpan {
     var instrumentationData: InstrumentationData?
     var beforeSend: (([String: Any]) -> [String: Any]?)?
     let viewManager: ViewManager?
+    weak var sessionManager: SessionManager?
     
     init?(otel: SpanDataProtocol,
           versionMetadata: VersionMetadata,
@@ -31,6 +32,7 @@ public class CxSpan {
         self.versionMetadata = versionMetadata
         self.subsystemName = Keys.cxRum.rawValue
         self.beforeSend = options.beforeSend
+        self.sessionManager = sessionManager
         if let severity = otel.getAttribute(forKey: Keys.severity.rawValue) as? String {
             self.severity = Int(severity) ?? 0
         }
@@ -65,14 +67,30 @@ public class CxSpan {
             if let editableCxRum = self.beforeSend?(subsetOfCxRum) {
                 let mergedDict = mergeDictionaries(original: originalCxRum, editable: editableCxRum)
                 result[Keys.text.rawValue] = [Keys.cxRum.rawValue: mergedDict]
-                
+
                 // Sync severity from editableCxRum to CxSpan's top-level severity
                 if let eventContext = editableCxRum[Keys.eventContext.rawValue] as? [String: Any],
                    let newSeverity = eventContext[Keys.severity.rawValue] as? Int {
                     result[Keys.severity.rawValue] = newSeverity
+
+                    // BUGV2-5379: adjust errorCount when beforeSend changes severity across the Error boundary
+                    let errorSeverity = CoralogixLogSeverity.error.rawValue
+                    let wasError = self.cxRum.eventContext.severity == errorSeverity
+                    let isNowError = newSeverity == errorSeverity
+                    if wasError && !isNowError {
+                        sessionManager?.decrementErrorCounter()
+                        updateSnapshotErrorCount(in: &result)
+                    } else if !wasError && isNowError {
+                        sessionManager?.incrementErrorCounter()
+                        updateSnapshotErrorCount(in: &result)
+                    }
                 }
             } else {
-                return nil // editableCxRum is nil we need to drop that span
+                // BUGV2-5379: span dropped by beforeSend — undo error increment if it was an Error
+                if self.cxRum.eventContext.severity == CoralogixLogSeverity.error.rawValue {
+                    sessionManager?.decrementErrorCounter()
+                }
+                return nil
             }
         } else {
             result[Keys.text.rawValue] = [Keys.cxRum.rawValue: originalCxRum]
@@ -119,6 +137,18 @@ public class CxSpan {
         return mergedDict
     }
     
+    private func updateSnapshotErrorCount(in result: inout [String: Any]) {
+        guard var textDict = result[Keys.text.rawValue] as? [String: Any],
+              var cxRumDict = textDict[Keys.cxRum.rawValue] as? [String: Any],
+              var snapshotDict = cxRumDict[Keys.snapshotContext.rawValue] as? [String: Any] else {
+            return
+        }
+        snapshotDict[Keys.errorCount.rawValue] = sessionManager?.getErrorCount() ?? 0
+        cxRumDict[Keys.snapshotContext.rawValue] = snapshotDict
+        textDict[Keys.cxRum.rawValue] = cxRumDict
+        result[Keys.text.rawValue] = textDict
+    }
+
     func createSubsetOfCxRum(from originalCxRum: [String: Any]) -> [String: Any] {
         var editableCxRum = originalCxRum
         // Remove sessionCreationDate and sessionId form sessionContext

--- a/Coralogix/Sources/Model/CxSpan.swift
+++ b/Coralogix/Sources/Model/CxSpan.swift
@@ -139,10 +139,12 @@ public class CxSpan {
     
     private func updateSnapshotErrorCount(in result: inout [String: Any]) {
         guard var textDict = result[Keys.text.rawValue] as? [String: Any],
-              var cxRumDict = textDict[Keys.cxRum.rawValue] as? [String: Any],
-              var snapshotDict = cxRumDict[Keys.snapshotContext.rawValue] as? [String: Any] else {
+              var cxRumDict = textDict[Keys.cxRum.rawValue] as? [String: Any] else {
             return
         }
+        // Fall back to an empty dict if snapshotContext is absent, NSNull, or a non-dict type,
+        // so errorCount is always written after beforeSend runs.
+        var snapshotDict = (cxRumDict[Keys.snapshotContext.rawValue] as? [String: Any]) ?? [:]
         snapshotDict[Keys.errorCount.rawValue] = sessionManager?.getErrorCount() ?? 0
         cxRumDict[Keys.snapshotContext.rawValue] = snapshotDict
         textDict[Keys.cxRum.rawValue] = cxRumDict

--- a/Coralogix/Sources/Model/CxSpan.swift
+++ b/Coralogix/Sources/Model/CxSpan.swift
@@ -79,47 +79,49 @@ public class CxSpan {
                 // parseSeverity accepts Int or numeric String (matching the OTEL init path)
                 // and falls back to the original value so a missing/unparseable severity
                 // is treated as "no change" rather than silently skipping reconciliation.
-                if let eventContext = editableCxRum[Keys.eventContext.rawValue] as? [String: Any] {
-                    let newSeverity = CxSpan.parseSeverity(
-                        eventContext[Keys.severity.rawValue],
-                        fallback: self.cxRum.eventContext.severity
-                    )
+                //
+                // Priority: eventContext[severity] → top-level editableCxRum[severity] → original.
+                // This covers the case where beforeSend removes eventContext entirely but
+                // still sets a top-level severity key.
+                let editableEventContext = editableCxRum[Keys.eventContext.rawValue] as? [String: Any]
+                let severitySource = editableEventContext?[Keys.severity.rawValue]
+                    ?? editableCxRum[Keys.severity.rawValue]
+                let newSeverity = CxSpan.parseSeverity(severitySource, fallback: self.cxRum.eventContext.severity)
 
-                    // Only write when the value actually changed to avoid a no-op overwrite
-                    // (e.g. when beforeSend returns an eventContext without a severity key,
-                    // parseSeverity returns the original value via fallback).
-                    if newSeverity != self.cxRum.eventContext.severity {
-                        result[Keys.severity.rawValue] = newSeverity
+                // Only write when the value actually changed to avoid a no-op overwrite
+                // (e.g. when beforeSend returns an eventContext without a severity key,
+                // parseSeverity returns the original value via fallback).
+                if newSeverity != self.cxRum.eventContext.severity {
+                    result[Keys.severity.rawValue] = newSeverity
+                }
+
+                // Write the normalised Int back into mergedDict so that
+                // text.cxRum.eventContext.severity matches the top-level severity.
+                if var ecDict = mergedDict[Keys.eventContext.rawValue] as? [String: Any] {
+                    ecDict[Keys.severity.rawValue] = newSeverity
+                    mergedDict[Keys.eventContext.rawValue] = ecDict
+                }
+
+                // Assign mergedDict before updateSnapshotErrorCount, which re-assigns
+                // result[Keys.text.rawValue] to patch snapshotContext.errorCount in place.
+                result[Keys.text.rawValue] = [Keys.cxRum.rawValue: mergedDict]
+
+                // BUGV2-5379: adjust errorCount when beforeSend changes severity across the Error boundary.
+                // Runs unconditionally so the counter stays correct even when beforeSend removes
+                // eventContext and expresses the severity change at the top level instead.
+                // Capture sessionManager once so the counter mutation and the getErrorCount()
+                // read inside updateSnapshotErrorCount see the same object (closes the TOCTOU
+                // window that the weak var would otherwise leave open).
+                let errorSeverity = CoralogixLogSeverity.error.rawValue
+                let wasError = self.cxRum.eventContext.severity == errorSeverity
+                let isNowError = newSeverity == errorSeverity
+                if wasError != isNowError, let sm = sessionManager {
+                    if wasError {
+                        sm.decrementErrorCounter()
+                    } else {
+                        sm.incrementErrorCounter()
                     }
-
-                    // Write the normalised Int back into mergedDict so that
-                    // text.cxRum.eventContext.severity matches the top-level severity.
-                    if var ecDict = mergedDict[Keys.eventContext.rawValue] as? [String: Any] {
-                        ecDict[Keys.severity.rawValue] = newSeverity
-                        mergedDict[Keys.eventContext.rawValue] = ecDict
-                    }
-
-                    // Assign mergedDict before updateSnapshotErrorCount, which re-assigns
-                    // result[Keys.text.rawValue] to patch snapshotContext.errorCount in place.
-                    result[Keys.text.rawValue] = [Keys.cxRum.rawValue: mergedDict]
-
-                    // BUGV2-5379: adjust errorCount when beforeSend changes severity across the Error boundary.
-                    // Capture sessionManager once so the counter mutation and the getErrorCount()
-                    // read inside updateSnapshotErrorCount see the same object (closes the TOCTOU
-                    // window that the weak var would otherwise leave open).
-                    let errorSeverity = CoralogixLogSeverity.error.rawValue
-                    let wasError = self.cxRum.eventContext.severity == errorSeverity
-                    let isNowError = newSeverity == errorSeverity
-                    if wasError != isNowError, let sm = sessionManager {
-                        if wasError {
-                            sm.decrementErrorCounter()
-                        } else {
-                            sm.incrementErrorCounter()
-                        }
-                        updateSnapshotErrorCount(in: &result, sessionManager: sm)
-                    }
-                } else {
-                    result[Keys.text.rawValue] = [Keys.cxRum.rawValue: mergedDict]
+                    updateSnapshotErrorCount(in: &result, sessionManager: sm)
                 }
             } else {
                 // BUGV2-5379: span dropped by beforeSend — undo error increment if it was an Error

--- a/Coralogix/Sources/Model/CxSpan.swift
+++ b/Coralogix/Sources/Model/CxSpan.swift
@@ -77,7 +77,13 @@ public class CxSpan {
                         eventContext[Keys.severity.rawValue],
                         fallback: self.cxRum.eventContext.severity
                     )
-                    result[Keys.severity.rawValue] = newSeverity
+
+                    // Only write when the value actually changed to avoid a no-op overwrite
+                    // (e.g. when beforeSend returns an eventContext without a severity key,
+                    // parseSeverity returns the original value via fallback).
+                    if newSeverity != self.cxRum.eventContext.severity {
+                        result[Keys.severity.rawValue] = newSeverity
+                    }
 
                     // Write the normalised Int back into mergedDict so that
                     // text.cxRum.eventContext.severity matches the top-level severity.
@@ -86,18 +92,24 @@ public class CxSpan {
                         mergedDict[Keys.eventContext.rawValue] = ecDict
                     }
 
+                    // Assign mergedDict before updateSnapshotErrorCount, which re-assigns
+                    // result[Keys.text.rawValue] to patch snapshotContext.errorCount in place.
                     result[Keys.text.rawValue] = [Keys.cxRum.rawValue: mergedDict]
 
-                    // BUGV2-5379: adjust errorCount when beforeSend changes severity across the Error boundary
+                    // BUGV2-5379: adjust errorCount when beforeSend changes severity across the Error boundary.
+                    // Capture sessionManager once so the counter mutation and the getErrorCount()
+                    // read inside updateSnapshotErrorCount see the same object (closes the TOCTOU
+                    // window that the weak var would otherwise leave open).
                     let errorSeverity = CoralogixLogSeverity.error.rawValue
                     let wasError = self.cxRum.eventContext.severity == errorSeverity
                     let isNowError = newSeverity == errorSeverity
-                    if wasError && !isNowError {
-                        sessionManager?.decrementErrorCounter()
-                        updateSnapshotErrorCount(in: &result)
-                    } else if !wasError && isNowError {
-                        sessionManager?.incrementErrorCounter()
-                        updateSnapshotErrorCount(in: &result)
+                    if wasError != isNowError, let sm = sessionManager {
+                        if wasError {
+                            sm.decrementErrorCounter()
+                        } else {
+                            sm.incrementErrorCounter()
+                        }
+                        updateSnapshotErrorCount(in: &result, sessionManager: sm)
                     }
                 } else {
                     result[Keys.text.rawValue] = [Keys.cxRum.rawValue: mergedDict]
@@ -163,7 +175,7 @@ public class CxSpan {
         return fallback
     }
 
-    private func updateSnapshotErrorCount(in result: inout [String: Any]) {
+    private func updateSnapshotErrorCount(in result: inout [String: Any], sessionManager: SessionManager) {
         guard var textDict = result[Keys.text.rawValue] as? [String: Any],
               var cxRumDict = textDict[Keys.cxRum.rawValue] as? [String: Any] else {
             return
@@ -171,7 +183,7 @@ public class CxSpan {
         // Fall back to an empty dict if snapshotContext is absent, NSNull, or a non-dict type,
         // so errorCount is always written after beforeSend runs.
         var snapshotDict = (cxRumDict[Keys.snapshotContext.rawValue] as? [String: Any]) ?? [:]
-        snapshotDict[Keys.errorCount.rawValue] = sessionManager?.getErrorCount() ?? 0
+        snapshotDict[Keys.errorCount.rawValue] = sessionManager.getErrorCount()
         cxRumDict[Keys.snapshotContext.rawValue] = snapshotDict
         textDict[Keys.cxRum.rawValue] = cxRumDict
         result[Keys.text.rawValue] = textDict

--- a/Coralogix/Sources/Utils/NetworkCaptureRule.swift
+++ b/Coralogix/Sources/Utils/NetworkCaptureRule.swift
@@ -144,9 +144,6 @@ public struct NetworkCaptureRule {
         if let body = request.httpBody {
             return (body, request)
         }
-        if request.httpBodyStream != nil {
-            return (nil, request)
-        }
         return (nil, request)
     }
 

--- a/Coralogix/Sources/Utils/SessionManager.swift
+++ b/Coralogix/Sources/Utils/SessionManager.swift
@@ -79,6 +79,12 @@ public class SessionManager {
     public func incrementErrorCounter() {
         errorCount += 1
     }
+
+    public func decrementErrorCounter() {
+        if errorCount > 0 {
+            errorCount -= 1
+        }
+    }
     
     public func incrementClickCounter() {
         clickCount += 1

--- a/Tests/CoralogixRumTests/AsyncAwaitNetworkInstrumentationTests.swift
+++ b/Tests/CoralogixRumTests/AsyncAwaitNetworkInstrumentationTests.swift
@@ -96,3 +96,67 @@ final class AsyncAwaitNetworkInstrumentationTests: XCTestCase {
     // Option 3: Mock Exporter
     // Create test-specific exporter that captures instead of sending
 }
+
+// MARK: - coerceToInt unit tests
+
+final class CoerceToIntTests: XCTestCase {
+    private var sut: CoralogixRum!
+
+    override func setUp() {
+        super.setUp()
+        let opts = CoralogixExporterOptions(coralogixDomain: .US2,
+                                            userContext: nil,
+                                            environment: "test",
+                                            application: "TestApp",
+                                            version: "1.0",
+                                            publicKey: "token",
+                                            ignoreUrls: [],
+                                            ignoreErrors: [],
+                                            labels: [:],
+                                            debug: false)
+        sut = CoralogixRum(options: opts)
+    }
+
+    override func tearDown() {
+        sut = nil
+        super.tearDown()
+    }
+
+    // NSNumber wrapping a true integer: preserved as-is
+    func test_coerceToInt_nsNumberInteger_returnsValue() {
+        XCTAssertEqual(sut.coerceToInt(NSNumber(value: 200)), 200)
+        XCTAssertEqual(sut.coerceToInt(NSNumber(value: 404)), 404)
+        XCTAssertEqual(sut.coerceToInt(NSNumber(value: 599)), 599)
+    }
+
+    // NSNumber with a fractional part: must be rejected (same as Double/String paths)
+    func test_coerceToInt_nsNumberFractional_returnsNil() {
+        XCTAssertNil(sut.coerceToInt(NSNumber(value: 200.5)),
+                     "NSNumber(200.5) must be rejected — fractional values are not exact integers")
+        XCTAssertNil(sut.coerceToInt(NSNumber(value: 404.1)))
+    }
+
+    // NSNumber out of representable Int range: must not trap and must return nil
+    func test_coerceToInt_nsNumberOutOfIntRange_returnsNil() {
+        // 1e20 > Int64.max; Int(exactly:) returns nil so no runtime trap occurs
+        XCTAssertNil(sut.coerceToInt(NSNumber(value: 1e20)))
+    }
+
+    // NSNumber outside the 100...599 status-code window: filtered by range check
+    func test_coerceToInt_nsNumberOutOfStatusRange_returnsNil() {
+        XCTAssertNil(sut.coerceToInt(NSNumber(value: 99)))
+        XCTAssertNil(sut.coerceToInt(NSNumber(value: 600)))
+        XCTAssertNil(sut.coerceToInt(NSNumber(value: 0)))
+    }
+
+    // Sanity-check the other branches are unaffected
+    func test_coerceToInt_otherTypes_behavesCorrectly() {
+        XCTAssertEqual(sut.coerceToInt(200),    200)   // Int
+        XCTAssertEqual(sut.coerceToInt(200.0),  200)   // Double exact
+        XCTAssertNil(sut.coerceToInt(200.5))           // Double fractional
+        XCTAssertEqual(sut.coerceToInt("201"),  201)   // String Int
+        XCTAssertNil(sut.coerceToInt("200.5"))         // String fractional Double
+        XCTAssertNil(sut.coerceToInt("abc"))           // String non-numeric
+        XCTAssertNil(sut.coerceToInt(nil))             // nil
+    }
+}

--- a/Tests/CoralogixRumTests/CoralogixExporterTests.swift
+++ b/Tests/CoralogixRumTests/CoralogixExporterTests.swift
@@ -662,6 +662,48 @@ final class CoralogixExporterTests: XCTestCase {
                        "errorCount should be 0 after error span is dropped by beforeSend")
     }
 
+    /// Covers the case where the original span had no snapshotContext (non-error, non-navigation,
+    /// < 1 minute since last snapshot) and beforeSend upgrades severity to Error.
+    /// updateSnapshotErrorCount must create snapshotContext rather than bailing out.
+    func test_beforeSend_nonErrorUpgradedToError_writesSnapshotContextWhenAbsent() {
+        var opts = CoralogixExporterOptions(coralogixDomain: .US2,
+                                            userContext: nil,
+                                            environment: "PROD",
+                                            application: "TestApp-iOS",
+                                            version: "1.0",
+                                            publicKey: "token",
+                                            ignoreUrls: [],
+                                            ignoreErrors: [],
+                                            labels: [:],
+                                            debug: true)
+        opts.beforeSend = { cxRum in
+            var modified = cxRum
+            if var eventContext = modified[Keys.eventContext.rawValue] as? [String: Any] {
+                eventContext[Keys.severity.rawValue] = CoralogixLogSeverity.error.rawValue
+                modified[Keys.eventContext.rawValue] = eventContext
+            }
+            return modified
+        }
+        let rum = CoralogixRum(options: opts)
+        guard let exporter = rum.coralogixExporter else { return XCTFail("Exporter nil") }
+
+        // Seed lastSnapshotEventTime so the 1-minute condition is false — ensures no snapshot
+        // is produced during build, giving us a span without snapshotContext in originalCxRum.
+        exporter.getSessionManager().lastSnapshotEventTime = Date()
+
+        let encoded = exporter.encodeSpans(spans: [makeValidSpanData()])
+
+        guard let span = encoded.first,
+              let textDict = span[Keys.text.rawValue] as? [String: Any],
+              let cxRumDict = textDict[Keys.cxRum.rawValue] as? [String: Any],
+              let snapshotDict = cxRumDict[Keys.snapshotContext.rawValue] as? [String: Any],
+              let errorCount = snapshotDict[Keys.errorCount.rawValue] as? Int else {
+            return XCTFail("snapshotContext.errorCount should be written even when originalCxRum had no snapshotContext")
+        }
+        XCTAssertEqual(errorCount, 1,
+                       "snapshotContext.errorCount must reflect the incremented count when beforeSend upgrades to Error")
+    }
+
     func test_beforeSend_nonErrorUpgradedToError_incrementsErrorCount() {
         var opts = CoralogixExporterOptions(coralogixDomain: .US2,
                                             userContext: nil,

--- a/Tests/CoralogixRumTests/CoralogixExporterTests.swift
+++ b/Tests/CoralogixRumTests/CoralogixExporterTests.swift
@@ -763,10 +763,20 @@ final class CoralogixExporterTests: XCTestCase {
         let encoded = exporter.encodeSpans(spans: [makeErrorSpanData()])
 
         XCTAssertFalse(encoded.isEmpty, "Span should not be dropped")
-        // Severity must be written as Int in the top-level result
+
+        // Top-level severity must be the normalised Int
         XCTAssertEqual(encoded.first?[Keys.severity.rawValue] as? Int,
                        CoralogixLogSeverity.info.rawValue,
-                       "Severity should be normalised to Int in the emitted span")
+                       "Top-level severity should be normalised to Int")
+
+        // text.cxRum.eventContext.severity must also be the normalised Int (not the raw String)
+        let nestedSeverity = (encoded.first?[Keys.text.rawValue] as? [String: Any])
+            .flatMap { $0[Keys.cxRum.rawValue] as? [String: Any] }
+            .flatMap { $0[Keys.eventContext.rawValue] as? [String: Any] }
+            .flatMap { $0[Keys.severity.rawValue] as? Int }
+        XCTAssertEqual(nestedSeverity, CoralogixLogSeverity.info.rawValue,
+                       "text.cxRum.eventContext.severity should match the normalised Int, not the raw String")
+
         XCTAssertEqual(exporter.getSessionManager().getErrorCount(), 0,
                        "errorCount should be decremented when severity String is normalised")
     }

--- a/Tests/CoralogixRumTests/CoralogixExporterTests.swift
+++ b/Tests/CoralogixRumTests/CoralogixExporterTests.swift
@@ -887,6 +887,71 @@ final class CoralogixExporterTests: XCTestCase {
                        "Severity should fall back to the original value when key is absent")
     }
 
+    /// beforeSend removes eventContext entirely and expresses the severity change via a
+    /// top-level "severity" key. The counter and snapshotContext must still be adjusted.
+    func test_beforeSend_removesEventContext_topLevelSeverityUsed_counterAdjusted() {
+        var opts = CoralogixExporterOptions(coralogixDomain: .US2,
+                                            userContext: nil,
+                                            environment: "PROD",
+                                            application: "TestApp-iOS",
+                                            version: "1.0",
+                                            publicKey: "token",
+                                            ignoreUrls: [],
+                                            ignoreErrors: [],
+                                            labels: [:],
+                                            debug: true)
+        // Downgrade error → info by removing eventContext and setting top-level severity
+        opts.beforeSend = { cxRum in
+            var modified = cxRum
+            modified.removeValue(forKey: Keys.eventContext.rawValue)
+            modified[Keys.severity.rawValue] = CoralogixLogSeverity.info.rawValue
+            return modified
+        }
+        let rum = CoralogixRum(options: opts)
+        guard let exporter = rum.coralogixExporter else { return XCTFail("Exporter nil") }
+
+        let encoded = exporter.encodeSpans(spans: [makeErrorSpanData()])
+
+        XCTAssertFalse(encoded.isEmpty, "Span should not be dropped")
+        // Error was decremented because severity crossed the Error boundary downward
+        XCTAssertEqual(exporter.getSessionManager().getErrorCount(), 0,
+                       "errorCount should be decremented when top-level severity downgrades from Error")
+        // Top-level severity reflects the new value
+        XCTAssertEqual(encoded.first?[Keys.severity.rawValue] as? Int,
+                       CoralogixLogSeverity.info.rawValue,
+                       "Top-level severity should reflect the top-level override from beforeSend")
+    }
+
+    /// beforeSend removes eventContext entirely with no severity key at all.
+    /// The fallback keeps the original severity and no counter adjustment fires.
+    func test_beforeSend_removesEventContextNoSeverity_fallsBackToOriginalNoCountChange() {
+        var opts = CoralogixExporterOptions(coralogixDomain: .US2,
+                                            userContext: nil,
+                                            environment: "PROD",
+                                            application: "TestApp-iOS",
+                                            version: "1.0",
+                                            publicKey: "token",
+                                            ignoreUrls: [],
+                                            ignoreErrors: [],
+                                            labels: [:],
+                                            debug: true)
+        opts.beforeSend = { cxRum in
+            var modified = cxRum
+            modified.removeValue(forKey: Keys.eventContext.rawValue)
+            // No severity key — fallback path should preserve original severity
+            return modified
+        }
+        let rum = CoralogixRum(options: opts)
+        guard let exporter = rum.coralogixExporter else { return XCTFail("Exporter nil") }
+
+        let encoded = exporter.encodeSpans(spans: [makeErrorSpanData()])
+
+        XCTAssertFalse(encoded.isEmpty, "Span should not be dropped")
+        // Original was Error(5); no change → counter stays at 1
+        XCTAssertEqual(exporter.getSessionManager().getErrorCount(), 1,
+                       "errorCount must be unchanged when eventContext and severity are both absent")
+    }
+
     override func tearDown() {
         super.tearDown()
     }

--- a/Tests/CoralogixRumTests/CoralogixExporterTests.swift
+++ b/Tests/CoralogixRumTests/CoralogixExporterTests.swift
@@ -733,6 +733,80 @@ final class CoralogixExporterTests: XCTestCase {
                        "errorCount should be 1 after beforeSend upgrades non-Error to Error")
     }
 
+    // MARK: - Severity normalisation (String / missing)
+
+    /// beforeSend returns severity as a numeric String instead of Int.
+    /// The cast `as? Int` would fail, so the old code silently skipped the decrement.
+    func test_beforeSend_severityAsString_isNormalisedAndCountAdjusted() {
+        var opts = CoralogixExporterOptions(coralogixDomain: .US2,
+                                            userContext: nil,
+                                            environment: "PROD",
+                                            application: "TestApp-iOS",
+                                            version: "1.0",
+                                            publicKey: "token",
+                                            ignoreUrls: [],
+                                            ignoreErrors: [],
+                                            labels: [:],
+                                            debug: true)
+        opts.beforeSend = { cxRum in
+            var modified = cxRum
+            if var eventContext = modified[Keys.eventContext.rawValue] as? [String: Any] {
+                // Supply severity as String "3" rather than Int 3
+                eventContext[Keys.severity.rawValue] = "\(CoralogixLogSeverity.info.rawValue)"
+                modified[Keys.eventContext.rawValue] = eventContext
+            }
+            return modified
+        }
+        let rum = CoralogixRum(options: opts)
+        guard let exporter = rum.coralogixExporter else { return XCTFail("Exporter nil") }
+
+        let encoded = exporter.encodeSpans(spans: [makeErrorSpanData()])
+
+        XCTAssertFalse(encoded.isEmpty, "Span should not be dropped")
+        // Severity must be written as Int in the top-level result
+        XCTAssertEqual(encoded.first?[Keys.severity.rawValue] as? Int,
+                       CoralogixLogSeverity.info.rawValue,
+                       "Severity should be normalised to Int in the emitted span")
+        XCTAssertEqual(exporter.getSessionManager().getErrorCount(), 0,
+                       "errorCount should be decremented when severity String is normalised")
+    }
+
+    /// beforeSend returns an eventContext without a severity key.
+    /// The fallback keeps the original severity, so no error-count adjustment should fire.
+    func test_beforeSend_severityKeyAbsent_fallsBackToOriginalAndNoCountChange() {
+        var opts = CoralogixExporterOptions(coralogixDomain: .US2,
+                                            userContext: nil,
+                                            environment: "PROD",
+                                            application: "TestApp-iOS",
+                                            version: "1.0",
+                                            publicKey: "token",
+                                            ignoreUrls: [],
+                                            ignoreErrors: [],
+                                            labels: [:],
+                                            debug: true)
+        opts.beforeSend = { cxRum in
+            var modified = cxRum
+            if var eventContext = modified[Keys.eventContext.rawValue] as? [String: Any] {
+                eventContext.removeValue(forKey: Keys.severity.rawValue)
+                modified[Keys.eventContext.rawValue] = eventContext
+            }
+            return modified
+        }
+        let rum = CoralogixRum(options: opts)
+        guard let exporter = rum.coralogixExporter else { return XCTFail("Exporter nil") }
+
+        let encoded = exporter.encodeSpans(spans: [makeErrorSpanData()])
+
+        XCTAssertFalse(encoded.isEmpty, "Span should not be dropped")
+        // Original was Error(5), no change → errorCount stays at 1
+        XCTAssertEqual(exporter.getSessionManager().getErrorCount(), 1,
+                       "errorCount should be unchanged when severity key is absent in beforeSend result")
+        // Top-level severity should reflect the fallback (original) value
+        XCTAssertEqual(encoded.first?[Keys.severity.rawValue] as? Int,
+                       CoralogixLogSeverity.error.rawValue,
+                       "Severity should fall back to the original value when key is absent")
+    }
+
     override func tearDown() {
         super.tearDown()
     }

--- a/Tests/CoralogixRumTests/CoralogixExporterTests.swift
+++ b/Tests/CoralogixRumTests/CoralogixExporterTests.swift
@@ -389,14 +389,15 @@ final class CoralogixExporterTests: XCTestCase {
         let coralogixRum = CoralogixRum(options: options!)
         
         // When
-        let result = coralogixRum.coralogixExporter?.spanUploader.resolvedUrlString(endPoint: endPoint)
-        
+        let uploader = coralogixRum.coralogixExporter?.spanUploader as? SpanUploader
+        let result = uploader?.resolvedUrlString(endPoint: endPoint)
+
         // Then
         guard let result = result else {
             XCTFail("URL should not be nil")
             return
         }
-        
+
         XCTAssertTrue(result.contains(proxyUrl))
         XCTAssertTrue(result.contains("cxforward="))
         XCTAssertTrue(result.contains(CoralogixDomain.US2.rawValue))
@@ -417,7 +418,8 @@ final class CoralogixExporterTests: XCTestCase {
                                           debug: true)
         let coralogixRum = CoralogixRum(options: options!)
         // When
-        let result = coralogixRum.coralogixExporter?.spanUploader.resolvedUrlString(endPoint: endPoint)
+        let uploader = coralogixRum.coralogixExporter?.spanUploader as? SpanUploader
+        let result = uploader?.resolvedUrlString(endPoint: endPoint)
 
         // Then
         XCTAssertEqual(result, coralogixRum.coralogixExporter?.endPoint)
@@ -488,7 +490,8 @@ final class CoralogixExporterTests: XCTestCase {
 
     func test_export_uploadsDirectly_whenFlutterAndBeforeSendCallBackIsNil() {
         // Previously, Flutter/ReactNative exports without a beforeSendCallBack
-        // would silently drop spans. Verify this no longer happens.
+        // would silently drop spans. Verify this no longer happens by injecting
+        // a mock uploader that records invocation without making network calls.
         let opts = CoralogixExporterOptions(coralogixDomain: .US2,
                                             userContext: nil,
                                             environment: "PROD",
@@ -506,13 +509,15 @@ final class CoralogixExporterTests: XCTestCase {
             return
         }
 
+        let mockUploader = MockSpanUploader()
+        exporter.spanUploader = mockUploader
+
         let span = makeValidSpanData()
         let result = exporter.export(spans: [span], explicitTimeout: nil)
 
-        // Previously spans were silently dropped (no callback, no upload). Now we must reach
-        // spanUploader.upload(). Assert .success to verify spans reached the upload path.
-        // (Upload may return .failure on network error in CI; if flaky, consider mocking the uploader.)
-        XCTAssertEqual(result, .success, "Span must reach upload path; no silent drop when beforeSendCallBack is nil")
+        XCTAssertTrue(mockUploader.uploadCalled, "spanUploader.upload must be invoked when beforeSendCallBack is nil")
+        XCTAssertFalse(mockUploader.uploadedSpans.isEmpty, "Upload should receive non-empty spans")
+        XCTAssertEqual(result, .success, "Export should return .success from mock uploader")
     }
 
     func test_export_nativeBypassesBeforeSendCallBack() {
@@ -546,7 +551,160 @@ final class CoralogixExporterTests: XCTestCase {
         XCTAssertFalse(callbackInvoked, "Native clients must not route spans through beforeSendCallBack")
     }
 
+    // MARK: - BUGV2-5379: beforeSend severity change must adjust errorCount
+
+    private func makeErrorSpanData() -> SpanData {
+        let attributes: [String: AttributeValue] = [
+            Keys.severity.rawValue: AttributeValue("5"),
+            Keys.eventType.rawValue: AttributeValue("error"),
+            Keys.source.rawValue: AttributeValue("console"),
+            Keys.environment.rawValue: AttributeValue("prod"),
+            Keys.userId.rawValue: AttributeValue("12345"),
+            Keys.userName.rawValue: AttributeValue("John Doe"),
+            Keys.userEmail.rawValue: AttributeValue("john.doe@example.com"),
+            Keys.sessionId.rawValue: AttributeValue("session_001"),
+            Keys.sessionCreationDate.rawValue: AttributeValue("1609459200"),
+            SemanticAttributes.httpUrl.rawValue: AttributeValue("https://example.com/api/data")
+        ]
+        return SpanData(traceId: TraceId.random(),
+                        spanId: SpanId.random(),
+                        name: "errorSpan",
+                        kind: .client,
+                        startTime: Date(),
+                        attributes: attributes,
+                        endTime: Date(),
+                        hasEnded: true)
+    }
+
+    func test_beforeSend_errorDowngradedToInfo_decrementsErrorCount() {
+        var opts = CoralogixExporterOptions(coralogixDomain: .US2,
+                                            userContext: nil,
+                                            environment: "PROD",
+                                            application: "TestApp-iOS",
+                                            version: "1.0",
+                                            publicKey: "token",
+                                            ignoreUrls: [],
+                                            ignoreErrors: [],
+                                            labels: [:],
+                                            debug: true)
+        opts.beforeSend = { cxRum in
+            var modified = cxRum
+            if var eventContext = modified[Keys.eventContext.rawValue] as? [String: Any] {
+                eventContext[Keys.severity.rawValue] = CoralogixLogSeverity.info.rawValue
+                modified[Keys.eventContext.rawValue] = eventContext
+            }
+            return modified
+        }
+        let rum = CoralogixRum(options: opts)
+        guard let exporter = rum.coralogixExporter else { return XCTFail("Exporter nil") }
+
+        let encoded = exporter.encodeSpans(spans: [makeErrorSpanData()])
+
+        XCTAssertFalse(encoded.isEmpty, "Span should not be dropped")
+        XCTAssertEqual(exporter.getSessionManager().getErrorCount(), 0,
+                       "errorCount should be 0 after beforeSend downgrades Error to Info")
+    }
+
+    func test_beforeSend_errorDowngraded_updatesSnapshotContextErrorCount() {
+        var opts = CoralogixExporterOptions(coralogixDomain: .US2,
+                                            userContext: nil,
+                                            environment: "PROD",
+                                            application: "TestApp-iOS",
+                                            version: "1.0",
+                                            publicKey: "token",
+                                            ignoreUrls: [],
+                                            ignoreErrors: [],
+                                            labels: [:],
+                                            debug: true)
+        opts.beforeSend = { cxRum in
+            var modified = cxRum
+            if var eventContext = modified[Keys.eventContext.rawValue] as? [String: Any] {
+                eventContext[Keys.severity.rawValue] = CoralogixLogSeverity.info.rawValue
+                modified[Keys.eventContext.rawValue] = eventContext
+            }
+            return modified
+        }
+        let rum = CoralogixRum(options: opts)
+        guard let exporter = rum.coralogixExporter else { return XCTFail("Exporter nil") }
+
+        let encoded = exporter.encodeSpans(spans: [makeErrorSpanData()])
+
+        guard let span = encoded.first,
+              let textDict = span[Keys.text.rawValue] as? [String: Any],
+              let cxRumDict = textDict[Keys.cxRum.rawValue] as? [String: Any],
+              let snapshotDict = cxRumDict[Keys.snapshotContext.rawValue] as? [String: Any],
+              let errorCount = snapshotDict[Keys.errorCount.rawValue] as? Int else {
+            return XCTFail("snapshotContext not found in encoded span")
+        }
+        XCTAssertEqual(errorCount, 0,
+                       "snapshotContext.errorCount should reflect the decremented count")
+    }
+
+    func test_beforeSend_errorSpanDropped_decrementsErrorCount() {
+        var opts = CoralogixExporterOptions(coralogixDomain: .US2,
+                                            userContext: nil,
+                                            environment: "PROD",
+                                            application: "TestApp-iOS",
+                                            version: "1.0",
+                                            publicKey: "token",
+                                            ignoreUrls: [],
+                                            ignoreErrors: [],
+                                            labels: [:],
+                                            debug: true)
+        opts.beforeSend = { _ in return nil }
+        let rum = CoralogixRum(options: opts)
+        guard let exporter = rum.coralogixExporter else { return XCTFail("Exporter nil") }
+
+        let encoded = exporter.encodeSpans(spans: [makeErrorSpanData()])
+
+        XCTAssertTrue(encoded.isEmpty, "Dropped span should produce empty result")
+        XCTAssertEqual(exporter.getSessionManager().getErrorCount(), 0,
+                       "errorCount should be 0 after error span is dropped by beforeSend")
+    }
+
+    func test_beforeSend_nonErrorUpgradedToError_incrementsErrorCount() {
+        var opts = CoralogixExporterOptions(coralogixDomain: .US2,
+                                            userContext: nil,
+                                            environment: "PROD",
+                                            application: "TestApp-iOS",
+                                            version: "1.0",
+                                            publicKey: "token",
+                                            ignoreUrls: [],
+                                            ignoreErrors: [],
+                                            labels: [:],
+                                            debug: true)
+        opts.beforeSend = { cxRum in
+            var modified = cxRum
+            if var eventContext = modified[Keys.eventContext.rawValue] as? [String: Any] {
+                eventContext[Keys.severity.rawValue] = CoralogixLogSeverity.error.rawValue
+                modified[Keys.eventContext.rawValue] = eventContext
+            }
+            return modified
+        }
+        let rum = CoralogixRum(options: opts)
+        guard let exporter = rum.coralogixExporter else { return XCTFail("Exporter nil") }
+
+        let encoded = exporter.encodeSpans(spans: [makeValidSpanData()])
+
+        XCTAssertFalse(encoded.isEmpty, "Span should not be dropped")
+        XCTAssertEqual(exporter.getSessionManager().getErrorCount(), 1,
+                       "errorCount should be 1 after beforeSend upgrades non-Error to Error")
+    }
+
     override func tearDown() {
         super.tearDown()
+    }
+}
+
+// MARK: - Test Doubles
+
+private class MockSpanUploader: SpanUploading {
+    var uploadCalled = false
+    var uploadedSpans: [[String: Any]] = []
+
+    func upload(_ spans: [[String: Any]], endPoint: String) -> SpanExporterResultCode {
+        uploadCalled = true
+        uploadedSpans = spans
+        return .success
     }
 }

--- a/Tests/CoralogixRumTests/CoralogixExporterTests.swift
+++ b/Tests/CoralogixRumTests/CoralogixExporterTests.swift
@@ -733,6 +733,76 @@ final class CoralogixExporterTests: XCTestCase {
                        "errorCount should be 1 after beforeSend upgrades non-Error to Error")
     }
 
+    // MARK: - snapshotContext tamper protection
+
+    /// beforeSend injects a snapshotContext with a fabricated errorCount.
+    /// The emitted span must contain the SDK-built value, not the injected one.
+    func test_beforeSend_cannotOverrideSnapshotContext_fabricatedInjection() {
+        var opts = CoralogixExporterOptions(coralogixDomain: .US2,
+                                            userContext: nil,
+                                            environment: "PROD",
+                                            application: "TestApp-iOS",
+                                            version: "1.0",
+                                            publicKey: "token",
+                                            ignoreUrls: [],
+                                            ignoreErrors: [],
+                                            labels: [:],
+                                            debug: true)
+        opts.beforeSend = { cxRum in
+            var tampered = cxRum
+            tampered[Keys.snapshotContext.rawValue] = [Keys.errorCount.rawValue: 999]
+            return tampered
+        }
+        let rum = CoralogixRum(options: opts)
+        guard let exporter = rum.coralogixExporter else { return XCTFail("Exporter nil") }
+
+        let encoded = exporter.encodeSpans(spans: [makeErrorSpanData()])
+
+        let errorCount = (encoded.first?[Keys.text.rawValue] as? [String: Any])
+            .flatMap { $0[Keys.cxRum.rawValue] as? [String: Any] }
+            .flatMap { $0[Keys.snapshotContext.rawValue] as? [String: Any] }
+            .flatMap { $0[Keys.errorCount.rawValue] as? Int }
+        XCTAssertNotEqual(errorCount, 999,
+                          "beforeSend must not be able to overwrite snapshotContext.errorCount")
+        XCTAssertEqual(errorCount, 1,
+                       "snapshotContext.errorCount must reflect the SDK-built value")
+    }
+
+    /// beforeSend receives a subset that already has a 'snapshotContext' key re-added
+    /// and mutates a nested field. The SDK-built snapshot must survive unchanged.
+    func test_beforeSend_cannotMutateSnapshotContextFields() {
+        var opts = CoralogixExporterOptions(coralogixDomain: .US2,
+                                            userContext: nil,
+                                            environment: "PROD",
+                                            application: "TestApp-iOS",
+                                            version: "1.0",
+                                            publicKey: "token",
+                                            ignoreUrls: [],
+                                            ignoreErrors: [],
+                                            labels: [:],
+                                            debug: true)
+        opts.beforeSend = { cxRum in
+            var tampered = cxRum
+            // Attempt partial mutation: inject a snapshotContext dict that only sets errorCount
+            tampered[Keys.snapshotContext.rawValue] = [
+                Keys.errorCount.rawValue: 0,
+                Keys.viewCount.rawValue: 0
+            ]
+            return tampered
+        }
+        let rum = CoralogixRum(options: opts)
+        guard let exporter = rum.coralogixExporter else { return XCTFail("Exporter nil") }
+
+        let encoded = exporter.encodeSpans(spans: [makeErrorSpanData()])
+
+        let snapshotDict = (encoded.first?[Keys.text.rawValue] as? [String: Any])
+            .flatMap { $0[Keys.cxRum.rawValue] as? [String: Any] }
+            .flatMap { $0[Keys.snapshotContext.rawValue] as? [String: Any] }
+        let errorCount = snapshotDict.flatMap { $0[Keys.errorCount.rawValue] as? Int }
+        XCTAssertEqual(errorCount, 1,
+                       "Partial snapshotContext injection must not corrupt errorCount")
+    }
+
     // MARK: - Severity normalisation (String / missing)
 
     /// beforeSend returns severity as a numeric String instead of Int.

--- a/Tests/CoralogixRumTests/CxRumBuilderTests.swift
+++ b/Tests/CoralogixRumTests/CxRumBuilderTests.swift
@@ -16,19 +16,23 @@ class MockSessionManager: SessionManager {
     var hasRec = false
     
     var incrementErrorCounterCallCount = 0
-    
+    var decrementErrorCounterCallCount = 0
+
     override func getErrorCount() -> Int { return errorCount }
     override var lastSnapshotEventTime: Date? {
         get { return lastSnapshotTime }
         set { lastSnapshotTime = newValue }
     }
-    
+
     override func incrementErrorCounter() {
         incrementErrorCounterCallCount += 1
         errorCount += 1
     }
-    
-    // Add other overrides as needed, returning default values
+
+    override func decrementErrorCounter() {
+        decrementErrorCounterCallCount += 1
+        if errorCount > 0 { errorCount -= 1 }
+    }
 }
 
 class MockViewManager: ViewManager {

--- a/Tests/CoralogixRumTests/NetworkCaptureIntegrationTests.swift
+++ b/Tests/CoralogixRumTests/NetworkCaptureIntegrationTests.swift
@@ -173,6 +173,8 @@ final class NetworkCaptureIntegrationTests: XCTestCase {
         performRequest(url: url, method: "POST", body: body.data(using: .utf8), headers: ["Content-Type": "application/json"])
         let span = try XCTUnwrap(waitForNetworkSpan(urlContains: "capturetest"))
         let payload = span.attributes[Keys.requestPayload.rawValue]?.description
+        XCTAssertNotNil(payload, "request_payload must be set for POST with collectReqPayload: true")
+        XCTAssertEqual(payload, body, "request_payload must match the original request body")
     }
 
     func test_collectReqPayload_largeBody_requestPayloadAbsent() throws {

--- a/Tests/CoralogixRumTests/NetworkCaptureIntegrationTests.swift
+++ b/Tests/CoralogixRumTests/NetworkCaptureIntegrationTests.swift
@@ -98,25 +98,38 @@ final class NetworkCaptureIntegrationTests: XCTestCase {
     }
 
     /// Waits for a network span matching the URL to appear in capturedSpans (flushes and polls briefly).
+    /// When `requiringRequestPayload` is true, only returns a span that has request_payload (avoids flaky picks).
     /// Note: Uses short polling intervals; on slow CI, pass a larger timeout if tests are flaky.
-    func waitForNetworkSpan(urlContains: String, timeout: TimeInterval = 5) -> SpanData? {
+    func waitForNetworkSpan(urlContains: String, requiringRequestPayload: Bool = false, timeout: TimeInterval = 5) -> SpanData? {
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {
             forceFlush()
-            if let span = findNetworkSpan(urlContains: urlContains) { return span }
+            if let span = findNetworkSpan(urlContains: urlContains, requiringRequestPayload: requiringRequestPayload) {
+                return span
+            }
             Thread.sleep(forTimeInterval: 0.1)
         }
         return nil
     }
 
     func findNetworkSpan(urlContains: String) -> SpanData? {
+        findNetworkSpan(urlContains: urlContains, requiringRequestPayload: false)
+    }
+
+    /// Finds a network span matching the URL. When `requiringRequestPayload` is true, only returns a span that has
+    /// request_payload set — avoids picking a span from another swizzle layer that lacks capture (flaky in CI).
+    func findNetworkSpan(urlContains: String, requiringRequestPayload: Bool) -> SpanData? {
         captureLock.lock()
         defer { captureLock.unlock() }
         return capturedSpans.first { span in
             let type = span.attributes[Keys.eventType.rawValue]?.description ?? ""
             guard type.contains(CoralogixEventType.networkRequest.rawValue) else { return false }
             guard let url = span.attributes[SemanticAttributes.httpUrl.rawValue]?.description else { return false }
-            return url.contains(urlContains)
+            guard url.contains(urlContains) else { return false }
+            if requiringRequestPayload {
+                return span.attributes[Keys.requestPayload.rawValue] != nil
+            }
+            return true
         }
     }
 
@@ -171,9 +184,12 @@ final class NetworkCaptureIntegrationTests: XCTestCase {
         CaptureTestURLProtocol.stub = (201, ["Content-Type": "application/json"], "{}".data(using: .utf8)!)
         startSDK(rules: [NetworkCaptureRule(url: "capturetest://integration", collectReqPayload: true)])
         performRequest(url: url, method: "POST", body: body.data(using: .utf8), headers: ["Content-Type": "application/json"])
-        let span = try XCTUnwrap(waitForNetworkSpan(urlContains: "capturetest"))
+        // Require request_payload so we pick our instrumentation's span (avoids flaky pick from other swizzle layers)
+        let span = try XCTUnwrap(
+            waitForNetworkSpan(urlContains: "/api/post", requiringRequestPayload: true),
+            "No span with request_payload for POST — either capture failed or wrong span was chosen (swizzle layers)"
+        )
         let payload = span.attributes[Keys.requestPayload.rawValue]?.description
-        XCTAssertNotNil(payload, "request_payload must be set for POST with collectReqPayload: true")
         XCTAssertEqual(payload, body, "request_payload must match the original request body")
     }
 

--- a/Tests/CoralogixRumTests/SessionManagerTests.swift
+++ b/Tests/CoralogixRumTests/SessionManagerTests.swift
@@ -78,6 +78,26 @@ class SessionManagerTests: XCTestCase {
         XCTAssertEqual(sessionManager.getErrorCount(), 1)
     }
 
+    // MARK: - BUGV2-5379: decrementErrorCounter
+
+    func testDecrementErrorCounter_reducesCountByOne() {
+        sessionManager.incrementErrorCounter()
+        sessionManager.incrementErrorCounter()
+        sessionManager.decrementErrorCounter()
+        XCTAssertEqual(sessionManager.getErrorCount(), 1)
+    }
+
+    func testDecrementErrorCounter_doesNotGoBelowZero() {
+        sessionManager.decrementErrorCounter()
+        XCTAssertEqual(sessionManager.getErrorCount(), 0, "errorCount must not go negative")
+    }
+
+    func testDecrementErrorCounter_incrementThenDecrementEqualsZero() {
+        sessionManager.incrementErrorCounter()
+        sessionManager.decrementErrorCounter()
+        XCTAssertEqual(sessionManager.getErrorCount(), 0)
+    }
+
     func testResetClearsData() {
         sessionManager.incrementClickCounter()
         sessionManager.incrementErrorCounter()


### PR DESCRIPTION
# User description
## Summary
Fixes error count tracking when `beforeSend` modifies span severity or drops spans:
- **Downgrade (Error → non-Error):** Decrements error count and updates `snapshotContext.errorCount`
- **Upgrade (non-Error → Error):** Increments error count and updates `snapshotContext.errorCount`
- **Drop (span filtered out):** Decrements error count when the dropped span was an error

## Code Review (pre-PR)
- **No issues found** — Severity boundary logic, `SessionManager.decrementErrorCounter`, and `updateSnapshotErrorCount` are correct.
- **Suggestion:** Consider logging when `sessionManager` is nil in `updateSnapshotErrorCount` (shouldn't occur; helps debugging).
- **Nit:** `makeErrorSpanData()` could be moved to a shared test helper if reused.
- All processing runs on `spanProcessingQueue` (serial) — no concurrency concerns.

Made with [Cursor](https://cursor.com)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Aligns <code>CxSpan</code>'s beforeSend path with the RUM session snapshot by normalizing severity, protecting <code>snapshotContext</code>, and incrementing/decrementing <code>SessionManager</code> counters so severity changes or dropped spans reflect their true error status. Ensures exporter flows (via <code>SpanUploader</code>, <code>SessionManager</code>, and span-data tests) keep snapshot error counts consistent with beforeSend modifications described in the ticket.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/172?tool=ast&topic=Instrumentation+updates>Instrumentation updates</a>
        </td><td>Hardens instrumentation utilities and tests by abstracting the uploader contract, tightening <code>coerceToInt</code>, refining network-capture helpers, and expanding coverage around payload selection and uploader invocation.<details><summary>Modified files (6)</summary><ul><li>Coralogix/Sources/Exporter/CoralogixExporter.swift</li>
<li>Coralogix/Sources/Exporter/SpanUploader.swift</li>
<li>Coralogix/Sources/Instrumentation/NetworkInstrumentation.swift</li>
<li>Coralogix/Sources/Utils/NetworkCaptureRule.swift</li>
<li>Tests/CoralogixRumTests/AsyncAwaitNetworkInstrumentationTests.swift</li>
<li>Tests/CoralogixRumTests/NetworkCaptureIntegrationTests.swift</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>CX-32889-Unify-beforeS...</td><td>March 16, 2026</td></tr>
<tr><td>aking618</td><td>Allow-clearing-user-co...</td><td>February 19, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/172?tool=ast&topic=Error-count+flow>Error-count flow</a>
        </td><td>Adjusts error-count flow so beforeSend severity changes or drops invoke <code>SessionManager</code> helpers, refresh <code>snapshotContext.errorCount</code>, and keep <code>CxSpan</code> severity fields and embeddings consistent with the SDK-built values.<details><summary>Modified files (5)</summary><ul><li>Coralogix/Sources/Model/CxSpan.swift</li>
<li>Coralogix/Sources/Utils/SessionManager.swift</li>
<li>Tests/CoralogixRumTests/CoralogixExporterTests.swift</li>
<li>Tests/CoralogixRumTests/CxRumBuilderTests.swift</li>
<li>Tests/CoralogixRumTests/SessionManagerTests.swift</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>CX-32889-Unify-beforeS...</td><td>March 16, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/coralogix/cx-ios-sdk/172?tool=ast>(Baz)</a>.