### PR TITLE
Refactor/span equatable record events hashable

### DIFF
--- a/Coralogix.podspec
+++ b/Coralogix.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "Coralogix"
-  spec.version      = "2.3.1"
+  spec.version      = "2.3.2"
   spec.summary      = "Coralogix OpenTelemetry pod for iOS."
 
   spec.description  = <<-DESC
@@ -29,7 +29,7 @@ Pod::Spec.new do |spec|
 
   spec.static_framework = true
   spec.dependency 'PLCrashReporter', '~> 1.12'
-  spec.dependency 'CoralogixInternal', '2.3.1'
+  spec.dependency 'CoralogixInternal', '2.3.2'
 
   spec.test_spec 'Tests' do |test|
     test.source_files = 'Tests/CoralogixRumTests/**/*.swift'

--- a/Coralogix/Sources/Otel/OpenTelemetryApi/Trace/Span.swift
+++ b/Coralogix/Sources/Otel/OpenTelemetryApi/Trace/Span.swift
@@ -8,7 +8,7 @@ import Foundation
 /// An interface that represents a span. It has an associated SpanContext.
 /// Spans are created by the SpanBuilder.startSpan method.
 /// Span must be ended by calling end().
-public protocol Span: AnyObject, CustomStringConvertible, Hashable {
+public protocol Span: AnyObject, CustomStringConvertible, Equatable {
     /// Type of span.
     /// Can be used to specify additional relationships between spans in addition to a parent/child relationship.
     var kind: SpanKind { get }
@@ -70,10 +70,6 @@ public protocol Span: AnyObject, CustomStringConvertible, Hashable {
 }
 
 public extension Span {
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(context.spanId)
-    }
-
     static func == (lhs: Self, rhs: Self) -> Bool {
         return lhs.context.spanId == rhs.context.spanId
     }

--- a/Coralogix/Sources/Otel/OpenTelemetrySdk/Trace/RecordEventsReadableSpan.swift
+++ b/Coralogix/Sources/Otel/OpenTelemetrySdk/Trace/RecordEventsReadableSpan.swift
@@ -8,11 +8,11 @@ import Foundation
 /// Implementation for the Span class that records trace events.
 public class RecordEventsReadableSpan: ReadableSpan, Hashable {
     public func hash(into hasher: inout Hasher) {
-        hasher.combine(ObjectIdentifier(self))
+        hasher.combine(context.spanId)
     }
 
     public static func == (lhs: RecordEventsReadableSpan, rhs: RecordEventsReadableSpan) -> Bool {
-        return lhs === rhs
+        return lhs.context.spanId == rhs.context.spanId
     }
 
     public var isRecording = true

--- a/Coralogix/Sources/Otel/OpenTelemetrySdk/Trace/RecordEventsReadableSpan.swift
+++ b/Coralogix/Sources/Otel/OpenTelemetrySdk/Trace/RecordEventsReadableSpan.swift
@@ -6,7 +6,15 @@
 import Foundation
 
 /// Implementation for the Span class that records trace events.
-public class RecordEventsReadableSpan: ReadableSpan {
+public class RecordEventsReadableSpan: ReadableSpan, Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(ObjectIdentifier(self))
+    }
+
+    public static func == (lhs: RecordEventsReadableSpan, rhs: RecordEventsReadableSpan) -> Bool {
+        return lhs === rhs
+    }
+
     public var isRecording = true
 
     fileprivate let internalStatusQueue = DispatchQueue(label: "org.opentelemetry.RecordEventsReadableSpan.internalStatusQueue", attributes: .concurrent)

--- a/CoralogixInternal.podspec
+++ b/CoralogixInternal.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "CoralogixInternal"
-  spec.version      = "2.3.1"
+  spec.version      = "2.3.2"
   spec.summary      = "Coralogix Internal Package. This module is not for public use."
 
   spec.description  = <<-DESC

--- a/CoralogixInternal/Sources/Utils.swift
+++ b/CoralogixInternal/Sources/Utils.swift
@@ -16,7 +16,7 @@ public enum ImageFormat {
 }
 
 public enum Global: String {
-    case sdk = "2.3.1"
+    case sdk = "2.3.2"
     case swiftVersion = "5.9"
     case coralogixPath = "/browser/v1beta/logs"
     case sessionReplayPath = "/browser/alpha/sessionrecording"

--- a/SessionReplay.podspec
+++ b/SessionReplay.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "SessionReplay"
-  spec.version      = "2.3.1"
+  spec.version      = "2.3.2"
   spec.summary      = "Coralogix Session-Replay pod for iOS."
 
   spec.description  = <<-DESC
@@ -23,7 +23,7 @@ Pod::Spec.new do |spec|
   spec.static_framework = true
 
   spec.source_files  = 'SessionReplay/Sources/**/*.swift'
-  spec.dependency 'CoralogixInternal', '2.3.1'
+  spec.dependency 'CoralogixInternal', '2.3.2'
   
     spec.test_spec 'Tests' do |test|
         test.source_files = 'Tests/SessionReplayTests/**/*.swift'


### PR DESCRIPTION
# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Align package metadata by bumping the Coralogix, SessionReplay, and CoralogixInternal pods to 2.3.2 while keeping the <code>Global.sdk</code> constant in sync, ensuring the release artifacts all report the same version. Enable <code>Span</code> equality by <code>spanId</code> and make <code>RecordEventsReadableSpan</code> <code>Hashable</code> so span instances retain their identity in hashed collections.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/175?tool=ast&topic=Version+Sync>Version Sync</a>
        </td><td>Align <code>Coralogix</code>, <code>SessionReplay</code>, and <code>CoralogixInternal</code> podspec versions with the <code>Global.sdk</code> constant so all packages and metadata report 2.3.2 consistently.<details><summary>Modified files (4)</summary><ul><li>Coralogix.podspec</li>
<li>CoralogixInternal.podspec</li>
<li>CoralogixInternal/Sources/Utils.swift</li>
<li>SessionReplay.podspec</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>Span-Hashable-SDK-2.3....</td><td>March 22, 2026</td></tr>
<tr><td>NatanCoralogix</td><td>bump-crash-reporter-106</td><td>September 01, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/175?tool=ast&topic=Span+Equality>Span Equality</a>
        </td><td>Update <code>Span</code> to be <code>Equatable</code> by <code>spanId</code> and make <code>RecordEventsReadableSpan</code> <code>Hashable</code> so readable spans work in hashed collections without changing their identity logic.<details><summary>Modified files (2)</summary><ul><li>Coralogix/Sources/Otel/OpenTelemetryApi/Trace/Span.swift</li>
<li>Coralogix/Sources/Otel/OpenTelemetrySdk/Trace/RecordEventsReadableSpan.swift</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>Span-Hashable-SDK-2.3....</td><td>March 22, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/coralogix/cx-ios-sdk/175?tool=ast>(Baz)</a>.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 2.3.2 across packages (Coralogix, CoralogixInternal, SessionReplay) and bumped SDK identifier.
* **Bug Fixes / Stability**
  * Improved span identity and equality behavior to ensure more consistent tracing handling across the SDK.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->