### PR TITLE
Add US3 region support to CoralogixDomain

### DIFF
--- a/Coralogix/Docs/CoralogixDomain.md
+++ b/Coralogix/Docs/CoralogixDomain.md
@@ -28,6 +28,12 @@ case US2 = "https://ingress.us2.rum-ingress-coralogix.com"
 ```
 Represents the US2 region (us-west-2, Oregon).
 
+### US3
+```swift
+case US3 = "https://ingress.us3.rum-ingress-coralogix.com"
+```
+Represents the US3 region.
+
 ### AP1
 ```swift
 case AP1 = "https://ingress.ap1.rum-ingress-coralogix.com"

--- a/CoralogixInternal/Sources/Utils.swift
+++ b/CoralogixInternal/Sources/Utils.swift
@@ -305,6 +305,7 @@ public enum CoralogixDomain: String {
     case EU2 = "https://ingress.eu2.rum-ingress-coralogix.com" // eu-north-1 (Stockholm)
     case US1 = "https://ingress.us1.rum-ingress-coralogix.com" // us-east-2 (Ohio)
     case US2 = "https://ingress.us2.rum-ingress-coralogix.com" // us-west-2 (Oregon)
+    case US3 = "https://ingress.us3.rum-ingress-coralogix.com"
     case AP1 = "https://ingress.ap1.rum-ingress-coralogix.com" // ap-south-1 (Mumbai)
     case AP2 = "https://ingress.ap2.rum-ingress-coralogix.com" // ap-southeast-1 (Singapore)
     case AP3 = "https://ingress.ap3.rum-ingress-coralogix.com" // ap-southeast-3 (Jakarta)
@@ -320,6 +321,8 @@ public enum CoralogixDomain: String {
             return "US1"
         case .US2:
             return "US2"
+        case .US3:
+            return "US3"
         case .AP1:
             return "AP1"
         case .AP2:


### PR DESCRIPTION
## Summary
This PR adds support for the US3 region to the Coralogix domain configuration, enabling RUM ingestion for the new US3 region endpoint.

## Key Changes
- Added `US3` case to the `CoralogixDomain` enum with the ingress endpoint `https://ingress.us3.rum-ingress-coralogix.com`
- Updated the `domainName` computed property to return `"US3"` for the new region case
- Updated documentation to include US3 region details

## Implementation Details
- The US3 region follows the same pattern as existing US regions (US1, US2)
- The endpoint URL follows the standard Coralogix RUM ingress naming convention
- Both the source code (`Utils.swift`) and documentation (`CoralogixDomain.md`) have been updated to maintain consistency

https://claude.ai/code/session_01YacPfvmvpAHtCvAXov1hm8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for US3 region with ingress endpoint configuration.

* **Documentation**
  * Updated region documentation to include US3 region details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->