### PR TITLE
fix: use pod trunk info instead of pod search for availability check

### DIFF
--- a/.github/workflows/publish-pods.yml
+++ b/.github/workflows/publish-pods.yml
@@ -86,7 +86,9 @@ jobs:
                 sleep 30
                 elapsed=$((elapsed + 30))
               done
-              echo "✅ CoralogixInternal is now available!"
+              echo "✅ CoralogixInternal is now available on trunk. Updating local CDN cache..."
+              pod repo update
+              echo "✅ Local CDN cache updated."
             else
               if echo "$push_output" | grep -q "Unable to accept duplicate entry"; then
                 echo "⚠️ Duplicate entry detected for CoralogixInternal, skipping to next phase..."

--- a/.github/workflows/publish-pods.yml
+++ b/.github/workflows/publish-pods.yml
@@ -77,7 +77,7 @@ jobs:
               echo "⏳ Waiting for CoralogixInternal to be available in CocoaPods Specs..."
               timeout=1800
               elapsed=0
-              until pod search CoralogixInternal | grep -q "CoralogixInternal"; do
+              until pod trunk info CoralogixInternal | grep -q "${TAG_RAW}"; do
                 if [ "$elapsed" -ge "$timeout" ]; then
                   echo "❌ Timeout: CoralogixInternal not available after $timeout seconds."
                   exit 1

--- a/lint_and_push_cocoapods.sh
+++ b/lint_and_push_cocoapods.sh
@@ -38,13 +38,18 @@ if [[ "$push_internal" =~ ^[Yy]$ ]]; then
   if [ $push_exit_code -eq 0 ]; then
     echo "✅ $INTERNAL pushed!"
     
-    # Wait for CoralogixInternal to become available
-    echo "⏳ Waiting for $INTERNAL to be available in CocoaPods Specs..."
-    until pod search CoralogixInternal | grep -q "CoralogixInternal"; do
-      echo "⏳ $INTERNAL not yet available, waiting 30 seconds..."
+    # Wait for CoralogixInternal to be visible on trunk, then refresh local CDN cache.
+    # pod trunk info queries trunk directly (authoritative); pod repo update syncs
+    # the local CDN cache so dependent podspecs can resolve the new version during validation.
+    VERSION=$(grep "spec.version" "$INTERNAL" | head -1 | sed "s/.*'\(.*\)'.*/\1/")
+    echo "⏳ Waiting for $INTERNAL $VERSION to appear on trunk..."
+    until pod trunk info CoralogixInternal | grep -q "$VERSION"; do
+      echo "⏳ $INTERNAL $VERSION not yet on trunk, waiting 30 seconds..."
       sleep 30
     done
-    echo "✅ $INTERNAL is now available!"
+    echo "✅ $INTERNAL $VERSION is on trunk. Updating local CDN cache..."
+    pod repo update
+    echo "✅ Local CDN cache updated."
   else
     if echo "$push_output" | grep -q "Unable to accept duplicate entry"; then
       echo "⚠️ Duplicate entry detected for $INTERNAL, skipping to next phase..."


### PR DESCRIPTION
# User description
## Summary

- `pod search` queries the local CocoaPods spec cache, which can lag behind trunk by hours — causing the wait loop to spin indefinitely even after the pod is already published on trunk
- Replace with `pod trunk info CoralogixInternal | grep -q "${TAG_RAW}"` which queries trunk directly, the same source that `pod trunk info` uses manually

## Test plan
- [ ] Trigger a release and confirm the publish step no longer hangs after CoralogixInternal is visible on trunk

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Use <code>pod trunk info</code> in the publish workflow to detect whether <code>CoralogixInternal</code> is on trunk, skip redundant pushes, and refresh the CDN cache after the published version appears. Ensure the helper push script mirrors the trunk-based availability checks and cache refresh so manual releases see the same behavior.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/179?tool=ast&topic=Push+helper+script>Push helper script</a>
        </td><td>Align <code>lint_and_push_cocoapods.sh</code> with the trunk-based availability check by parsing the version, waiting until <code>pod trunk info CoralogixInternal</code> reports it, and updating the CDN cache before finishing.<details><summary>Modified files (1)</summary><ul><li>lint_and_push_cocoapods.sh</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>fix update podspec scr...</td><td>January 05, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/179?tool=ast&topic=Publish+workflow>Publish workflow</a>
        </td><td>Use trunk info polling in the publish workflow to detect the new <code>CoralogixInternal</code> tag, skip pushing when it already exists, and refresh the local CDN cache once trunk reports the version.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/publish-pods.yml</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>Span Hashable, SDK 2.3...</td><td>March 22, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/coralogix/cx-ios-sdk/179?tool=ast>(Baz)</a>.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release verification to wait for the exact published version to appear.
  * Added a local package index refresh after detection so new releases resolve immediately.
  * Enhanced log messages to clearly reflect version detection and cache refresh progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->