### PR TITLE
fix: traceparent header capture in RN/Flutter hybrid network path

### DIFF
--- a/Coralogix.podspec
+++ b/Coralogix.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "Coralogix"
-  spec.version      = "2.4.0"
+  spec.version      = "2.4.1"
   spec.summary      = "Coralogix OpenTelemetry pod for iOS."
 
   spec.description  = <<-DESC
@@ -29,7 +29,7 @@ Pod::Spec.new do |spec|
 
   spec.static_framework = true
   spec.dependency 'PLCrashReporter', '~> 1.12'
-  spec.dependency 'CoralogixInternal', '2.4.0'
+  spec.dependency 'CoralogixInternal', '2.4.1'
 
   spec.test_spec 'Tests' do |test|
     test.source_files = 'Tests/CoralogixRumTests/**/*.swift'

--- a/Coralogix/Sources/Instrumentation/NetworkInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/NetworkInstrumentation.swift
@@ -228,17 +228,48 @@ extension CoralogixRum {
         span.setAttribute(key: Keys.customSpanId.rawValue, value: dictionary[Keys.customSpanId.rawValue] as? String ?? "")
         span.setAttribute(key: Keys.customTraceId.rawValue, value: dictionary[Keys.customTraceId.rawValue] as? String ?? "")
 
-        if let reqHeaders = dictionary[Keys.requestHeaders.rawValue] as? [String: Any] {
-            let json = Helper.convertDictionayToJsonString(dict: reqHeaders)
-            if !json.isEmpty {
+        let requestUrl = dictionary[Keys.url.rawValue] as? String ?? ""
+        var options: CoralogixExporterOptions?
+        CoralogixRum.exporterQueue.sync { options = self.options }
+        let configs = options?.networkExtraConfig
+        let rule = configs.flatMap { resolveConfigForUrl(requestUrl, configs: $0) }
+
+        // Request headers: merge JS-visible headers with natively-stored headers (which include
+        // traceparent injected by URLSession instrumentation — invisible to the JS interceptor).
+        // Native headers win on conflicts (e.g. traceparent); then filter by reqHeaders allowlist.
+        let nativeReqHeaders = sessionInstrumentation?.nativeRequestHeaders(forUrl: requestUrl)
+        var mergedReqHeaders = (dictionary[Keys.requestHeaders.rawValue] as? [String: Any])?.compactMapValues { $0 as? String } ?? [:]
+        if let native = nativeReqHeaders {
+            mergedReqHeaders.merge(native) { _, nativeValue in nativeValue }
+        }
+        if !mergedReqHeaders.isEmpty {
+            let filtered: [String: String]
+            if let allowlist = rule?.reqHeaders {
+                filtered = NetworkCaptureRule.filterHeaders(mergedReqHeaders, allowlist: allowlist)
+            } else {
+                filtered = mergedReqHeaders
+            }
+            if !filtered.isEmpty {
+                let dictAny = Dictionary(uniqueKeysWithValues: filtered.map { ($0.key, $0.value as Any) })
+                let json = Helper.convertDictionayToJsonString(dict: dictAny)
                 span.setAttribute(key: Keys.requestHeaders.rawValue, value: AttributeValue.string(json))
             }
         } else if let reqHeaders = dictionary[Keys.requestHeaders.rawValue] as? String, !reqHeaders.isEmpty {
             span.setAttribute(key: Keys.requestHeaders.rawValue, value: AttributeValue.string(reqHeaders))
         }
-        if let resHeaders = dictionary[Keys.responseHeaders.rawValue] as? [String: Any] {
-            let json = Helper.convertDictionayToJsonString(dict: resHeaders)
-            if !json.isEmpty {
+
+        // Response headers: filter by the rule's resHeaders allowlist when a rule is configured.
+        if let resHeadersDict = dictionary[Keys.responseHeaders.rawValue] as? [String: Any] {
+            let allRes = resHeadersDict.compactMapValues { $0 as? String }
+            let filtered: [String: String]
+            if let allowlist = rule?.resHeaders {
+                filtered = NetworkCaptureRule.filterHeaders(allRes, allowlist: allowlist)
+            } else {
+                filtered = allRes
+            }
+            if !filtered.isEmpty {
+                let dictAny = Dictionary(uniqueKeysWithValues: filtered.map { ($0.key, $0.value as Any) })
+                let json = Helper.convertDictionayToJsonString(dict: dictAny)
                 span.setAttribute(key: Keys.responseHeaders.rawValue, value: AttributeValue.string(json))
             }
         } else if let resHeaders = dictionary[Keys.responseHeaders.rawValue] as? String, !resHeaders.isEmpty {

--- a/Coralogix/Sources/Model/TraceParentInHeader.swift
+++ b/Coralogix/Sources/Model/TraceParentInHeader.swift
@@ -17,7 +17,8 @@ internal struct TraceParentInHeader {
             Log.e("[TraceParentInHeader missing params]")
             return
         }
-        enable = params[Keys.enable.rawValue] as? Bool ?? false
+        // Accept both "enable" (native) and "enabled" (React Native bridge) for compatibility
+        enable = params[Keys.enable.rawValue] as? Bool ?? params["enabled"] as? Bool ?? false
         let options = params[Keys.options.rawValue] as? [String: Any]
         allowedTracingUrls = options?[Keys.allowedTracingUrls.rawValue] as? [String]
     }

--- a/Coralogix/Sources/Otel/URLSession/URLSessionInstrumentation.swift
+++ b/Coralogix/Sources/Otel/URLSession/URLSessionInstrumentation.swift
@@ -84,12 +84,15 @@ public class URLSessionInstrumentation {
     }
 
     /// Stores the request for the task so it can be read at response time (e.g. for header capture).
-    /// Last write per taskId wins; callers should pass the instrumented/processed request when available.
+    /// - Parameters:
+    ///   - ifAbsent: When `true`, skips the write if a request is already stored for `taskId` (atomic check-and-set inside the barrier). Use this when the factory path may have already stored a better (instrumented) request and you don't want to overwrite it.
     /// Also populates `nativeRequestHeadersByUrl` so the hybrid path can look up injected headers by URL.
-    internal func storeRequest(_ request: URLRequest, forTaskId taskId: String) {
+    internal func storeRequest(_ request: URLRequest, forTaskId taskId: String, ifAbsent: Bool = false) {
         queue.sync(flags: .barrier) {
             if requestMap[taskId] == nil {
                 requestMap[taskId] = NetworkRequestState()
+            } else if ifAbsent {
+                return  // already stored by factory path — do not overwrite
             }
             requestMap[taskId]?.setRequest(request)
 
@@ -1345,9 +1348,9 @@ public class URLSessionInstrumentation {
         // (with traceparent in allHTTPHeaderFields); the resume path falls back here only
         // for tasks that were not created through the factory swizzle (e.g. async/await).
         // Store instrumentedRequest when available so traceparent is captured in reqHeaders.
-        if requestMap[taskId] == nil {
-            storeRequest(instrumentedRequest ?? request, forTaskId: taskId)
-        }
+        // ifAbsent: true makes the check-and-set atomic inside the barrier, preventing a race
+        // where the resume path overwrites a factory-stored instrumented request (with traceparent).
+        storeRequest(instrumentedRequest ?? request, forTaskId: taskId, ifAbsent: true)
 
         // Handle iOS 15+ async/await - detect and set up delegate for completion tracking
         if #available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *) {

--- a/Coralogix/Sources/Otel/URLSession/URLSessionInstrumentation.swift
+++ b/Coralogix/Sources/Otel/URLSession/URLSessionInstrumentation.swift
@@ -1319,11 +1319,9 @@ public class URLSessionInstrumentation {
         // The factory path (bridgedArgumentForFactory) stores the instrumented request
         // (with traceparent in allHTTPHeaderFields); the resume path falls back here only
         // for tasks that were not created through the factory swizzle (e.g. async/await).
-        queue.sync(flags: .barrier) {
-            if self.requestMap[taskId] == nil {
-                self.requestMap[taskId] = NetworkRequestState()
-                self.requestMap[taskId]?.setRequest(request)
-            }
+        // Store instrumentedRequest when available so traceparent is captured in reqHeaders.
+        if requestMap[taskId] == nil {
+            storeRequest(instrumentedRequest ?? request, forTaskId: taskId)
         }
 
         // Handle iOS 15+ async/await - detect and set up delegate for completion tracking

--- a/Coralogix/Sources/Otel/URLSession/URLSessionInstrumentation.swift
+++ b/Coralogix/Sources/Otel/URLSession/URLSessionInstrumentation.swift
@@ -1285,12 +1285,13 @@ public class URLSessionInstrumentation {
           injectHeadersIntoTask(task, request: instrumentedRequest)
         }
         
-        // Store request for tracking
+        // Store request for tracking — use instrumented request so injected headers
+        // (e.g. traceparent) are visible when receivedResponse captures reqHeaders.
         queue.sync(flags: .barrier) {
             if self.requestMap[taskId] == nil {
                 self.requestMap[taskId] = NetworkRequestState()
           }
-            self.requestMap[taskId]?.setRequest(request)
+            self.requestMap[taskId]?.setRequest(instrumentedRequest ?? request)
         }
 
         // Handle iOS 15+ async/await - detect and set up delegate for completion tracking

--- a/Coralogix/Sources/Otel/URLSession/URLSessionInstrumentation.swift
+++ b/Coralogix/Sources/Otel/URLSession/URLSessionInstrumentation.swift
@@ -32,6 +32,12 @@ public class URLSessionInstrumentation {
     private var responseBodyStore = [String: Data]()
     /// Max bytes to buffer per task for response body capture; aligned with downstream 1024-char limit (avoid unbounded growth).
     private static let maxResponseBodyStoreBytes = 64 * 1024
+
+    /// Request headers keyed by absolute URL, populated when an instrumented request is stored.
+    /// Used by the React Native hybrid path to retrieve natively-injected headers (e.g. traceparent)
+    /// which are invisible to the JS interceptor. Capped at maxNativeHeadersEntries to bound memory.
+    private var nativeRequestHeadersByUrl = [String: [String: String]]()
+    private static let maxNativeHeadersEntries = 100
     
     private var _configuration: URLSessionInstrumentationConfiguration
     public var configuration: URLSessionInstrumentationConfiguration {
@@ -77,13 +83,34 @@ public class URLSessionInstrumentation {
 
     /// Stores the request for the task so it can be read at response time (e.g. for header capture).
     /// Last write per taskId wins; callers should pass the instrumented/processed request when available.
+    /// Also populates `nativeRequestHeadersByUrl` so the hybrid path can look up injected headers by URL.
     internal func storeRequest(_ request: URLRequest, forTaskId taskId: String) {
         queue.sync(flags: .barrier) {
             if requestMap[taskId] == nil {
                 requestMap[taskId] = NetworkRequestState()
             }
             requestMap[taskId]?.setRequest(request)
+
+            // Keep a URL-keyed copy of the headers for the hybrid path (RN/Flutter).
+            // The hybrid span is reported after the native task ends, so requestMap is already
+            // cleared by then — this store survives the cleanup.
+            if let url = request.url?.absoluteString, let headers = request.allHTTPHeaderFields, !headers.isEmpty {
+                if nativeRequestHeadersByUrl.count >= Self.maxNativeHeadersEntries {
+                    nativeRequestHeadersByUrl.removeAll()
+                }
+                nativeRequestHeadersByUrl[url] = headers
+            }
         }
+    }
+
+    /// Returns natively-stored request headers for the given absolute URL, or nil if none recorded.
+    /// Used by the hybrid path (React Native / Flutter) to obtain headers invisible to the JS interceptor.
+    internal func nativeRequestHeaders(forUrl url: String) -> [String: String]? {
+        var headers: [String: String]?
+        queue.sync {
+            headers = nativeRequestHeadersByUrl[url]
+        }
+        return headers
     }
 
     /// Returns and removes accumulated response body for the task (rule-based capture). Returns nil if none.

--- a/Coralogix/Sources/Otel/URLSession/URLSessionInstrumentation.swift
+++ b/Coralogix/Sources/Otel/URLSession/URLSessionInstrumentation.swift
@@ -1381,16 +1381,9 @@ public class URLSessionInstrumentation {
     ///   - task: The URLSessionTask to modify
     ///   - request: The instrumented request with headers to inject
     private func injectHeadersIntoTask(_ task: URLSessionTask, request: URLRequest) {
-        // Scenario A: currentRequest is already mutable (rare but possible)
-        if let mutableRequest = task.currentRequest as? NSMutableURLRequest {
-            // Easy case - modify directly
-            for (key, value) in request.allHTTPHeaderFields ?? [:] {
-                mutableRequest.setValue(value, forHTTPHeaderField: key)
-            }
-            return
-        }
-        
-        // Scenario B: Use private setCurrentRequest: selector (industry-standard approach)
+        // Always use setCurrentRequest: to inject headers.
+        // task.currentRequest returns a copy — mutating NSMutableURLRequest in-place has no effect
+        // on what the task actually sends. setCurrentRequest: is the only way to push the change back.
         let setCurrentRequestSelector = NSSelectorFromString("setCurrentRequest:")
         guard task.responds(to: setCurrentRequestSelector) else {
             // Task doesn't support setCurrentRequest: - headers won't be injected

--- a/Coralogix/Sources/Otel/URLSession/URLSessionInstrumentation.swift
+++ b/Coralogix/Sources/Otel/URLSession/URLSessionInstrumentation.swift
@@ -406,6 +406,9 @@ public class URLSessionInstrumentation {
             if let originalReq = coerceToRequest(argument) {
                 let inject = shouldInject(for: originalReq)
                 let (_, requestToUse) = prepareAndLogRequest(originalReq, injectHeaders: inject, existingSessionTaskId: sessionTaskId)
+                // Store now so receivedResponse can read injected headers (e.g. traceparent).
+                // The resume swizzle only stores when requestMap is still empty, so this wins.
+                storeRequest(requestToUse, forTaskId: sessionTaskId)
                 return requestToUse as NSURLRequest
             }
             // Fallback: forward as-is
@@ -1285,13 +1288,15 @@ public class URLSessionInstrumentation {
           injectHeadersIntoTask(task, request: instrumentedRequest)
         }
         
-        // Store request for tracking — use instrumented request so injected headers
-        // (e.g. traceparent) are visible when receivedResponse captures reqHeaders.
+        // Store request for tracking — only when not already stored by the factory path.
+        // The factory path (bridgedArgumentForFactory) stores the instrumented request
+        // (with traceparent in allHTTPHeaderFields); the resume path falls back here only
+        // for tasks that were not created through the factory swizzle (e.g. async/await).
         queue.sync(flags: .barrier) {
             if self.requestMap[taskId] == nil {
                 self.requestMap[taskId] = NetworkRequestState()
-          }
-            self.requestMap[taskId]?.setRequest(instrumentedRequest ?? request)
+                self.requestMap[taskId]?.setRequest(request)
+            }
         }
 
         // Handle iOS 15+ async/await - detect and set up delegate for completion tracking

--- a/Coralogix/Sources/Otel/URLSession/URLSessionInstrumentation.swift
+++ b/Coralogix/Sources/Otel/URLSession/URLSessionInstrumentation.swift
@@ -111,6 +111,23 @@ public class URLSessionInstrumentation {
         }
     }
 
+    /// Re-indexes native headers under the final (post-redirect) URL when it differs from the original.
+    /// Called from URLSessionLogger.logResponse so the hybrid path can look up by the URL the JS bridge reports.
+    internal func indexNativeHeadersForRedirectIfNeeded(originalUrl: String?, responseUrl: String?) {
+        guard let originalUrl, let responseUrl, originalUrl != responseUrl else { return }
+        queue.sync(flags: .barrier) {
+            guard let headers = nativeRequestHeadersByUrl[originalUrl],
+                  nativeRequestHeadersByUrl[responseUrl] == nil else { return }
+            if nativeRequestHeadersByUrl.count >= Self.maxNativeHeadersEntries,
+               let oldest = nativeRequestHeadersKeyOrder.first {
+                nativeRequestHeadersByUrl.removeValue(forKey: oldest)
+                nativeRequestHeadersKeyOrder.removeFirst()
+            }
+            nativeRequestHeadersByUrl[responseUrl] = headers
+            nativeRequestHeadersKeyOrder.append(responseUrl)
+        }
+    }
+
     /// Returns natively-stored request headers for the given absolute URL, or nil if none recorded.
     /// Used by the hybrid path (React Native / Flutter) to obtain headers invisible to the JS interceptor.
     internal func nativeRequestHeaders(forUrl url: String) -> [String: String]? {

--- a/Coralogix/Sources/Otel/URLSession/URLSessionInstrumentation.swift
+++ b/Coralogix/Sources/Otel/URLSession/URLSessionInstrumentation.swift
@@ -37,6 +37,8 @@ public class URLSessionInstrumentation {
     /// Used by the React Native hybrid path to retrieve natively-injected headers (e.g. traceparent)
     /// which are invisible to the JS interceptor. Capped at maxNativeHeadersEntries to bound memory.
     private var nativeRequestHeadersByUrl = [String: [String: String]]()
+    /// Tracks insertion order for FIFO eviction — oldest key is at index 0.
+    private var nativeRequestHeadersKeyOrder = [String]()
     private static let maxNativeHeadersEntries = 100
     
     private var _configuration: URLSessionInstrumentationConfiguration
@@ -95,8 +97,14 @@ public class URLSessionInstrumentation {
             // The hybrid span is reported after the native task ends, so requestMap is already
             // cleared by then — this store survives the cleanup.
             if let url = request.url?.absoluteString, let headers = request.allHTTPHeaderFields, !headers.isEmpty {
-                if nativeRequestHeadersByUrl.count >= Self.maxNativeHeadersEntries {
-                    nativeRequestHeadersByUrl.removeAll()
+                if nativeRequestHeadersByUrl[url] == nil {
+                    // New URL: evict the oldest entry first if at capacity (FIFO).
+                    if nativeRequestHeadersByUrl.count >= Self.maxNativeHeadersEntries,
+                       let oldest = nativeRequestHeadersKeyOrder.first {
+                        nativeRequestHeadersByUrl.removeValue(forKey: oldest)
+                        nativeRequestHeadersKeyOrder.removeFirst()
+                    }
+                    nativeRequestHeadersKeyOrder.append(url)
                 }
                 nativeRequestHeadersByUrl[url] = headers
             }

--- a/Coralogix/Sources/Otel/URLSession/URLSessionLogger.swift
+++ b/Coralogix/Sources/Otel/URLSession/URLSessionLogger.swift
@@ -138,6 +138,12 @@ class URLSessionLogger {
         // Use caller-supplied body when present; otherwise take from rule-based store (e.g. delegate-only path).
         // Prefer dataOrFile first to avoid redundant captureQueue.sync when completion-handler or delegate already passed body.
         let effectiveData = dataOrFile ?? instrumentation.takeResponseBody(forTaskId: sessionTaskId)
+        // Re-index native headers under the final URL when a redirect changed it, so the hybrid
+        // path (RN/Flutter) can find them by the URL the JS bridge reports.
+        instrumentation.indexNativeHeadersForRedirectIfNeeded(
+            originalUrl: request?.url?.absoluteString,
+            responseUrl: response.url?.absoluteString
+        )
         instrumentation.configuration.receivedResponse?(response, effectiveData, span, request)
         span.end()
     }

--- a/Coralogix/Sources/Utils/NetworkCaptureRule.swift
+++ b/Coralogix/Sources/Utils/NetworkCaptureRule.swift
@@ -254,29 +254,40 @@ public struct NetworkCaptureRule {
 
 // MARK: - Rule resolution
 
-/// Returns the first rule in `configs` whose URL matcher applies to `requestUrl`
-/// (first-match-wins), or `nil` if no rule matches.
+/// Returns a merged `NetworkCaptureRule` combining **all** rules in `configs` that match `requestUrl`,
+/// or `nil` if no rule matches.
 ///
-/// **Caller contract**: when the return value is `nil`, all four capture fields
-/// (`reqHeaders`, `resHeaders`, `collectReqPayload`, `collectResPayload`) must be skipped.
+/// Merge semantics (union/OR across all matching rules):
+/// - `reqHeaders` / `resHeaders`: union of allowlists from every matching rule; `nil` when all matching rules have `nil`.
+/// - `collectReqPayload` / `collectResPayload`: `true` if any matching rule enables it.
 ///
-/// Mirrors the browser SDK helper:
-/// ```js
-/// resolveConfigForUrl(url, configs) {
-///   return configs.find(({ url: configUrl }) =>
-///     configUrl === url || (configUrl instanceof RegExp && configUrl.test(url)));
-/// }
-/// ```
+/// This means you can have a broad rule that captures payloads and a narrow rule that adds extra
+/// headers — both will be applied to any URL they match.
 ///
 /// - Parameters:
 ///   - requestUrl: The absolute URL string of the outgoing request.
 ///   - configs: The ordered array of rules from `CoralogixExporterOptions.networkExtraConfig`.
-/// - Returns: The first matching `NetworkCaptureRule`, or `nil`.
+/// - Returns: A merged `NetworkCaptureRule`, or `nil` when no rule matches.
 internal func resolveConfigForUrl(_ requestUrl: String, configs: [NetworkCaptureRule]) -> NetworkCaptureRule? {
     guard let url = URL(string: requestUrl) else {
         let preview = String(requestUrl.prefix(100))
         Log.w("resolveConfigForUrl: '\(preview)' is not a valid URL — skipping rule evaluation.")
         return nil
     }
-    return configs.first { $0.matches(url) }
+    let matching = configs.filter { $0.matches(url) }
+    guard !matching.isEmpty else { return nil }
+    guard matching.count > 1 else { return matching[0] }
+
+    // Merge: union headers, OR booleans
+    let allReqHeaders = matching.compactMap { $0.reqHeaders }.flatMap { $0 }
+    let allResHeaders = matching.compactMap { $0.resHeaders }.flatMap { $0 }
+    let mergedReqHeaders: [String]? = allReqHeaders.isEmpty ? nil : Array(Set(allReqHeaders))
+    let mergedResHeaders: [String]? = allResHeaders.isEmpty ? nil : Array(Set(allResHeaders))
+    let collectReq = matching.contains { $0.collectReqPayload }
+    let collectRes = matching.contains { $0.collectResPayload }
+    return NetworkCaptureRule(url: requestUrl,
+                              reqHeaders: mergedReqHeaders,
+                              resHeaders: mergedResHeaders,
+                              collectReqPayload: collectReq,
+                              collectResPayload: collectRes)
 }

--- a/CoralogixInternal.podspec
+++ b/CoralogixInternal.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "CoralogixInternal"
-  spec.version      = "2.4.0"
+  spec.version      = "2.4.1"
   spec.summary      = "Coralogix Internal Package. This module is not for public use."
 
   spec.description  = <<-DESC

--- a/CoralogixInternal/Sources/Utils.swift
+++ b/CoralogixInternal/Sources/Utils.swift
@@ -16,7 +16,7 @@ public enum ImageFormat {
 }
 
 public enum Global: String {
-    case sdk = "2.4.0"
+    case sdk = "2.4.1"
     case swiftVersion = "5.9"
     case coralogixPath = "/browser/v1beta/logs"
     case sessionReplayPath = "/browser/alpha/sessionrecording"

--- a/SessionReplay.podspec
+++ b/SessionReplay.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "SessionReplay"
-  spec.version      = "2.4.0"
+  spec.version      = "2.4.1"
   spec.summary      = "Coralogix Session-Replay pod for iOS."
 
   spec.description  = <<-DESC
@@ -23,7 +23,7 @@ Pod::Spec.new do |spec|
   spec.static_framework = true
 
   spec.source_files  = 'SessionReplay/Sources/**/*.swift'
-  spec.dependency 'CoralogixInternal', '2.4.0'
+  spec.dependency 'CoralogixInternal', '2.4.1'
   
     spec.test_spec 'Tests' do |test|
         test.source_files = 'Tests/SessionReplayTests/**/*.swift'

--- a/Tests/CoralogixRumTests/CoralogixRumTests.swift
+++ b/Tests/CoralogixRumTests/CoralogixRumTests.swift
@@ -611,7 +611,93 @@ final class CoralogixRumTests: XCTestCase {
         let result = coralogixRum.shouldAddTraceParent(to: request, options: mockOptions)
         XCTAssertTrue(result)
     }
-    
+
+    // MARK: - traceParentInHeader: "enabled" key (React Native bridge compatibility)
+
+    /// Regression: RN bridge sends "enabled" (with 'd') but native historically read only "enable".
+    /// Both must now be accepted.
+    func testShouldReturnFalse_WhenTracingDisabled_UsingEnabledKey() {
+        let request = URLRequest(url: URL(string: "https://example.com")!)
+        let mockOptions = CoralogixExporterOptions(
+            coralogixDomain: .US2,
+            userContext: nil,
+            environment: "PROD",
+            application: "TestApp-iOS",
+            version: "1.0",
+            publicKey: "token",
+            ignoreUrls: [],
+            ignoreErrors: [],
+            sessionSampleRate: 100,
+            traceParentInHeader: ["enabled": false],
+            debug: true
+        )
+        let coralogixRum = CoralogixRum(options: mockOptions)
+        let result = coralogixRum.shouldAddTraceParent(to: request, options: mockOptions)
+        XCTAssertFalse(result, "enabled: false (RN key) must disable traceparent injection")
+    }
+
+    func testShouldReturnTrue_WhenNoAllowedUrlsDefined_UsingEnabledKey() {
+        let request = URLRequest(url: URL(string: "https://random.com")!)
+        let mockOptions = CoralogixExporterOptions(
+            coralogixDomain: .US2,
+            userContext: nil,
+            environment: "PROD",
+            application: "TestApp-iOS",
+            version: "1.0",
+            publicKey: "token",
+            ignoreUrls: [],
+            ignoreErrors: [],
+            sessionSampleRate: 100,
+            traceParentInHeader: ["enabled": true],
+            debug: true
+        )
+        let coralogixRum = CoralogixRum(options: mockOptions)
+        let result = coralogixRum.shouldAddTraceParent(to: request, options: mockOptions)
+        XCTAssertTrue(result, "enabled: true (RN key) with no allowedTracingUrls must allow all URLs")
+    }
+
+    func testShouldReturnTrue_WhenAllowedUrlsMatch_UsingEnabledKey() {
+        let request = URLRequest(url: URL(string: "https://allowed.com/path")!)
+        let mockOptions = CoralogixExporterOptions(
+            coralogixDomain: .US2,
+            userContext: nil,
+            environment: "PROD",
+            application: "TestApp-iOS",
+            version: "1.0",
+            publicKey: "token",
+            ignoreUrls: [],
+            ignoreErrors: [],
+            sessionSampleRate: 100,
+            traceParentInHeader: ["enabled": true,
+                                  "options": ["allowedTracingUrls": ["https://allowed.com/path"]]],
+            debug: true
+        )
+        let coralogixRum = CoralogixRum(options: mockOptions)
+        let result = coralogixRum.shouldAddTraceParent(to: request, options: mockOptions)
+        XCTAssertTrue(result, "enabled: true (RN key) with matching allowedTracingUrls must return true")
+    }
+
+    /// When both "enable" and "enabled" are present, "enable" (checked first) wins.
+    func testTraceParent_EnableKeyTakesPrecedenceOverEnabledKey() {
+        let request = URLRequest(url: URL(string: "https://example.com")!)
+        let mockOptions = CoralogixExporterOptions(
+            coralogixDomain: .US2,
+            userContext: nil,
+            environment: "PROD",
+            application: "TestApp-iOS",
+            version: "1.0",
+            publicKey: "token",
+            ignoreUrls: [],
+            ignoreErrors: [],
+            sessionSampleRate: 100,
+            traceParentInHeader: ["enable": true, "enabled": false],
+            debug: true
+        )
+        let coralogixRum = CoralogixRum(options: mockOptions)
+        let result = coralogixRum.shouldAddTraceParent(to: request, options: mockOptions)
+        XCTAssertTrue(result, "\"enable\" key must take precedence when both keys are present")
+    }
+
     func testSetView() {
         let mockOptions = CoralogixExporterOptions(
             coralogixDomain: .US2,

--- a/Tests/CoralogixRumTests/NetworkCaptureRuleTests.swift
+++ b/Tests/CoralogixRumTests/NetworkCaptureRuleTests.swift
@@ -133,18 +133,78 @@ final class NetworkCaptureRuleTests: XCTestCase {
         XCTAssertNil(result)
     }
 
-    func testResolveConfigForUrl_firstMatchWins_returnsFirstMatchingRule() {
-        let firstRule  = NetworkCaptureRule(url: "example.com", reqHeaders: ["X-First"])
-        let secondRule = NetworkCaptureRule(url: "example.com", reqHeaders: ["X-Second"])
-        let result = resolveConfigForUrl("https://api.example.com/users", configs: [firstRule, secondRule])
-        XCTAssertEqual(result?.reqHeaders, ["X-First"],
-                       "First matching rule should win; second rule must not be returned")
-    }
-
-    func testResolveConfigForUrl_firstMatchWins_nonMatchingRuleBeforeMatchingRule() throws {
+    func testResolveConfigForUrl_nonMatchingRuleBeforeMatchingRule_returnsMatchingRule() throws {
         let nonMatching = NetworkCaptureRule(url: "other.com")
         let matching    = NetworkCaptureRule(url: "example.com", collectReqPayload: true)
         let result = try XCTUnwrap(resolveConfigForUrl("https://api.example.com/users", configs: [nonMatching, matching]))
+        XCTAssertTrue(result.collectReqPayload)
+    }
+
+    // MARK: - resolveConfigForUrl — merge semantics (multiple matching rules)
+
+    func testResolveConfigForUrl_multipleMatchingRules_mergesReqHeaders() {
+        let broadRule    = NetworkCaptureRule(url: "example.com",   reqHeaders: ["Content-Type", "Accept"])
+        let specificRule = NetworkCaptureRule(url: "example.com/v2", reqHeaders: ["traceparent", "X-Custom"])
+        let result = resolveConfigForUrl("https://api.example.com/v2/items", configs: [broadRule, specificRule])
+        let merged = Set(result?.reqHeaders ?? [])
+        XCTAssertEqual(merged, ["Content-Type", "Accept", "traceparent", "X-Custom"],
+                       "reqHeaders from all matching rules must be unioned")
+    }
+
+    func testResolveConfigForUrl_multipleMatchingRules_mergesResHeaders() {
+        let ruleA = NetworkCaptureRule(url: "example.com", resHeaders: ["Content-Type"])
+        let ruleB = NetworkCaptureRule(url: "example.com", resHeaders: ["X-Request-Id"])
+        let result = resolveConfigForUrl("https://api.example.com/data", configs: [ruleA, ruleB])
+        let merged = Set(result?.resHeaders ?? [])
+        XCTAssertEqual(merged, ["Content-Type", "X-Request-Id"])
+    }
+
+    func testResolveConfigForUrl_multipleMatchingRules_collectPayloadTrueIfAnyRuleEnablesIt() {
+        let noPayload  = NetworkCaptureRule(url: "example.com",   collectResPayload: false)
+        let hasPayload = NetworkCaptureRule(url: "example.com/v2", collectResPayload: true)
+        let result = resolveConfigForUrl("https://api.example.com/v2/items", configs: [noPayload, hasPayload])
+        XCTAssertTrue(result?.collectResPayload == true,
+                      "collectResPayload must be true when any matching rule enables it")
+    }
+
+    func testResolveConfigForUrl_multipleMatchingRules_collectPayloadFalseWhenNoRuleEnablesIt() {
+        let ruleA = NetworkCaptureRule(url: "example.com",   collectResPayload: false)
+        let ruleB = NetworkCaptureRule(url: "example.com/v2", collectResPayload: false)
+        let result = resolveConfigForUrl("https://api.example.com/v2/items", configs: [ruleA, ruleB])
+        XCTAssertFalse(result?.collectResPayload == true)
+    }
+
+    func testResolveConfigForUrl_multipleMatchingRules_allNilReqHeaders_mergedIsNil() {
+        let ruleA = NetworkCaptureRule(url: "example.com")   // reqHeaders: nil
+        let ruleB = NetworkCaptureRule(url: "example.com/v2") // reqHeaders: nil
+        let result = resolveConfigForUrl("https://api.example.com/v2/items", configs: [ruleA, ruleB])
+        XCTAssertNil(result?.reqHeaders,
+                     "Merged reqHeaders must be nil when all matching rules have nil reqHeaders")
+    }
+
+    /// Regression: broad rule (no traceparent) + specific rule (with traceparent) — merged allowlist must include traceparent.
+    /// This is the RN hybrid scenario: Rule 1 matches the host broadly, Rule 5 matches the specific path and adds traceparent.
+    func testResolveConfigForUrl_broadAndSpecificRule_traceparentIncludedInMergedAllowlist() {
+        let broadRule    = NetworkCaptureRule(url: "jsonplaceholder.typicode.com",
+                                             reqHeaders: ["content-type", "accept"],
+                                             collectResPayload: true)
+        let specificRule = NetworkCaptureRule(url: "jsonplaceholder.typicode.com/posts/1",
+                                             reqHeaders: ["accept", "traceparent"],
+                                             collectResPayload: false)
+        let result = resolveConfigForUrl("https://jsonplaceholder.typicode.com/posts/1", configs: [broadRule, specificRule])
+        let merged = Set(result?.reqHeaders ?? [])
+        XCTAssertTrue(merged.contains("traceparent"),
+                      "traceparent must appear in the merged allowlist even if only the specific rule lists it")
+        XCTAssertTrue(result?.collectResPayload == true,
+                      "collectResPayload must be true because the broad rule enables it")
+    }
+
+    func testResolveConfigForUrl_singleMatchingRule_returnedUnchanged() throws {
+        let rule = NetworkCaptureRule(url: "example.com",
+                                     reqHeaders: ["Authorization"],
+                                     collectReqPayload: true)
+        let result = try XCTUnwrap(resolveConfigForUrl("https://api.example.com/users", configs: [rule]))
+        XCTAssertEqual(result.reqHeaders, ["Authorization"])
         XCTAssertTrue(result.collectReqPayload)
     }
 


### PR DESCRIPTION
# User description
## Summary

- **Native headers (traceparent) missing in hybrid span**: `dataTask(with:)` (no-completion-handler factory) injected traceparent into the request but never stored it — fixed by calling `storeRequest` in `bridgedArgumentForFactory`. Added a `nativeRequestHeadersByUrl` URL-keyed store that survives `requestMap` cleanup so `reportHybridNetworkRequest` can look up native headers when building the hybrid span.
- **Resume path overwrote factory-stored request**: `urlSessionTaskWillResume` unconditionally overwrote `requestMap[taskId]` with `task.currentRequest` (normalized, headers stripped) — fixed to only write if not already populated by the factory path.
- **`"enable"` vs `"enabled"` key mismatch**: `TraceParentInHeader` read `params["enable"]` but the React Native bridge sends `params["enabled"]`, causing traceparent injection to always be disabled in RN hybrid flows — fixed to accept both keys.
- **First-match-wins rule resolution dropped headers from overlapping rules**: `resolveConfigForUrl` returned only the first matching rule, so a broad rule (matching the host) silently beat a specific rule (matching the full path) that had `traceparent` in `reqHeaders` — changed to merge all matching rules (union headers, OR booleans).
- **`injectHeadersIntoTask` Scenario A silently no-ops on real devices**: `task.currentRequest` always returns a copy; mutating `NSMutableURLRequest` in-place does not affect what the task sends. On real devices the copy comes back as `NSMutableURLRequest` so the early return was hit, skipping `setCurrentRequest:` entirely — removed Scenario A, always go through `setCurrentRequest:`.

## Test plan

- [ ] New `NetworkCaptureRuleTests` cases covering merge semantics and the traceparent-in-merged-allowlist regression
- [ ] New `CoralogixRumTests` cases for `"enabled"` key and key precedence in `TraceParentInHeader`
- [ ] All 81 tests pass (0 failures)
- [ ] Verify on real device: traceparent appears in `request_headers` in `network_request_context` for RN hybrid fetch requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Unify the RN/Flutter hybrid network instrumentation so <code>URLSessionInstrumentation</code>, <code>URLSessionLogger</code>, and <code>NetworkInstrumentation</code> retain injected <code>traceparent</code> headers, always push native header updates via <code>setCurrentRequest:</code>, and honor both <code>enable</code> and <code>enabled</code> keys that configure <code>TraceParentInHeader</code>. Align the rule-resolution path by merging matching <code>NetworkCaptureRule</code> entries and adding regression tests while bumping the Coralogix, SessionReplay, and CoralogixInternal pods (and embedded <code>Global.sdk</code>) to 2.4.1 for this behavior rollout.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/178?tool=ast&topic=Hybrid+header+capture>Hybrid header capture</a>
        </td><td>Enable hybrid spans to read injected <code>traceparent</code> data by persisting native headers in <code>URLSessionInstrumentation</code>, re-indexing them after redirects (<code>URLSessionLogger</code>), and merging them with JS-visible headers in <code>NetworkInstrumentation</code> before attribute capture while also accepting RN’s <code>enabled</code> key for traceparent toggling and covering the regression in <code>CoralogixRumTests</code>.<details><summary>Modified files (5)</summary><ul><li>Coralogix/Sources/Instrumentation/NetworkInstrumentation.swift</li>
<li>Coralogix/Sources/Model/TraceParentInHeader.swift</li>
<li>Coralogix/Sources/Otel/URLSession/URLSessionInstrumentation.swift</li>
<li>Coralogix/Sources/Otel/URLSession/URLSessionLogger.swift</li>
<li>Tests/CoralogixRumTests/CoralogixRumTests.swift</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>fix: forward request/r...</td><td>March 22, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/178?tool=ast&topic=Rule+merge+logic>Rule merge logic</a>
        </td><td>Merge overlapping <code>NetworkCaptureRule</code> matches so allowlists accumulate (<code>reqHeaders</code>/<code>resHeaders</code>) and payload flags OR together, and codify the new semantics plus merged-rule regressions in <code>NetworkCaptureRuleTests</code>.<details><summary>Modified files (2)</summary><ul><li>Coralogix/Sources/Utils/NetworkCaptureRule.swift</li>
<li>Tests/CoralogixRumTests/NetworkCaptureRuleTests.swift</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>BUGV2-5379: Fix before...</td><td>March 17, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/178?tool=ast&topic=Release+alignment>Release alignment</a>
        </td><td>Align all Coralogix-related podspecs and the internal <code>Global.sdk</code> constant to <code>2.4.1</code>, ensuring the bundled SessionReplay and SDK targets depend on the matching internal package release that contains these behavioral fixes.<details><summary>Modified files (4)</summary><ul><li>Coralogix.podspec</li>
<li>CoralogixInternal.podspec</li>
<li>CoralogixInternal/Sources/Utils.swift</li>
<li>SessionReplay.podspec</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>feat: Flutter obfuscat...</td><td>March 26, 2026</td></tr>
<tr><td>NatanCoralogix</td><td>bump crash reporter (#...</td><td>September 01, 2025</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/coralogix/cx-ios-sdk/178?tool=ast>(Baz)</a>.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Native header caching and redirect-aware header reindexing for more accurate HTTP redirect tracking.
  * Per-URL capture rules now merge across multiple matches, combining header allowlists and payload collection flags.

* **Bug Fixes**
  * Smarter request/response header capture that merges native and JS-visible headers and applies configured filters.

* **Tests**
  * Added tests covering trace-parent config key variants and merged rule behavior.

* **Chores**
  * Version bumps to 2.4.1 across pods and internal SDK identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->