### PR TITLE
fix: forward request/response headers and payload in Flutter hybrid network path

### DIFF
--- a/Coralogix.podspec
+++ b/Coralogix.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "Coralogix"
-  spec.version      = "2.3.2"
+  spec.version      = "2.3.3"
   spec.summary      = "Coralogix OpenTelemetry pod for iOS."
 
   spec.description  = <<-DESC
@@ -29,7 +29,7 @@ Pod::Spec.new do |spec|
 
   spec.static_framework = true
   spec.dependency 'PLCrashReporter', '~> 1.12'
-  spec.dependency 'CoralogixInternal', '2.3.2'
+  spec.dependency 'CoralogixInternal', '2.3.3'
 
   spec.test_spec 'Tests' do |test|
     test.source_files = 'Tests/CoralogixRumTests/**/*.swift'

--- a/Coralogix/Sources/Instrumentation/NetworkInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/NetworkInstrumentation.swift
@@ -228,10 +228,20 @@ extension CoralogixRum {
         span.setAttribute(key: Keys.customSpanId.rawValue, value: dictionary[Keys.customSpanId.rawValue] as? String ?? "")
         span.setAttribute(key: Keys.customTraceId.rawValue, value: dictionary[Keys.customTraceId.rawValue] as? String ?? "")
 
-        if let reqHeaders = dictionary[Keys.requestHeaders.rawValue] as? String, !reqHeaders.isEmpty {
+        if let reqHeaders = dictionary[Keys.requestHeaders.rawValue] as? [String: Any] {
+            let json = Helper.convertDictionayToJsonString(dict: reqHeaders)
+            if !json.isEmpty {
+                span.setAttribute(key: Keys.requestHeaders.rawValue, value: AttributeValue.string(json))
+            }
+        } else if let reqHeaders = dictionary[Keys.requestHeaders.rawValue] as? String, !reqHeaders.isEmpty {
             span.setAttribute(key: Keys.requestHeaders.rawValue, value: AttributeValue.string(reqHeaders))
         }
-        if let resHeaders = dictionary[Keys.responseHeaders.rawValue] as? String, !resHeaders.isEmpty {
+        if let resHeaders = dictionary[Keys.responseHeaders.rawValue] as? [String: Any] {
+            let json = Helper.convertDictionayToJsonString(dict: resHeaders)
+            if !json.isEmpty {
+                span.setAttribute(key: Keys.responseHeaders.rawValue, value: AttributeValue.string(json))
+            }
+        } else if let resHeaders = dictionary[Keys.responseHeaders.rawValue] as? String, !resHeaders.isEmpty {
             span.setAttribute(key: Keys.responseHeaders.rawValue, value: AttributeValue.string(resHeaders))
         }
         if let reqPayload = dictionary[Keys.requestPayload.rawValue] as? String, !reqPayload.isEmpty {

--- a/Coralogix/Sources/Instrumentation/NetworkInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/NetworkInstrumentation.swift
@@ -227,6 +227,20 @@ extension CoralogixRum {
         span.setAttribute(key: SemanticAttributes.httpScheme.rawValue, value: dictionary[Keys.schema.rawValue] as? String ?? "")
         span.setAttribute(key: Keys.customSpanId.rawValue, value: dictionary[Keys.customSpanId.rawValue] as? String ?? "")
         span.setAttribute(key: Keys.customTraceId.rawValue, value: dictionary[Keys.customTraceId.rawValue] as? String ?? "")
+
+        if let reqHeaders = dictionary[Keys.requestHeaders.rawValue] as? String, !reqHeaders.isEmpty {
+            span.setAttribute(key: Keys.requestHeaders.rawValue, value: AttributeValue.string(reqHeaders))
+        }
+        if let resHeaders = dictionary[Keys.responseHeaders.rawValue] as? String, !resHeaders.isEmpty {
+            span.setAttribute(key: Keys.responseHeaders.rawValue, value: AttributeValue.string(resHeaders))
+        }
+        if let reqPayload = dictionary[Keys.requestPayload.rawValue] as? String, !reqPayload.isEmpty {
+            span.setAttribute(key: Keys.requestPayload.rawValue, value: AttributeValue.string(reqPayload))
+        }
+        if let resPayload = dictionary[Keys.responsePayload.rawValue] as? String, !resPayload.isEmpty {
+            span.setAttribute(key: Keys.responsePayload.rawValue, value: AttributeValue.string(resPayload))
+        }
+
         span.end()
     }
 

--- a/CoralogixInternal.podspec
+++ b/CoralogixInternal.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "CoralogixInternal"
-  spec.version      = "2.3.2"
+  spec.version      = "2.3.3"
   spec.summary      = "Coralogix Internal Package. This module is not for public use."
 
   spec.description  = <<-DESC

--- a/CoralogixInternal/Sources/Utils.swift
+++ b/CoralogixInternal/Sources/Utils.swift
@@ -16,7 +16,7 @@ public enum ImageFormat {
 }
 
 public enum Global: String {
-    case sdk = "2.3.2"
+    case sdk = "2.3.3"
     case swiftVersion = "5.9"
     case coralogixPath = "/browser/v1beta/logs"
     case sessionReplayPath = "/browser/alpha/sessionrecording"

--- a/SessionReplay.podspec
+++ b/SessionReplay.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "SessionReplay"
-  spec.version      = "2.3.2"
+  spec.version      = "2.3.3"
   spec.summary      = "Coralogix Session-Replay pod for iOS."
 
   spec.description  = <<-DESC
@@ -23,7 +23,7 @@ Pod::Spec.new do |spec|
   spec.static_framework = true
 
   spec.source_files  = 'SessionReplay/Sources/**/*.swift'
-  spec.dependency 'CoralogixInternal', '2.3.2'
+  spec.dependency 'CoralogixInternal', '2.3.3'
   
     spec.test_spec 'Tests' do |test|
         test.source_files = 'Tests/SessionReplayTests/**/*.swift'


### PR DESCRIPTION
# User description
## Summary
- `reportHybridNetworkRequest` (the path used by **all** Flutter network requests) was silently dropping the four network capture properties received from the Flutter SDK: `request_headers`, `response_headers`, `request_payload`, `response_payload`
- React Native is unaffected because its requests go through native `NSURLSession` → `receivedResponse`, which already handles these properties
- Fix reads the four keys from the dictionary and sets them as span attributes when non-empty, matching the native path behaviour

## Test plan
- [ ] Configure `networkCaptureConfig` rules in the Flutter SDK with `reqHeaders`, `resHeaders`, `collectReqPayload`, `collectResPayload`
- [ ] Make a network request matching the rule URL pattern
- [ ] Verify `request_headers`, `response_headers`, `request_payload`, `response_payload` appear in the RUM span

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add span attribute handling in <code>NetworkInstrumentation</code> to capture Flutter-provided header and payload metadata and align the hybrid path with native behavior. Bump <code>Coralogix</code>, <code>CoralogixInternal</code>, and <code>SessionReplay</code> pod versions to 2.3.3 so the updated helpers ship together.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/176?tool=ast&topic=Version+bump>Version bump</a>
        </td><td>Sync podspec versions for <code>Coralogix</code>, <code>CoralogixInternal</code>, <code>SessionReplay</code>, and the <code>Global</code> SDK constant to 2.3.3 so the updated instrumentation ships with the release.<details><summary>Modified files (4)</summary><ul><li>Coralogix.podspec</li>
<li>CoralogixInternal.podspec</li>
<li>CoralogixInternal/Sources/Utils.swift</li>
<li>SessionReplay.podspec</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>Refactor-span-equatabl...</td><td>March 22, 2026</td></tr>
<tr><td>NatanCoralogix</td><td>bump-crash-reporter-106</td><td>September 01, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/176?tool=ast&topic=Network+metadata>Network metadata</a>
        </td><td>Capture Flutter request/response headers and payloads by reading the provided keys and setting span attributes via <code>NetworkInstrumentation</code>.<details><summary>Modified files (1)</summary><ul><li>Coralogix/Sources/Instrumentation/NetworkInstrumentation.swift</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>fix-React-Native-respo...</td><td>March 18, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/coralogix/cx-ios-sdk/176?tool=ast>(Baz)</a>.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced network instrumentation to capture additional context: request headers, response headers, request payload, and response payload for improved debugging and monitoring.

* **Chores**
  * Bumped SDK and internal component versions to 2.3.3 across releases and podspecs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->