### PR TITLE
feat: Flutter obfuscated errors + error metadata (arch, build_id, stack_trace_type)

### DIFF
--- a/Coralogix.podspec
+++ b/Coralogix.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "Coralogix"
-  spec.version      = "2.3.3"
+  spec.version      = "2.4.0"
   spec.summary      = "Coralogix OpenTelemetry pod for iOS."
 
   spec.description  = <<-DESC
@@ -29,7 +29,7 @@ Pod::Spec.new do |spec|
 
   spec.static_framework = true
   spec.dependency 'PLCrashReporter', '~> 1.12'
-  spec.dependency 'CoralogixInternal', '2.3.3'
+  spec.dependency 'CoralogixInternal', '2.4.0'
 
   spec.test_spec 'Tests' do |test|
     test.source_files = 'Tests/CoralogixRumTests/**/*.swift'

--- a/Coralogix/Docs/CORALOGIX_RUM.md
+++ b/Coralogix/Docs/CORALOGIX_RUM.md
@@ -206,6 +206,57 @@ Reports an error to Coralogix using a custom message and optional data.
 * message: A string describing the error.
 * data: An optional dictionary containing additional data related to the error.
 
+### reportError (hybrid stack trace)
+```swift
+public func reportError(message: String,
+                        stackTrace: [[String: Any]],
+                        errorType: String?,
+                        isCrash: Bool = false,
+                        arch: String? = nil,
+                        buildId: String? = nil,
+                        stackTraceType: String? = nil)
+```
+Reports an error from a hybrid framework (React Native, Flutter symbolicated) using a pre-parsed stack trace. Each frame is a dictionary with keys such as `functionName`, `fileName`, `lineNumber`, and `columnNumber`.
+
+#### Parameters
+* message: A string describing the error.
+* stackTrace: An array of frame dictionaries.
+* errorType: An optional string identifying the error type (e.g. `"FlutterError"`).
+* isCrash: Whether the error was fatal. Defaults to `false`.
+* arch: Optional CPU architecture string (e.g. `"arm64"`).
+* buildId: Optional build identifier used for symbolication.
+* stackTraceType: Optional stack trace type label (e.g. `"symbolicated"`).
+
+### reportError (obfuscated Flutter stack trace)
+```swift
+public func reportError(message: String,
+                        obfuscatedStackTrace: [String],
+                        arch: String? = nil,
+                        buildId: String? = nil,
+                        stackTraceType: String? = Keys.obfuscated.rawValue)
+```
+Reports a Dart obfuscated error from Flutter. Use this when the stack trace contains raw virtual addresses produced by a `--obfuscate --split-debug-info` build. The server uses `arch` and `buildId` together with the app's debug symbols to symbolicate the addresses.
+
+#### Parameters
+* message: A string describing the error.
+* obfuscatedStackTrace: An array of virtual address strings (e.g. `["0x00000000003da15f", ...]`). May be empty — the error is still reported with its message and metadata.
+* arch: Optional CPU architecture string (e.g. `"arm64"`).
+* buildId: The Dart snapshot build ID required for symbolication.
+* stackTraceType: The stack trace type label. Defaults to `"obfuscated"`.
+
+#### Example
+```swift
+coralogixRum.reportError(
+    message: "StateError: bad state",
+    obfuscatedStackTrace: [
+        "0x00000000003da15f",
+        "0x000000000022d923"
+    ],
+    arch: "arm64",
+    buildId: "e4f372b4e5cb2ba87653648d9c509cb1"
+)
+```
+
 ### log
 ```swift
 public func log(severity: CoralogixLogSeverity, message: String, data: [String: Any]?)

--- a/Coralogix/Docs/CORALOGIX_RUM.md
+++ b/Coralogix/Docs/CORALOGIX_RUM.md
@@ -241,7 +241,7 @@ Reports a Dart obfuscated error from Flutter. Use this when the stack trace cont
 * message: A string describing the error.
 * obfuscatedStackTrace: An array of virtual address strings (e.g. `["0x00000000003da15f", ...]`). May be empty — the error is still reported with its message and metadata.
 * arch: Optional CPU architecture string (e.g. `"arm64"`).
-* buildId: The Dart snapshot build ID required for symbolication.
+* buildId: Optional build identifier used to symbolicate the addresses on the server.
 * stackTraceType: The stack trace type label. Defaults to `"obfuscated"`.
 
 #### Example

--- a/Coralogix/Sources/CoralogixRum.swift
+++ b/Coralogix/Sources/CoralogixRum.swift
@@ -253,7 +253,7 @@ public class CoralogixRum {
                             obfuscatedStackTrace: [String],
                             arch: String? = nil,
                             buildId: String? = nil,
-                            stackTraceType: String? = nil) {
+                            stackTraceType: String? = Keys.obfuscated.rawValue) {
         guard CoralogixRum.isInitialized else { return }
         self.reportErrorWith(message: message,
                              obfuscatedStackTrace: obfuscatedStackTrace,

--- a/Coralogix/Sources/CoralogixRum.swift
+++ b/Coralogix/Sources/CoralogixRum.swift
@@ -224,12 +224,42 @@ public class CoralogixRum {
     public func reportError(message: String,
                             stackTrace: [[String: Any]],
                             errorType: String?,
-                            isCrash: Bool = false) {
+                            isCrash: Bool = false,
+                            arch: String? = nil,
+                            buildId: String? = nil,
+                            stackTraceType: String? = nil) {
         guard CoralogixRum.isInitialized else { return }
         self.reportErrorWith(message: message,
                              stackTrace: stackTrace,
                              errorType: errorType,
-                             isCrash: isCrash)
+                             isCrash: isCrash,
+                             arch: arch,
+                             buildId: buildId,
+                             stackTraceType: stackTraceType)
+    }
+
+    /// Reports a Dart obfuscated error from Flutter.
+    ///
+    /// Use when the Dart stack trace is not symbolicated — pass raw virtual addresses
+    /// extracted from the obfuscated crash output.
+    ///
+    /// - Parameters:
+    ///   - message: The error message.
+    ///   - obfuscatedStackTrace: Array of virtual address strings (e.g. `["0x00000000003da15f", ...]`).
+    ///   - arch: The CPU architecture (e.g. `"arm64"`).
+    ///   - buildId: The Dart snapshot build ID used for symbolication.
+    ///   - stackTraceType: The stack trace type (e.g. `"obfuscated"`).
+    public func reportError(message: String,
+                            obfuscatedStackTrace: [String],
+                            arch: String? = nil,
+                            buildId: String? = nil,
+                            stackTraceType: String? = nil) {
+        guard CoralogixRum.isInitialized else { return }
+        self.reportErrorWith(message: message,
+                             obfuscatedStackTrace: obfuscatedStackTrace,
+                             arch: arch,
+                             buildId: buildId,
+                             stackTraceType: stackTraceType)
     }
     
     public func reportMobileVitalsMeasurement(type: String, metrics: [HybridMetric]) {

--- a/Coralogix/Sources/Instrumentation/ErrorInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/ErrorInstrumentation.swift
@@ -71,7 +71,6 @@ extension CoralogixRum {
                          buildId: String?,
                          stackTraceType: String?) {
         guard isErrorsEnabled else { return }
-        guard !obfuscatedStackTrace.isEmpty else { return }
         let frames: [[String: Any]] = obfuscatedStackTrace.map { [Keys.virt.rawValue: $0] }
         let stackTraceJson = Helper.convertArrayToJsonString(array: frames)
         reportErrorInternal(message: message,

--- a/Coralogix/Sources/Instrumentation/ErrorInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/ErrorInstrumentation.swift
@@ -55,7 +55,7 @@ extension CoralogixRum {
         self.log(severity: CoralogixLogSeverity.error, message: message, data: data)
     }
     
-    //MARK: - Used By Flutter
+    //MARK: - Used By Flutter (symbolicated)
     func reportErrorWith(message: String, stackTrace: String?) {
         let stackTraceJson = stackTrace.flatMap {
             let stackTraceArray = Helper.parseStackTrace($0)
@@ -63,31 +63,57 @@ extension CoralogixRum {
         }
         reportErrorInternal(message: message, stackTraceJson: stackTraceJson)
     }
-    
+
+    //MARK: - Used By Flutter (obfuscated)
+    func reportErrorWith(message: String,
+                         obfuscatedStackTrace: [String],
+                         arch: String?,
+                         buildId: String?,
+                         stackTraceType: String?) {
+        let frames: [[String: Any]] = obfuscatedStackTrace.map { [Keys.virt.rawValue: $0] }
+        let stackTraceJson = Helper.convertArrayToJsonString(array: frames)
+        reportErrorInternal(message: message,
+                            stackTraceJson: stackTraceJson,
+                            arch: arch,
+                            buildId: buildId,
+                            stackTraceType: stackTraceType)
+    }
+
     //MARK: - Used By React Native
     func reportErrorWith(message: String,
                          stackTrace: [[String: Any]],
                          errorType: String?,
-                         isCrash: Bool = false) {
+                         isCrash: Bool = false,
+                         arch: String? = nil,
+                         buildId: String? = nil,
+                         stackTraceType: String? = nil) {
         let stackTraceJson = Helper.convertArrayToJsonString(array: stackTrace)
         reportErrorInternal(message: message,
                             stackTraceJson: stackTraceJson,
                             errorType: errorType,
-                            isCrash: isCrash)
+                            isCrash: isCrash,
+                            arch: arch,
+                            buildId: buildId,
+                            stackTraceType: stackTraceType)
     }
-    
+
     private func reportErrorInternal(message: String,
                                      stackTraceJson: String?,
                                      errorType: String? = nil,
-                                     isCrash: Bool = false) {
+                                     isCrash: Bool = false,
+                                     arch: String? = nil,
+                                     buildId: String? = nil,
+                                     stackTraceType: String? = nil) {
         guard isErrorsEnabled else { return }
         self.writeError(
             domain: "",
-            code: 0,
             message: message,
             stackTraceJson: stackTraceJson,
             errorType: errorType,
-            isCrash: isCrash
+            isCrash: isCrash,
+            arch: arch,
+            buildId: buildId,
+            stackTraceType: stackTraceType
         )
     }
 
@@ -137,14 +163,17 @@ extension CoralogixRum {
         return sessionReplay.captureEvent(properties: location.toProperties())
     }
     
-    private func writeError(domain: String, code: Int, message: String,
+    private func writeError(domain: String, code: Int? = nil, message: String,
                             userInfo: [String: Any]? = nil,
                             stackTraceJson: String? = nil,
                             errorType: String? = nil,
-                            isCrash: Bool = false) {
+                            isCrash: Bool = false,
+                            arch: String? = nil,
+                            buildId: String? = nil,
+                            stackTraceType: String? = nil) {
         var span = makeSpan(event: .error, source: .console, severity: .error)
         span.setAttribute(key: Keys.domain.rawValue, value: domain)
-        span.setAttribute(key: Keys.code.rawValue, value: code)
+        if let code { span.setAttribute(key: Keys.code.rawValue, value: code) }
         span.setAttribute(key: Keys.errorMessage.rawValue, value: message)
         span.setAttribute(key: Keys.isCrash.rawValue, value: isCrash)
         if let errorType { span.setAttribute(key: Keys.errorType.rawValue, value: errorType) }
@@ -152,6 +181,9 @@ extension CoralogixRum {
         if let userInfo, !userInfo.isEmpty {
             span.setAttribute(key: Keys.userInfo.rawValue, value: Helper.convertDictionayToJsonString(dict: userInfo))
         }
+        if let arch { span.setAttribute(key: Keys.arch.rawValue, value: arch) }
+        if let buildId { span.setAttribute(key: Keys.buildId.rawValue, value: buildId) }
+        if let stackTraceType { span.setAttribute(key: Keys.stackTraceType.rawValue, value: stackTraceType) }
         recordScreenshotForSpan(to: &span)
         span.end()
     }

--- a/Coralogix/Sources/Instrumentation/ErrorInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/ErrorInstrumentation.swift
@@ -55,7 +55,7 @@ extension CoralogixRum {
         self.log(severity: CoralogixLogSeverity.error, message: message, data: data)
     }
     
-    //MARK: - Used By Flutter (symbolicated)
+    // MARK: - Used By Flutter (symbolicated)
     func reportErrorWith(message: String, stackTrace: String?) {
         let stackTraceJson = stackTrace.flatMap {
             let stackTraceArray = Helper.parseStackTrace($0)
@@ -64,7 +64,7 @@ extension CoralogixRum {
         reportErrorInternal(message: message, stackTraceJson: stackTraceJson)
     }
 
-    //MARK: - Used By Flutter (obfuscated)
+    // MARK: - Used By Flutter (obfuscated)
     func reportErrorWith(message: String,
                          obfuscatedStackTrace: [String],
                          arch: String?,
@@ -81,7 +81,7 @@ extension CoralogixRum {
                             stackTraceType: stackTraceType)
     }
 
-    //MARK: - Used By React Native
+    // MARK: - Used By React Native
     func reportErrorWith(message: String,
                          stackTrace: [[String: Any]],
                          errorType: String?,

--- a/Coralogix/Sources/Instrumentation/ErrorInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/ErrorInstrumentation.swift
@@ -70,6 +70,7 @@ extension CoralogixRum {
                          arch: String?,
                          buildId: String?,
                          stackTraceType: String?) {
+        guard !obfuscatedStackTrace.isEmpty else { return }
         let frames: [[String: Any]] = obfuscatedStackTrace.map { [Keys.virt.rawValue: $0] }
         let stackTraceJson = Helper.convertArrayToJsonString(array: frames)
         reportErrorInternal(message: message,

--- a/Coralogix/Sources/Instrumentation/ErrorInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/ErrorInstrumentation.swift
@@ -183,7 +183,7 @@ extension CoralogixRum {
         if let userInfo, !userInfo.isEmpty {
             span.setAttribute(key: Keys.userInfo.rawValue, value: Helper.convertDictionayToJsonString(dict: userInfo))
         }
-        if let arch { span.setAttribute(key: Keys.arch.rawValue, value: arch) }
+        if let arch, !arch.isEmpty { span.setAttribute(key: Keys.arch.rawValue, value: arch) }
         if let buildId { span.setAttribute(key: Keys.buildId.rawValue, value: buildId) }
         if let stackTraceType { span.setAttribute(key: Keys.stackTraceType.rawValue, value: stackTraceType) }
         recordScreenshotForSpan(to: &span)

--- a/Coralogix/Sources/Instrumentation/ErrorInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/ErrorInstrumentation.swift
@@ -70,6 +70,7 @@ extension CoralogixRum {
                          arch: String?,
                          buildId: String?,
                          stackTraceType: String?) {
+        guard isErrorsEnabled else { return }
         guard !obfuscatedStackTrace.isEmpty else { return }
         let frames: [[String: Any]] = obfuscatedStackTrace.map { [Keys.virt.rawValue: $0] }
         let stackTraceJson = Helper.convertArrayToJsonString(array: frames)

--- a/Coralogix/Sources/Instrumentation/ErrorInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/ErrorInstrumentation.swift
@@ -70,7 +70,6 @@ extension CoralogixRum {
                          arch: String?,
                          buildId: String?,
                          stackTraceType: String?) {
-        guard isErrorsEnabled else { return }
         let frames: [[String: Any]] = obfuscatedStackTrace.map { [Keys.virt.rawValue: $0] }
         let stackTraceJson = Helper.convertArrayToJsonString(array: frames)
         reportErrorInternal(message: message,
@@ -183,8 +182,10 @@ extension CoralogixRum {
             span.setAttribute(key: Keys.userInfo.rawValue, value: Helper.convertDictionayToJsonString(dict: userInfo))
         }
         if let arch, !arch.isEmpty { span.setAttribute(key: Keys.arch.rawValue, value: arch) }
-        if let buildId { span.setAttribute(key: Keys.buildId.rawValue, value: buildId) }
-        if let stackTraceType { span.setAttribute(key: Keys.stackTraceType.rawValue, value: stackTraceType) }
+        if let buildId, !buildId.isEmpty { span.setAttribute(key: Keys.buildId.rawValue, value: buildId) }
+        if let stackTraceType, !stackTraceType.isEmpty { span.setAttribute(key: Keys.stackTraceType.rawValue, value: stackTraceType) }
+        // Note: hybrid error paths (Flutter/RN) intentionally omit the code attribute — there is
+        // no meaningful error code in these contexts. Native paths pass an explicit code when relevant.
         recordScreenshotForSpan(to: &span)
         span.end()
     }

--- a/Coralogix/Sources/Model/Contexts/ErrorContext.swift
+++ b/Coralogix/Sources/Model/Contexts/ErrorContext.swift
@@ -24,7 +24,9 @@ struct ErrorContext {
     let baseAddress: String
     let arch: String
     var isCrash: Bool = false
-    
+    var buildId: String?
+    var stackTraceType: String?
+
     init(otel: SpanDataProtocol) {
         self.domain = otel.getAttribute(forKey: Keys.domain.rawValue) as? String ?? ""
         self.code = otel.getAttribute(forKey: Keys.code.rawValue) as? String ?? ""
@@ -60,6 +62,8 @@ struct ErrorContext {
         }
         self.baseAddress = otel.getAttribute(forKey: Keys.baseAddress.rawValue) as? String ?? ""
         self.arch = otel.getAttribute(forKey: Keys.arch.rawValue) as? String ?? ""
+        self.buildId = otel.getAttribute(forKey: Keys.buildId.rawValue) as? String
+        self.stackTraceType = otel.getAttribute(forKey: Keys.stackTraceType.rawValue) as? String
         self.errorType = otel.getAttribute(forKey: Keys.errorType.rawValue) as? String ?? ""
         if let anr = otel.getAttribute(forKey: Keys.mobileVitalsType.rawValue) as? String {
             self.errorType = anr
@@ -105,11 +109,23 @@ struct ErrorContext {
             if let stackTrace = self.stackTrace {
                 errorContext[Keys.originalStackTrace.rawValue] = stackTrace
             }
-            
+
             if !self.errorType.isEmpty {
                 errorContext[Keys.errorType.rawValue] = errorType
             }
-            
+
+            if !self.arch.isEmpty {
+                errorContext[Keys.arch.rawValue] = self.arch
+            }
+
+            if let buildId = self.buildId {
+                errorContext[Keys.buildId.rawValue] = buildId
+            }
+
+            if let stackTraceType = self.stackTraceType {
+                errorContext[Keys.stackTraceType.rawValue] = stackTraceType
+            }
+
             errorContext[Keys.isCrash.rawValue] = self.isCrash
         }
         return errorContext

--- a/Coralogix/Sources/Model/Contexts/ErrorContext.swift
+++ b/Coralogix/Sources/Model/Contexts/ErrorContext.swift
@@ -24,8 +24,8 @@ struct ErrorContext {
     let baseAddress: String
     let arch: String
     var isCrash: Bool = false
-    var buildId: String?
-    var stackTraceType: String?
+    let buildId: String?
+    let stackTraceType: String?
 
     init(otel: SpanDataProtocol) {
         self.domain = otel.getAttribute(forKey: Keys.domain.rawValue) as? String ?? ""

--- a/CoralogixInternal.podspec
+++ b/CoralogixInternal.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "CoralogixInternal"
-  spec.version      = "2.3.3"
+  spec.version      = "2.4.0"
   spec.summary      = "Coralogix Internal Package. This module is not for public use."
 
   spec.description  = <<-DESC

--- a/CoralogixInternal/Sources/Keys.swift
+++ b/CoralogixInternal/Sources/Keys.swift
@@ -156,6 +156,7 @@ public enum Keys: String {
     case buildId = "build_id"
     case stackTraceType = "stack_trace_type"
     case virt = "virt"
+    case obfuscated = "obfuscated"
     case tvos
     case television
     case mobileVitalsContext = "mobile_vitals_context"

--- a/CoralogixInternal/Sources/Keys.swift
+++ b/CoralogixInternal/Sources/Keys.swift
@@ -155,7 +155,7 @@ public enum Keys: String {
     case isCrash = "is_crash"
     case buildId = "build_id"
     case stackTraceType = "stack_trace_type"
-    case virt
+    case virt = "virt"
     case tvos
     case television
     case mobileVitalsContext = "mobile_vitals_context"

--- a/CoralogixInternal/Sources/Keys.swift
+++ b/CoralogixInternal/Sources/Keys.swift
@@ -153,6 +153,9 @@ public enum Keys: String {
     case click
     case errorMessage = "error_message"
     case isCrash = "is_crash"
+    case buildId = "build_id"
+    case stackTraceType = "stack_trace_type"
+    case virt
     case tvos
     case television
     case mobileVitalsContext = "mobile_vitals_context"

--- a/CoralogixInternal/Sources/Utils.swift
+++ b/CoralogixInternal/Sources/Utils.swift
@@ -16,7 +16,7 @@ public enum ImageFormat {
 }
 
 public enum Global: String {
-    case sdk = "2.3.3"
+    case sdk = "2.4.0"
     case swiftVersion = "5.9"
     case coralogixPath = "/browser/v1beta/logs"
     case sessionReplayPath = "/browser/alpha/sessionrecording"

--- a/Example/DemoAppSwift/ErrorViewController.swift
+++ b/Example/DemoAppSwift/ErrorViewController.swift
@@ -66,6 +66,18 @@ final class ErrorViewController: UITableViewController {
             subtitle: "Application Not Responding",
             systemImageName: "hourglass",
             key: .simulateANR
+        ),
+        .init(
+            title: "Flutter Symbolicated Error",
+            subtitle: "Simulate readable Dart stack trace",
+            systemImageName: "curlybraces",
+            key: .sendFlutterSymbolicatedError
+        ),
+        .init(
+            title: "Flutter Obfuscated Error",
+            subtitle: "Simulate obfuscated Dart stack trace (virt addresses)",
+            systemImageName: "eye.slash",
+            key: .sendFlutterObfuscatedError
         )
     ]
 
@@ -164,6 +176,12 @@ final class ErrorViewController: UITableViewController {
 
         case .simulateANR:
             ErrorSim.simulateANR()
+
+        case .sendFlutterSymbolicatedError:
+            ErrorSim.sendFlutterSymbolicatedError()
+
+        case .sendFlutterObfuscatedError:
+            ErrorSim.sendFlutterObfuscatedError()
 
         default:
             break

--- a/Example/Shared/Keys.swift
+++ b/Example/Shared/Keys.swift
@@ -31,6 +31,8 @@ enum Keys: String {
     case modalPresentation = "Modal Presentation"
     case segmentedCollectionView = "Segmented / Collection"
     case simulateANR = "Simulate ANR"
+    case sendFlutterSymbolicatedError = "Flutter Symbolicated Error"
+    case sendFlutterObfuscatedError = "Flutter Obfuscated Error"
     case succesfullAlamofire = "✅ Succesfull Alamofire Request"
     case failureAlamofire = "❌ Failure Alamofire Request"
     case sessionReplay = "Session Replay"

--- a/Example/Shared/SimulateFolder/ErrorSim.swift
+++ b/Example/Shared/SimulateFolder/ErrorSim.swift
@@ -51,6 +51,41 @@ class ErrorSim {
     static func simulateANR() {
         sleep(10)
     }
+
+    // Simulates a Flutter error with a symbolicated (readable) Dart stack trace.
+    // This is the format produced by a non-obfuscated Flutter/Dart app.
+    static func sendFlutterSymbolicatedError() {
+        let frames: [[String: Any]] = [
+            ["functionName": "throwExceptionInDart", "fileName": "package:coralogix_sdk/main.dart", "lineNumber": 134, "columnNumber": 5],
+            ["functionName": "_MyAppState.build.<anonymous closure>", "fileName": "package:coralogix_sdk/main.dart", "lineNumber": 121, "columnNumber": 32],
+            ["functionName": "_InkResponseState.handleTap", "fileName": "package:flutter/src/material/ink_well.dart", "lineNumber": 1171, "columnNumber": 21],
+            ["functionName": "GestureRecognizer.invokeCallback", "fileName": "package:flutter/src/gestures/recognizer.dart", "lineNumber": 344, "columnNumber": 24],
+            ["functionName": "TapGestureRecognizer.handleTapUp", "fileName": "package:flutter/src/gestures/tap.dart", "lineNumber": 652, "columnNumber": 11]
+        ]
+        CoralogixRumManager.shared.sdk.reportError(
+            message: "state error try catch",
+            stackTrace: frames,
+            errorType: "FlutterError",
+            stackTraceType: "symbolicated"
+        )
+    }
+
+    // Simulates a Flutter error with an obfuscated Dart stack trace.
+    // This is the format produced when the Flutter app is built with --obfuscate --split-debug-info.
+    // Only virtual addresses are available; symbolication requires the app's debug symbols + build_id.
+    static func sendFlutterObfuscatedError() {
+        CoralogixRumManager.shared.sdk.reportError(
+            message: "StateError: state error try catch",
+            obfuscatedStackTrace: [
+                "0x00000000003da15f",
+                "0x000000000022d923",
+                "0x000000000025bf87"
+            ],
+            arch: "arm64",
+            buildId: "e4f372b4e5cb2ba87653648d9c509cb1",
+            stackTraceType: "obfuscated"
+        )
+    }
     
     enum CustomError: Error {
         case invalidInput

--- a/SessionReplay.podspec
+++ b/SessionReplay.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "SessionReplay"
-  spec.version      = "2.3.3"
+  spec.version      = "2.4.0"
   spec.summary      = "Coralogix Session-Replay pod for iOS."
 
   spec.description  = <<-DESC
@@ -23,7 +23,7 @@ Pod::Spec.new do |spec|
   spec.static_framework = true
 
   spec.source_files  = 'SessionReplay/Sources/**/*.swift'
-  spec.dependency 'CoralogixInternal', '2.3.3'
+  spec.dependency 'CoralogixInternal', '2.4.0'
   
     spec.test_spec 'Tests' do |test|
         test.source_files = 'Tests/SessionReplayTests/**/*.swift'

--- a/Tests/CoralogixRumTests/ErrorContextTests.swift
+++ b/Tests/CoralogixRumTests/ErrorContextTests.swift
@@ -184,6 +184,24 @@ final class ErrorContextTests: XCTestCase {
         XCTAssertEqual("obfuscated", dictionary[Keys.stackTraceType.rawValue] as? String)
     }
 
+    func testSymbolicatedFrameDoesNotEmitArchOrBuildId() {
+        let frames: [[String: Any]] = [
+            ["functionName": "throwExceptionInDart", "fileName": "package:coralogix_sdk/main.dart", "lineNumber": 134, "columnNumber": 5]
+        ]
+        mockSpanData = MockSpanData(attributes: [
+            Keys.errorMessage.rawValue: AttributeValue("state error try catch"),
+            Keys.stackTrace.rawValue: AttributeValue(Helper.convertArrayToJsonString(array: frames)),
+            Keys.stackTraceType.rawValue: AttributeValue("symbolicated")
+        ])
+        let errorStruct = ErrorContext(otel: mockSpanData)
+        let dictionary = errorStruct.getDictionary()
+
+        XCTAssertEqual("symbolicated", dictionary[Keys.stackTraceType.rawValue] as? String)
+        XCTAssertNil(dictionary[Keys.arch.rawValue], "arch should be absent for symbolicated frames")
+        XCTAssertNil(dictionary[Keys.buildId.rawValue], "build_id should be absent for symbolicated frames")
+        XCTAssertNil(dictionary[Keys.code.rawValue], "code should be absent in Flutter error path")
+    }
+
     func testNewFieldsOmittedWhenNil() {
         mockSpanData = MockSpanData(attributes: [
             Keys.errorMessage.rawValue: AttributeValue("Some error"),

--- a/Tests/CoralogixRumTests/ErrorContextTests.swift
+++ b/Tests/CoralogixRumTests/ErrorContextTests.swift
@@ -167,6 +167,24 @@ final class ErrorContextTests: XCTestCase {
         XCTAssertNil(dictionary[Keys.code.rawValue], "code should not be present in obfuscated Flutter error")
     }
 
+    func testObfuscatedDefaultStackTraceType_propagatesToDictionary() {
+        // The public reportError(obfuscatedStackTrace:) defaults stackTraceType to Keys.obfuscated.rawValue.
+        // This test locks down the constant's string value and verifies it roundtrips through ErrorContext,
+        // so that changing the constant or removing the default will break this test.
+        XCTAssertEqual(Keys.obfuscated.rawValue, "obfuscated",
+                       "Keys.obfuscated rawValue must stay \"obfuscated\" — it is the default for the public obfuscated reportError API")
+        mockSpanData = MockSpanData(attributes: [
+            Keys.errorMessage.rawValue: AttributeValue("crash"),
+            Keys.stackTrace.rawValue: AttributeValue(Helper.convertArrayToJsonString(array: [[Keys.virt.rawValue: "0x1234"]])),
+            Keys.stackTraceType.rawValue: AttributeValue(Keys.obfuscated.rawValue)
+        ])
+        let errorStruct = ErrorContext(otel: mockSpanData)
+        let dictionary = errorStruct.getDictionary()
+
+        XCTAssertEqual(dictionary[Keys.stackTraceType.rawValue] as? String, "obfuscated",
+                       "stackTraceType must be serialized with the obfuscated default value")
+    }
+
     func testNewFieldsPresentWhenSet() {
         mockSpanData = MockSpanData(attributes: [
             Keys.errorMessage.rawValue: AttributeValue("StateError"),

--- a/Tests/CoralogixRumTests/ErrorContextTests.swift
+++ b/Tests/CoralogixRumTests/ErrorContextTests.swift
@@ -143,6 +143,95 @@ final class ErrorContextTests: XCTestCase {
         XCTAssertEqual(dictionary[Keys.crashTimestamp.rawValue] as? String, "1625097600")
     }
     
+    // MARK: - Obfuscated Dart frame serialization
+
+    func testObfuscatedFrameSerializesWithVirtKey() {
+        let frame: [String: Any] = [Keys.virt.rawValue: "0x00000000003da15f"]
+        let frames = [frame]
+        mockSpanData = MockSpanData(attributes: [
+            Keys.errorMessage.rawValue: AttributeValue("StateError: state error try catch"),
+            Keys.code.rawValue: AttributeValue("0"),
+            Keys.domain.rawValue: AttributeValue(""),
+            Keys.stackTrace.rawValue: AttributeValue(Helper.convertArrayToJsonString(array: frames)),
+            Keys.arch.rawValue: AttributeValue("arm64"),
+            Keys.buildId.rawValue: AttributeValue("e4f372b4e5cb2ba87653648d9c509cb1"),
+            Keys.stackTraceType.rawValue: AttributeValue("obfuscated")
+        ])
+        let errorStruct = ErrorContext(otel: mockSpanData)
+        let dictionary = errorStruct.getDictionary()
+
+        guard let stackTrace = dictionary[Keys.originalStackTrace.rawValue] as? [[String: Any]] else {
+            XCTFail("original_stacktrace should be present")
+            return
+        }
+        XCTAssertEqual(1, stackTrace.count)
+        XCTAssertEqual("0x00000000003da15f", stackTrace[0][Keys.virt.rawValue] as? String)
+    }
+
+    func testNewFieldsPresentWhenSet() {
+        mockSpanData = MockSpanData(attributes: [
+            Keys.errorMessage.rawValue: AttributeValue("StateError"),
+            Keys.code.rawValue: AttributeValue("0"),
+            Keys.domain.rawValue: AttributeValue(""),
+            Keys.arch.rawValue: AttributeValue("arm64"),
+            Keys.buildId.rawValue: AttributeValue("e4f372b4e5cb2ba87653648d9c509cb1"),
+            Keys.stackTraceType.rawValue: AttributeValue("obfuscated")
+        ])
+        let errorStruct = ErrorContext(otel: mockSpanData)
+        let dictionary = errorStruct.getDictionary()
+
+        XCTAssertEqual("arm64", dictionary[Keys.arch.rawValue] as? String)
+        XCTAssertEqual("e4f372b4e5cb2ba87653648d9c509cb1", dictionary[Keys.buildId.rawValue] as? String)
+        XCTAssertEqual("obfuscated", dictionary[Keys.stackTraceType.rawValue] as? String)
+    }
+
+    func testNewFieldsOmittedWhenNil() {
+        mockSpanData = MockSpanData(attributes: [
+            Keys.errorMessage.rawValue: AttributeValue("Some error"),
+            Keys.code.rawValue: AttributeValue("0"),
+            Keys.domain.rawValue: AttributeValue("")
+        ])
+        let errorStruct = ErrorContext(otel: mockSpanData)
+        let dictionary = errorStruct.getDictionary()
+
+        XCTAssertNil(dictionary[Keys.buildId.rawValue])
+        XCTAssertNil(dictionary[Keys.stackTraceType.rawValue])
+        XCTAssertNil(dictionary[Keys.arch.rawValue])
+    }
+
+    func testNativeCrashPathUnaffected() {
+        var threads = [String]()
+        var result = [[String: Any]]()
+        var frameObj = [String: Any]()
+        frameObj[Keys.frameNumber.rawValue] = "0"
+        frameObj[Keys.binary.rawValue] = "DemoAppSwift"
+        frameObj[Keys.functionAddressCalled.rawValue] = "0x0000000104b31f94"
+        frameObj[Keys.base.rawValue] = "_$s12DemoAppSwift8CrashSimC"
+        frameObj[Keys.offset.rawValue] = "224"
+        result.append(frameObj)
+        threads.append(Helper.convertArrayToJsonString(array: result))
+
+        mockSpanData = MockSpanData(attributes: [
+            Keys.threads.rawValue: AttributeValue(Helper.convertArrayOfStringToJsonString(array: threads)),
+            Keys.exceptionType.rawValue: AttributeValue("EXC_BAD_ACCESS"),
+            Keys.crashTimestamp.rawValue: AttributeValue("1625097600"),
+            Keys.processName.rawValue: AttributeValue("DemoApp"),
+            Keys.applicationIdentifier.rawValue: AttributeValue("com.myapp"),
+            Keys.triggeredByThread.rawValue: AttributeValue("0"),
+            Keys.baseAddress.rawValue: AttributeValue("0x1000000"),
+            Keys.arch.rawValue: AttributeValue("arm64")
+        ])
+        let errorStruct = ErrorContext(otel: mockSpanData)
+        let dictionary = errorStruct.getDictionary()
+
+        // Crash path still emits arch and baseAddress at the top level
+        XCTAssertEqual("arm64", dictionary[Keys.arch.rawValue] as? String)
+        XCTAssertEqual("0x1000000", dictionary[Keys.baseAddress.rawValue] as? String)
+        // And does NOT emit buildId / stackTraceType (they were never set)
+        XCTAssertNil(dictionary[Keys.buildId.rawValue])
+        XCTAssertNil(dictionary[Keys.stackTraceType.rawValue])
+    }
+
     func testGetDictionaryWithoutStackTrace() {
         mockSpanData = MockSpanData(attributes: [
             Keys.domain.rawValue: AttributeValue("com.example.error"),

--- a/Tests/CoralogixRumTests/ErrorContextTests.swift
+++ b/Tests/CoralogixRumTests/ErrorContextTests.swift
@@ -168,21 +168,23 @@ final class ErrorContextTests: XCTestCase {
     }
 
     func testObfuscatedDefaultStackTraceType_propagatesToDictionary() {
-        // The public reportError(obfuscatedStackTrace:) defaults stackTraceType to Keys.obfuscated.rawValue.
-        // This test locks down the constant's string value and verifies it roundtrips through ErrorContext,
-        // so that changing the constant or removing the default will break this test.
+        // Locks down the string value of Keys.obfuscated — this constant is used as the default
+        // for the public reportError(obfuscatedStackTrace:) API parameter. If the constant is
+        // renamed or changed, this assertion catches it.
         XCTAssertEqual(Keys.obfuscated.rawValue, "obfuscated",
                        "Keys.obfuscated rawValue must stay \"obfuscated\" — it is the default for the public obfuscated reportError API")
+
+        // When stackTraceType is absent from the span (i.e. the caller omits it), ErrorContext
+        // must NOT inject a default — the default belongs to the public API layer, not ErrorContext.
         mockSpanData = MockSpanData(attributes: [
             Keys.errorMessage.rawValue: AttributeValue("crash"),
-            Keys.stackTrace.rawValue: AttributeValue(Helper.convertArrayToJsonString(array: [[Keys.virt.rawValue: "0x1234"]])),
-            Keys.stackTraceType.rawValue: AttributeValue(Keys.obfuscated.rawValue)
+            Keys.stackTrace.rawValue: AttributeValue(Helper.convertArrayToJsonString(array: [[Keys.virt.rawValue: "0x1234"]]))
         ])
         let errorStruct = ErrorContext(otel: mockSpanData)
         let dictionary = errorStruct.getDictionary()
 
-        XCTAssertEqual(dictionary[Keys.stackTraceType.rawValue] as? String, "obfuscated",
-                       "stackTraceType must be serialized with the obfuscated default value")
+        XCTAssertNil(dictionary[Keys.stackTraceType.rawValue],
+                     "ErrorContext must not inject a stackTraceType default — that is the public API's responsibility")
     }
 
     func testNewFieldsPresentWhenSet() {

--- a/Tests/CoralogixRumTests/ErrorContextTests.swift
+++ b/Tests/CoralogixRumTests/ErrorContextTests.swift
@@ -150,8 +150,6 @@ final class ErrorContextTests: XCTestCase {
         let frames = [frame]
         mockSpanData = MockSpanData(attributes: [
             Keys.errorMessage.rawValue: AttributeValue("StateError: state error try catch"),
-            Keys.code.rawValue: AttributeValue("0"),
-            Keys.domain.rawValue: AttributeValue(""),
             Keys.stackTrace.rawValue: AttributeValue(Helper.convertArrayToJsonString(array: frames)),
             Keys.arch.rawValue: AttributeValue("arm64"),
             Keys.buildId.rawValue: AttributeValue("e4f372b4e5cb2ba87653648d9c509cb1"),
@@ -166,6 +164,7 @@ final class ErrorContextTests: XCTestCase {
         }
         XCTAssertEqual(1, stackTrace.count)
         XCTAssertEqual("0x00000000003da15f", stackTrace[0][Keys.virt.rawValue] as? String)
+        XCTAssertNil(dictionary[Keys.code.rawValue], "code should not be present in obfuscated Flutter error")
     }
 
     func testNewFieldsPresentWhenSet() {


### PR DESCRIPTION
# User description
## Summary
- **Public API**: `reportError` gains optional `arch`, `buildId`, `stackTraceType` on the existing stack-trace overload; new overload for **obfuscated** Dart stacks (`obfuscatedStackTrace: [String]`).
- **Serialization**: Obfuscated frames are stored as JSON frames with `virt` (virtual address); new span keys `build_id`, `stack_trace_type`, `virt`.
- **ErrorContext**: Reads and emits `arch`, `build_id`, `stack_trace_type` in the error payload when present.
- **writeError**: `code` is optional; attribute is set only when a code is provided.
- **Example**: Demo app simulates symbolicated vs obfuscated Flutter errors; **tests** cover `virt` serialization, new fields, and native crash path.

## Pre-merge code review (scoped)

### `Coralogix/Sources/Instrumentation/ErrorInstrumentation.swift`
- **Suggestion**: Hybrid `reportErrorInternal` now calls `writeError` without `code` (previously `0`). Spans from Flutter/RN error reporting will **no longer include** the `code` attribute unless callers add a separate path. Confirm with backend/analytics that omitting `code` is desired; otherwise pass `code: 0` again for parity.

### `Coralogix/Sources/Model/Contexts/ErrorContext.swift`
- **Nit**: `arch` is only added to `errorContext` when non-empty; behavior is consistent with optional `buildId` / `stackTraceType`.

### `Coralogix/Sources/CoralogixRum.swift`
- **Nit**: Doc comments on the obfuscated overload clarify usage for Flutter; good for integrators.

### `Tests/CoralogixRumTests/ErrorContextTests.swift`
- **New code looks good**: Covers virt key, optional fields, and crash path regression.

---

**Note:** `.claude/` was left untracked and not included in this PR.

Made with [Cursor](https://cursor.com)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Document the new Flutter error-reporting entry points so <code>CoralogixRum</code>/<code>ErrorInstrumentation</code> can accept symbolicated or obfuscated stack traces and let the demo and docs illustrate how to exercise each variant. Align podspec versions, <code>Keys</code>, <code>ErrorContext</code>, tests, and span writing so optional metadata (<code>arch</code>, <code>buildId</code>, <code>stackTraceType</code>, <code>virt</code>) is emitted with every error path while remaining absent when callers omit it.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/177?tool=ast&topic=Flutter+error+flow>Flutter error flow</a>
        </td><td>Enable <code>CoralogixRum</code>/<code>ErrorInstrumentation</code> to accept both symbolicated and obfuscated Flutter stack traces, add the client-facing documentation, and expand the demo controls so developers can exercise each path with the new APIs.<details><summary>Modified files (6)</summary><ul><li>Coralogix/Docs/CORALOGIX_RUM.md</li>
<li>Coralogix/Sources/CoralogixRum.swift</li>
<li>Coralogix/Sources/Instrumentation/ErrorInstrumentation.swift</li>
<li>Example/DemoAppSwift/ErrorViewController.swift</li>
<li>Example/Shared/Keys.swift</li>
<li>Example/Shared/SimulateFolder/ErrorSim.swift</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>CX-33234: Response bod...</td><td>March 15, 2026</td></tr>
<tr><td>aking618</td><td>Allow clearing user co...</td><td>February 19, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/177?tool=ast&topic=Error+metadata>Error metadata</a>
        </td><td>Propagate the new metadata keys through the SDK by bumping podspec versions, extending <code>Keys</code>/<code>Global</code>, serializing the values in <code>ErrorContext</code>, making <code>writeError</code> optional for <code>code</code>, and covering it all with dedicated tests.<details><summary>Modified files (7)</summary><ul><li>Coralogix.podspec</li>
<li>Coralogix/Sources/Model/Contexts/ErrorContext.swift</li>
<li>CoralogixInternal.podspec</li>
<li>CoralogixInternal/Sources/Keys.swift</li>
<li>CoralogixInternal/Sources/Utils.swift</li>
<li>SessionReplay.podspec</li>
<li>Tests/CoralogixRumTests/ErrorContextTests.swift</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>fix: forward request/r...</td><td>March 22, 2026</td></tr>
<tr><td>NatanCoralogix</td><td>bump crash reporter (#...</td><td>September 01, 2025</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/coralogix/cx-ios-sdk/177?tool=ast>(Baz)</a>.