### PR TITLE
Span Hashable, SDK 2.3.1, publish-pods & Jira MCP tooling

### DIFF
--- a/.github/COCOAPODS_TRUNK_SETUP.md
+++ b/.github/COCOAPODS_TRUNK_SETUP.md
@@ -1,0 +1,17 @@
+# CocoaPods Trunk token (GitHub Actions)
+
+The `publish-pods` workflow needs a valid **CocoaPods Trunk** token in the repository secret `COCOAPODS_TRUNK_TOKEN`.
+
+## Add the secret
+
+1. In GitHub: **Settings → Secrets and variables → Actions → New repository secret**
+2. Name: `COCOAPODS_TRUNK_TOKEN`
+3. Value: the token from your machine’s `~/.netrc` after registering with Trunk (see below).
+
+## Register and obtain a token
+
+1. Run locally: `pod trunk register YOUR_EMAIL "Your Name"`
+2. Confirm the link in the email from CocoaPods.
+3. After registration, your `~/.netrc` will contain the token used for `pod trunk push`.
+
+If the token is missing or invalid, the workflow will fail at the “Authenticate with CocoaPods Trunk” step—update the secret with a fresh token from `~/.netrc` after a successful `pod trunk register`.

--- a/.github/JIRA_MCP_SETUP.md
+++ b/.github/JIRA_MCP_SETUP.md
@@ -1,0 +1,15 @@
+# Jira MCP (Cursor)
+
+If the Jira MCP shows **“The MCP server errored”**, check:
+
+1. **Use the npm server** — `~/.cursor/mcp.json` should run `mcp-jira-cloud`, not a missing local `package/build`.
+2. **Environment variable names** — `mcp-jira-cloud` expects:
+   - `JIRA_BASE_URL` — e.g. `https://YOURSITE.atlassian.net`
+   - `JIRA_EMAIL` — your Atlassian account email
+   - `JIRA_API_TOKEN` — from [Atlassian API tokens](https://id.atlassian.com/manage-profile/security/api-tokens)
+
+Wrong names (`JIRA_URL`, `JIRA_API_MAIL`, `JIRA_API_KEY`) will fail authentication.
+
+3. **Restart Cursor** after changing `mcp.json`.
+
+Optional: point MCP at `scripts/run-jira-mcp.sh` (runs `npx -y mcp-jira-cloud@4`); keep the same `env` block in `mcp.json`.

--- a/.github/workflows/publish-pods.yml
+++ b/.github/workflows/publish-pods.yml
@@ -42,10 +42,19 @@ jobs:
       # Set up CocoaPods Trunk authentication
       - name: Authenticate with CocoaPods Trunk
         run: |
-           set -euo pipefail
-           test -n "${COCOAPODS_TRUNK_TOKEN:-}" || { echo "Missing COCOAPODS_TRUNK_TOKEN"; exit 1; }
-           echo "Validating CocoaPods Trunk token..."
-           pod trunk me || { echo "Invalid or missing COCOAPODS_TRUNK_TOKEN"; exit 1; }
+          set -euo pipefail
+          if [ -z "${COCOAPODS_TRUNK_TOKEN:-}" ]; then
+            echo "::error::COCOAPODS_TRUNK_TOKEN secret is missing. Add it in Settings → Secrets and variables → Actions."
+            echo "See .github/COCOAPODS_TRUNK_SETUP.md for step-by-step setup."
+            exit 1
+          fi
+          echo "Validating CocoaPods Trunk token..."
+          if ! pod trunk me; then
+            echo "::error::CocoaPods Trunk token is invalid or unverified. Update the COCOAPODS_TRUNK_TOKEN secret."
+            echo "Fix: run 'pod trunk register EMAIL Name', verify the email link, then get the token from ~/.netrc and set it in GitHub Secrets."
+            echo "See .github/COCOAPODS_TRUNK_SETUP.md for full instructions."
+            exit 1
+          fi
 
       # Push CoralogixInternal.podspec
       - name: Push CoralogixInternal.podspec
@@ -66,7 +75,7 @@ jobs:
               
               # Wait for CoralogixInternal to become available
               echo "⏳ Waiting for CoralogixInternal to be available in CocoaPods Specs..."
-              timeout=900
+              timeout=1800
               elapsed=0
               until pod search CoralogixInternal | grep -q "CoralogixInternal"; do
                 if [ "$elapsed" -ge "$timeout" ]; then

--- a/Coralogix.podspec
+++ b/Coralogix.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "Coralogix"
-  spec.version      = "2.3.0"
+  spec.version      = "2.3.1"
   spec.summary      = "Coralogix OpenTelemetry pod for iOS."
 
   spec.description  = <<-DESC
@@ -29,7 +29,7 @@ Pod::Spec.new do |spec|
 
   spec.static_framework = true
   spec.dependency 'PLCrashReporter', '~> 1.12'
-  spec.dependency 'CoralogixInternal', '2.3.0'
+  spec.dependency 'CoralogixInternal', '2.3.1'
 
   spec.test_spec 'Tests' do |test|
     test.source_files = 'Tests/CoralogixRumTests/**/*.swift'

--- a/Coralogix/Sources/Otel/OpenTelemetryApi/Trace/Span.swift
+++ b/Coralogix/Sources/Otel/OpenTelemetryApi/Trace/Span.swift
@@ -8,7 +8,7 @@ import Foundation
 /// An interface that represents a span. It has an associated SpanContext.
 /// Spans are created by the SpanBuilder.startSpan method.
 /// Span must be ended by calling end().
-public protocol Span: AnyObject, CustomStringConvertible, Equatable {
+public protocol Span: AnyObject, CustomStringConvertible, Hashable {
     /// Type of span.
     /// Can be used to specify additional relationships between spans in addition to a parent/child relationship.
     var kind: SpanKind { get }

--- a/CoralogixInternal.podspec
+++ b/CoralogixInternal.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "CoralogixInternal"
-  spec.version      = "2.3.0"
+  spec.version      = "2.3.1"
   spec.summary      = "Coralogix Internal Package. This module is not for public use."
 
   spec.description  = <<-DESC

--- a/CoralogixInternal/Sources/Utils.swift
+++ b/CoralogixInternal/Sources/Utils.swift
@@ -16,7 +16,7 @@ public enum ImageFormat {
 }
 
 public enum Global: String {
-    case sdk = "2.3.0"
+    case sdk = "2.3.1"
     case swiftVersion = "5.9"
     case coralogixPath = "/browser/v1beta/logs"
     case sessionReplayPath = "/browser/alpha/sessionrecording"

--- a/SessionReplay.podspec
+++ b/SessionReplay.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "SessionReplay"
-  spec.version      = "2.3.0"
+  spec.version      = "2.3.1"
   spec.summary      = "Coralogix Session-Replay pod for iOS."
 
   spec.description  = <<-DESC
@@ -23,7 +23,7 @@ Pod::Spec.new do |spec|
   spec.static_framework = true
 
   spec.source_files  = 'SessionReplay/Sources/**/*.swift'
-  spec.dependency 'CoralogixInternal', '2.3.0'
+  spec.dependency 'CoralogixInternal', '2.3.1'
   
     spec.test_spec 'Tests' do |test|
         test.source_files = 'Tests/SessionReplayTests/**/*.swift'

--- a/scripts/run-jira-mcp.sh
+++ b/scripts/run-jira-mcp.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
-# Run patched Jira MCP (uses /rest/api/3/search/jql)
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-cd "$SCRIPT_DIR/../package" && exec node build/index.js
+# Runs the official CocoaPods-style Jira MCP (npm: mcp-jira-cloud).
+# Configure Cursor ~/.cursor/mcp.json with command "npx", args ["-y","mcp-jira-cloud@4"],
+# and env: JIRA_BASE_URL, JIRA_EMAIL, JIRA_API_TOKEN (see Atlassian API tokens).
+# This script is optional; you can point MCP directly at npx as above.
+exec npx -y mcp-jira-cloud@4 "$@"


### PR DESCRIPTION
# User description
## Summary
- **`Span`**: refine protocol from `Equatable` to `Hashable` (default `hash(into:)` / `==` in `Span` extension unchanged—still keyed by `context.spanId`).
- **Release**: bump CocoaPods / `Global.sdk` to **2.3.1**.
- **CI**: `publish-pods` — clearer `::error::` messages when Trunk token is missing/invalid; wait for `CoralogixInternal` in Specs **900s → 1800s**.
- **Tooling/docs**: Jira MCP run script uses `npx mcp-jira-cloud@4`; add `.github/JIRA_MCP_SETUP.md` and **`.github/COCOAPODS_TRUNK_SETUP.md`** (referenced by the workflow).

## Pre-merge code review (scoped to this branch)

### `Coralogix/Sources/Otel/OpenTelemetryApi/Trace/Span.swift`
- **Suggestion**: `Hashable`/`==` use `context.spanId` only (same as prior `Equatable`). That matches OTel-style identity for a single trace; collisions across traces are astronomically rare. No change required unless product wants trace-aware identity.

### `.github/workflows/publish-pods.yml`
- **Suggestion**: Longer timeout helps slow CDN propagation; still worth monitoring if 30m is ever insufficient.

### `scripts/run-jira-mcp.sh`
- **Nit**: First run may download `mcp-jira-cloud` via `npx` (network). Expected for optional dev tooling.

### Podspecs / `CoralogixInternal/Sources/Utils.swift`
- **Nit**: Version bumps are mechanical; ensure release notes/changelog match 2.3.1 elsewhere if you maintain them.

### Cleanup
- Removed accidental **`.claude/settings.local.json`** commit from this branch before opening the PR.

---
**New code looks good** after adding the missing `COCOAPODS_TRUNK_SETUP.md` so workflow error text points at a real file.

Made with [Cursor](https://cursor.com)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Strengthen the <code>Span</code> protocol by conforming it to <code>Hashable</code>, keeping <code>context.spanId</code> as the identity key and aligning with SDK expectations. Update the SDK/podspec versions to 2.3.1 and clarify release tooling with new CocoaPods/Jira MCP setup docs plus hardened <code>publish-pods</code> workflow logic and <code>run-jira-mcp</code> script.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/174?tool=ast&topic=Release+tooling>Release tooling</a>
        </td><td>Update the SDK and podspec versions to 2.3.1, extend <code>publish-pods</code> with clearer CocoaPods Trunk validation and longer Specs wait, and document the CocoaPods token plus Jira MCP setup while switching <code>run-jira-mcp.sh</code> to <code>npx mcp-jira-cloud@4</code>.<details><summary>Modified files (8)</summary><ul><li>.github/COCOAPODS_TRUNK_SETUP.md</li>
<li>.github/JIRA_MCP_SETUP.md</li>
<li>.github/workflows/publish-pods.yml</li>
<li>Coralogix.podspec</li>
<li>CoralogixInternal.podspec</li>
<li>CoralogixInternal/Sources/Utils.swift</li>
<li>SessionReplay.podspec</li>
<li>scripts/run-jira-mcp.sh</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>fix-update-podspec-scr...</td><td>January 05, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/174?tool=ast&topic=Span+identity>Span identity</a>
        </td><td>Conform <code>Span</code> to <code>Hashable</code> so its identity remains driven by <code>context.spanId</code> while keeping the existing equality behaviour.<details><summary>Modified files (1)</summary><ul><li>Coralogix/Sources/Otel/OpenTelemetryApi/Trace/Span.swift</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>Roll-Back-open-telemet...</td><td>April 03, 2025</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/coralogix/cx-ios-sdk/174?tool=ast>(Baz)</a>.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 2.3.1 across Coralogix and SessionReplay SDKs

* **Documentation**
  * Added setup guides for CocoaPods Trunk and Jira MCP integration troubleshooting

* **Bug Fixes**
  * Enhanced error messaging and validation in publish workflow
  * Increased deployment timeout for improved reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->