### PR TITLE
CX-35951: Custom Spans API, OTel context, and RUM/Tracing parity (Browser)

### DIFF
--- a/Coralogix/Docs/CORALOGIX_RUM.md
+++ b/Coralogix/Docs/CORALOGIX_RUM.md
@@ -308,6 +308,34 @@ coralogixIntegration.log(severity: .error, message: "A critical error occurred",
 coralogixIntegration.shutdown()
 ```
 
+## Custom spans (manual tracing)
+
+The Custom Spans API mirrors the Coralogix Browser SDK naming (`startCustomSpan`, `endSpan`, not `startChildSpan` / `end`).
+
+### Types
+
+- `CoralogixIgnoredInstrument` — `.networkRequests`, `.userInteractions`, `.errors` (values are reserved for future behavior when combining auto-instrumentation with custom traces).
+- `CoralogixCustomTracer` — from `getCustomTracer(ignoredInstruments:)`.
+- `CoralogixGlobalSpan` — root span from `startGlobalSpan(name:labels:)`; exposes `span`, `withContext(_:)`, `startCustomSpan(name:labels:)`, `endSpan()`.
+- `CoralogixCustomSpan` — nested span; exposes `span`, `endSpan()`, `setAttribute`, `addEvent`, `setStatus`.
+
+### Example
+
+```swift
+let tracer = coralogixRum.getCustomTracer(ignoredInstruments: [.networkRequests])
+guard let global = tracer.startGlobalSpan(name: "checkout", labels: ["step": "payment"]) else { return }
+
+global.withContext {
+    let child = global.startCustomSpan(name: "authorize")
+    child.setAttribute(key: "result", value: "ok")
+    child.endSpan()
+}
+
+global.endSpan()
+```
+
+`startGlobalSpan` returns `nil` if the SDK did not finish initialization (for example, sampling disabled the SDK).
+
 ## About Method Swizzling and SwiftUI Modifiers
 ### Method Swizzling
 Method swizzling is a technique used in Objective-C and Swift that allows the changing of the implementation of an existing selector at runtime. This can be used to inject custom behavior into existing methods without altering the original code. However, method swizzling can lead to maintenance challenges and unpredictable behavior, especially with system APIs.

--- a/Coralogix/Docs/CORALOGIX_RUM.md
+++ b/Coralogix/Docs/CORALOGIX_RUM.md
@@ -316,6 +316,8 @@ Only **one** global custom span may exist at a time (same as the Browser SDK). `
 
 **Label merge (CX-35953, Browser parity):** Labels from `CoralogixRum` init / `setLabels` (SDK level), then `startGlobalSpan(name:labels:)`, then `startCustomSpan(name:labels:)`—each step overrides the same key from the previous. The merged map is stored on the span as a JSON string attribute **`custom_labels`**, same as the Browser SDK’s `setCustomLabelsForSpan` / `getCustomMergedLabels`. RUM `text.cx_rum.labels` is built from SDK options merged with that attribute (see `Helper.getLabels`).
 
+**Tracing:** Each exported custom-span log also includes **`instrumentation_data`** with **`otelSpan`** (name, trace/span/parent ids, times, attributes), matching the Browser SDK path used by `buildExporterPayload` / `tracesExporter` so the event can appear in Coralogix **Tracing**, not only RUM Logs.
+
 ### Types
 
 - `CoralogixIgnoredInstrument` — `.networkRequests`, `.userInteractions`, `.errors` (values are reserved for future behavior when combining auto-instrumentation with custom traces).

--- a/Coralogix/Docs/CORALOGIX_RUM.md
+++ b/Coralogix/Docs/CORALOGIX_RUM.md
@@ -312,6 +312,8 @@ coralogixIntegration.shutdown()
 
 The Custom Spans API mirrors the Coralogix Browser SDK naming (`startCustomSpan`, `endSpan`, not `startChildSpan` / `end`). Exported RUM matches the browser: `event_context.type` is **`custom-span`**, with **`source`** `code` and **info** severity (unless you override attributes on the underlying OTel span).
 
+Only **one** global custom span may exist at a time (same as the Browser SDK). `startGlobalSpan` registers it as the **active OpenTelemetry span**, so auto-instrumented spans and network propagation can share the same `traceId` until `endSpan()` (which restores the prior active context). `withContext` is a no-op when the global span is already active. `shutdown()` clears a leaked global registration.
+
 ### Types
 
 - `CoralogixIgnoredInstrument` — `.networkRequests`, `.userInteractions`, `.errors` (values are reserved for future behavior when combining auto-instrumentation with custom traces).

--- a/Coralogix/Docs/CORALOGIX_RUM.md
+++ b/Coralogix/Docs/CORALOGIX_RUM.md
@@ -316,7 +316,7 @@ Only **one** global custom span may exist at a time (same as the Browser SDK). `
 
 **Label merge (CX-35953, Browser parity):** Labels from `CoralogixRum` init / `setLabels` (SDK level), then `startGlobalSpan(name:labels:)`, then `startCustomSpan(name:labels:)`—each step overrides the same key from the previous. The merged map is stored on the span as a JSON string attribute **`custom_labels`**, same as the Browser SDK’s `setCustomLabelsForSpan` / `getCustomMergedLabels`. RUM `text.cx_rum.labels` is built from SDK options merged with that attribute (see `Helper.getLabels`).
 
-**Tracing:** Each exported custom-span log also includes **`instrumentation_data`** with **`otelSpan`** (name, trace/span/parent ids, times, attributes), matching the Browser SDK path used by `buildExporterPayload` / `tracesExporter` so the event can appear in Coralogix **Tracing**, not only RUM Logs.
+**Tracing:** Each exported custom-span log includes **`instrumentation_data.otelSpan`** with mobile fields plus **OTLP-style mirrors** used by the Browser trace converter (`trace_id`, `span_id`, `parent_span_id`, `start_time_unix_nano`, `end_time_unix_nano`, `kind_string`, `status_otlp`). The Browser SDK also sends a **separate** OTLP payload via optional `tracesExporter`; iOS only uses the RUM logs endpoint. If spans still do not appear under **Tracing**, confirm with Coralogix that your account indexes `instrumentation_data` from **mobile** RUM (pipeline may differ from web).
 
 ### Types
 

--- a/Coralogix/Docs/CORALOGIX_RUM.md
+++ b/Coralogix/Docs/CORALOGIX_RUM.md
@@ -310,7 +310,7 @@ coralogixIntegration.shutdown()
 
 ## Custom spans (manual tracing)
 
-The Custom Spans API mirrors the Coralogix Browser SDK naming (`startCustomSpan`, `endSpan`, not `startChildSpan` / `end`). Exported RUM matches the browser: `event_context.type` is **`custom-span`**, with **`source`** `code` and **info** severity (unless you override attributes on the underlying OTel span).
+The Custom Spans API mirrors the Coralogix Browser SDK naming (`startCustomSpan`, `endSpan`, not `startChildSpan` / `end`). Exported RUM matches the browser: `event_context.type` is **`custom-span`**, with **`source`** `code` and **info** severity (unless you override attributes on the underlying OTel span). Nested spans receive the same session and user metadata as the global span so each ended span can be encoded for RUM export.
 
 Only **one** global custom span may exist at a time (same as the Browser SDK). `startGlobalSpan` registers it as the **active OpenTelemetry span**, so auto-instrumented spans and network propagation can share the same `traceId` until `endSpan()` (which restores the prior active context). `withContext` is a no-op when the global span is already active. `shutdown()` clears a leaked global registration.
 

--- a/Coralogix/Docs/CORALOGIX_RUM.md
+++ b/Coralogix/Docs/CORALOGIX_RUM.md
@@ -314,6 +314,8 @@ The Custom Spans API mirrors the Coralogix Browser SDK naming (`startCustomSpan`
 
 Only **one** global custom span may exist at a time (same as the Browser SDK). `startGlobalSpan` registers it as the **active OpenTelemetry span**, so auto-instrumented spans and network propagation can share the same `traceId` until `endSpan()` (which restores the prior active context). `withContext` is a no-op when the global span is already active. `shutdown()` clears a leaked global registration.
 
+**Label merge (CX-35953, Browser parity):** Labels from `CoralogixRum` init / `setLabels` (SDK level), then `startGlobalSpan(name:labels:)`, then `startCustomSpan(name:labels:)`—each step overrides the same key from the previous. The merged map is stored on the span as a JSON string attribute **`custom_labels`**, same as the Browser SDK’s `setCustomLabelsForSpan` / `getCustomMergedLabels`. RUM `text.cx_rum.labels` is built from SDK options merged with that attribute (see `Helper.getLabels`).
+
 ### Types
 
 - `CoralogixIgnoredInstrument` — `.networkRequests`, `.userInteractions`, `.errors` (values are reserved for future behavior when combining auto-instrumentation with custom traces).

--- a/Coralogix/Docs/CORALOGIX_RUM.md
+++ b/Coralogix/Docs/CORALOGIX_RUM.md
@@ -310,7 +310,7 @@ coralogixIntegration.shutdown()
 
 ## Custom spans (manual tracing)
 
-The Custom Spans API mirrors the Coralogix Browser SDK naming (`startCustomSpan`, `endSpan`, not `startChildSpan` / `end`).
+The Custom Spans API mirrors the Coralogix Browser SDK naming (`startCustomSpan`, `endSpan`, not `startChildSpan` / `end`). Exported RUM matches the browser: `event_context.type` is **`custom-span`**, with **`source`** `code` and **info** severity (unless you override attributes on the underlying OTel span).
 
 ### Types
 

--- a/Coralogix/Sources/CoralogixCustomSpans.swift
+++ b/Coralogix/Sources/CoralogixCustomSpans.swift
@@ -130,7 +130,7 @@ public final class CoralogixCustomTracer {
         let mergedSdkAndGlobal = mergingCustomLabelLayer(into: sdkLabels, labels)
         var otelSpan = tracer.spanBuilder(spanName: name).setNoParent().startSpan()
         stampCoralogixCustomSpanRUM(on: &otelSpan)
-        rum.enrichCustomSpanMetadata(to: &otelSpan)
+        rum.addRumCorrelationMetadata(to: &otelSpan)
         setMergedCustomLabelsJSON(merged: mergedSdkAndGlobal, on: &otelSpan)
         guard CoralogixCustomGlobalSpanRegistry.shared.registerGlobalSpan(otelSpan) else {
             Log.w("Global custom span already active — startGlobalSpan ignored; ending orphan span")
@@ -199,7 +199,7 @@ public final class CoralogixGlobalSpan {
         let mergedAllLevels = mergingCustomLabelLayer(into: mergedSdkAndGlobalLabels, labels)
         var child = baseBuilder.startSpan()
         stampCoralogixCustomSpanRUM(on: &child)
-        rum?.enrichCustomSpanMetadata(to: &child)
+        rum?.addRumCorrelationMetadata(to: &child)
         setMergedCustomLabelsJSON(merged: mergedAllLevels, on: &child)
         return CoralogixCustomSpan(span: child)
     }

--- a/Coralogix/Sources/CoralogixCustomSpans.swift
+++ b/Coralogix/Sources/CoralogixCustomSpans.swift
@@ -78,13 +78,27 @@ private func stampCoralogixCustomSpanRUM(on span: inout any Span) {
     span.setAttribute(key: Keys.severity.rawValue, value: AttributeValue.int(CoralogixLogSeverity.info.rawValue))
 }
 
-private func spanBuilderWithLabels(_ builder: any SpanBuilder, labels: [String: String]?) -> any SpanBuilder {
-    guard let labels else { return builder }
-    var b = builder
-    for (key, value) in labels {
-        b = b.setAttribute(key: key, value: value)
+// MARK: - Custom span labels (CX-35953, Browser `getCustomMergedLabels` / `setCustomLabelsForSpan`)
+
+/// Merge order: `base` (SDK-level `[String: Any]`) then `layer` (`[String: String]` wins on key collision).
+private func mergingCustomLabelLayer(into base: [String: Any], _ layer: [String: String]?) -> [String: Any] {
+    guard let layer, !layer.isEmpty else { return base }
+    var out = base
+    for (key, value) in layer {
+        out[key] = value
     }
-    return b
+    return out
+}
+
+/// Writes Browser-parity `custom_labels` JSON on the span for RUM (`Helper.getLabels` / Explorer).
+private func setMergedCustomLabelsJSON(merged: [String: Any], on span: inout any Span) {
+    guard !merged.isEmpty else { return }
+    let json = Helper.convertDictionayToJsonString(dict: merged)
+    guard !json.isEmpty else {
+        Log.w("Custom span labels could not be JSON-encoded — custom_labels attribute omitted")
+        return
+    }
+    span.setAttribute(key: Keys.customLabels.rawValue, value: json)
 }
 
 /// Auto-instrumentation categories that may be excluded from custom-tracer context behavior in future releases.
@@ -112,16 +126,23 @@ public final class CoralogixCustomTracer {
             return nil
         }
         let tracer = rum.tracerProvider()
-        let builder = spanBuilderWithLabels(tracer.spanBuilder(spanName: name).setNoParent(), labels: labels)
-        var otelSpan = builder.startSpan()
+        let sdkLabels = rum.labels ?? [:]
+        let mergedSdkAndGlobal = mergingCustomLabelLayer(into: sdkLabels, labels)
+        var otelSpan = tracer.spanBuilder(spanName: name).setNoParent().startSpan()
         stampCoralogixCustomSpanRUM(on: &otelSpan)
         rum.enrichCustomSpanMetadata(to: &otelSpan)
+        setMergedCustomLabelsJSON(merged: mergedSdkAndGlobal, on: &otelSpan)
         guard CoralogixCustomGlobalSpanRegistry.shared.registerGlobalSpan(otelSpan) else {
             Log.w("Global custom span already active — startGlobalSpan ignored; ending orphan span")
             otelSpan.end()
             return nil
         }
-        return CoralogixGlobalSpan(span: otelSpan, tracer: tracer, rum: rum)
+        return CoralogixGlobalSpan(
+            span: otelSpan,
+            tracer: tracer,
+            rum: rum,
+            mergedSdkAndGlobalLabels: mergedSdkAndGlobal
+        )
     }
 }
 
@@ -130,11 +151,19 @@ public final class CoralogixGlobalSpan {
     public let span: any Span
     private let tracer: Tracer
     private weak var rum: CoralogixRum?
+    /// Snapshot of SDK ∪ global labels at `startGlobalSpan` time; child spans merge child keys on top (CX-35953).
+    private let mergedSdkAndGlobalLabels: [String: Any]
 
-    internal init(span: any Span, tracer: Tracer, rum: CoralogixRum) {
+    internal init(
+        span: any Span,
+        tracer: Tracer,
+        rum: CoralogixRum,
+        mergedSdkAndGlobalLabels: [String: Any]
+    ) {
         self.span = span
         self.tracer = tracer
         self.rum = rum
+        self.mergedSdkAndGlobalLabels = mergedSdkAndGlobalLabels
     }
 
     private func isRegisteredGlobalActiveInOTel() -> Bool {
@@ -167,10 +196,11 @@ public final class CoralogixGlobalSpan {
             Log.w("startCustomSpan: global span is not active; using explicit parent — prefer calling before endSpan()")
             baseBuilder = tracer.spanBuilder(spanName: name).setParent(span)
         }
-        let builder = spanBuilderWithLabels(baseBuilder, labels: labels)
-        var child = builder.startSpan()
+        let mergedAllLevels = mergingCustomLabelLayer(into: mergedSdkAndGlobalLabels, labels)
+        var child = baseBuilder.startSpan()
         stampCoralogixCustomSpanRUM(on: &child)
         rum?.enrichCustomSpanMetadata(to: &child)
+        setMergedCustomLabelsJSON(merged: mergedAllLevels, on: &child)
         return CoralogixCustomSpan(span: child)
     }
 

--- a/Coralogix/Sources/CoralogixCustomSpans.swift
+++ b/Coralogix/Sources/CoralogixCustomSpans.swift
@@ -121,7 +121,7 @@ public final class CoralogixCustomTracer {
             otelSpan.end()
             return nil
         }
-        return CoralogixGlobalSpan(span: otelSpan, tracer: tracer)
+        return CoralogixGlobalSpan(span: otelSpan, tracer: tracer, rum: rum)
     }
 }
 
@@ -129,10 +129,12 @@ public final class CoralogixCustomTracer {
 public final class CoralogixGlobalSpan {
     public let span: any Span
     private let tracer: Tracer
+    private weak var rum: CoralogixRum?
 
-    internal init(span: any Span, tracer: Tracer) {
+    internal init(span: any Span, tracer: Tracer, rum: CoralogixRum) {
         self.span = span
         self.tracer = tracer
+        self.rum = rum
     }
 
     private func isRegisteredGlobalActiveInOTel() -> Bool {
@@ -168,6 +170,7 @@ public final class CoralogixGlobalSpan {
         let builder = spanBuilderWithLabels(baseBuilder, labels: labels)
         var child = builder.startSpan()
         stampCoralogixCustomSpanRUM(on: &child)
+        rum?.enrichCustomSpanMetadata(to: &child)
         return CoralogixCustomSpan(span: child)
     }
 

--- a/Coralogix/Sources/CoralogixCustomSpans.swift
+++ b/Coralogix/Sources/CoralogixCustomSpans.swift
@@ -8,11 +8,83 @@
 import Foundation
 import CoralogixInternal
 
+// MARK: - Global span registry (CX-35952, Browser `window.__globalSpan__` equivalent)
+
+/// Process-wide active custom global span and the OTel context to restore after `endSpan()`.
+final class CoralogixCustomGlobalSpanRegistry {
+    static let shared = CoralogixCustomGlobalSpanRegistry()
+
+    private let lock = NSLock()
+    private weak var registeredGlobal: (any Span)?
+    private weak var spanActiveBeforeGlobal: (any Span)?
+
+    private init() {}
+
+    /// Ends the span and re-activates the OTel context from before `startGlobalSpan()` (single implementation for `endSpan` / `shutdown` / tests).
+    private static func endGlobalSpanAndRestorePrevious(_ span: any Span, previous: (any Span)?) {
+        span.end()
+        if let previous {
+            OpenTelemetry.instance.contextProvider.setActiveSpan(previous)
+        }
+    }
+
+    /// Returns `false` if a global custom span is already registered (second `startGlobalSpan` is ignored, like the Browser SDK).
+    func registerGlobalSpan(_ span: any Span) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        if registeredGlobal != nil {
+            return false
+        }
+        spanActiveBeforeGlobal = OpenTelemetry.instance.contextProvider.activeSpan
+        registeredGlobal = span
+        OpenTelemetry.instance.contextProvider.setActiveSpan(span)
+        return true
+    }
+
+    /// Ends the registry entry for this span: clears state, ends the span, restores previous active context. Returns `false` if `span` is not the registered global.
+    func endGlobalSpanIfMatches(_ span: any Span) -> Bool {
+        lock.lock()
+        let isMatch = (registeredGlobal as AnyObject?) === (span as AnyObject)
+        let previous = spanActiveBeforeGlobal
+        if isMatch {
+            registeredGlobal = nil
+            spanActiveBeforeGlobal = nil
+        }
+        lock.unlock()
+        guard isMatch else {
+            return false
+        }
+        Self.endGlobalSpanAndRestorePrevious(span, previous: previous)
+        return true
+    }
+
+    /// Clears any registered global custom span (`shutdown` and unit tests). Ends the span if still active and restores the pre-global OTel context.
+    internal func teardownIfNeeded() {
+        lock.lock()
+        let g = registeredGlobal
+        let previous = spanActiveBeforeGlobal
+        registeredGlobal = nil
+        spanActiveBeforeGlobal = nil
+        lock.unlock()
+        guard let g else { return }
+        Self.endGlobalSpanAndRestorePrevious(g, previous: previous)
+    }
+}
+
 /// Browser SDK sets `EVENT_TYPE` to `custom-span` on global and nested custom spans (`coralogix-rum.ts`).
 private func stampCoralogixCustomSpanRUM(on span: inout any Span) {
     span.setAttribute(key: Keys.eventType.rawValue, value: CoralogixEventType.customSpan.rawValue)
     span.setAttribute(key: Keys.source.rawValue, value: Keys.code.rawValue)
     span.setAttribute(key: Keys.severity.rawValue, value: AttributeValue.int(CoralogixLogSeverity.info.rawValue))
+}
+
+private func spanBuilderWithLabels(_ builder: any SpanBuilder, labels: [String: String]?) -> any SpanBuilder {
+    guard let labels else { return builder }
+    var b = builder
+    for (key, value) in labels {
+        b = b.setAttribute(key: key, value: value)
+    }
+    return b
 }
 
 /// Auto-instrumentation categories that may be excluded from custom-tracer context behavior in future releases.
@@ -40,15 +112,15 @@ public final class CoralogixCustomTracer {
             return nil
         }
         let tracer = rum.tracerProvider()
-        var builder = tracer.spanBuilder(spanName: name).setNoParent()
-        if let labels {
-            for (key, value) in labels {
-                builder = builder.setAttribute(key: key, value: value)
-            }
-        }
+        let builder = spanBuilderWithLabels(tracer.spanBuilder(spanName: name).setNoParent(), labels: labels)
         var otelSpan = builder.startSpan()
         stampCoralogixCustomSpanRUM(on: &otelSpan)
         rum.enrichCustomSpanMetadata(to: &otelSpan)
+        guard CoralogixCustomGlobalSpanRegistry.shared.registerGlobalSpan(otelSpan) else {
+            Log.w("Global custom span already active — startGlobalSpan ignored; ending orphan span")
+            otelSpan.end()
+            return nil
+        }
         return CoralogixGlobalSpan(span: otelSpan, tracer: tracer)
     }
 }
@@ -63,8 +135,16 @@ public final class CoralogixGlobalSpan {
         self.tracer = tracer
     }
 
-    /// Runs `work` with this span installed as the active span for OpenTelemetry context (e.g. outbound trace propagation).
+    private func isRegisteredGlobalActiveInOTel() -> Bool {
+        let active = OpenTelemetry.instance.contextProvider.activeSpan
+        return (active as AnyObject?) === (span as AnyObject)
+    }
+
+    /// Runs `work` with this span as the active OTel context. If it is already active (after `startGlobalSpan`), runs `work` without removing it from context.
     public func withContext<R>(_ work: () throws -> R) rethrows -> R {
+        if isRegisteredGlobalActiveInOTel() {
+            return try work()
+        }
         let previous = OpenTelemetry.instance.contextProvider.activeSpan
         OpenTelemetry.instance.contextProvider.setActiveSpan(span)
         defer {
@@ -76,21 +156,27 @@ public final class CoralogixGlobalSpan {
         return try work()
     }
 
-    /// Starts a child span of this global span.
+    /// Starts a child span while the global span is the OTel active span (same trace/parent as Browser `context.with(global, …)`).
     public func startCustomSpan(name: String, labels: [String: String]? = nil) -> CoralogixCustomSpan {
-        var builder = tracer.spanBuilder(spanName: name).setParent(span)
-        if let labels {
-            for (key, value) in labels {
-                builder = builder.setAttribute(key: key, value: value)
-            }
+        let baseBuilder: any SpanBuilder
+        if isRegisteredGlobalActiveInOTel() {
+            baseBuilder = tracer.spanBuilder(spanName: name)
+        } else {
+            Log.w("startCustomSpan: global span is not active; using explicit parent — prefer calling before endSpan()")
+            baseBuilder = tracer.spanBuilder(spanName: name).setParent(span)
         }
+        let builder = spanBuilderWithLabels(baseBuilder, labels: labels)
         var child = builder.startSpan()
         stampCoralogixCustomSpanRUM(on: &child)
         return CoralogixCustomSpan(span: child)
     }
 
-    /// Ends this span (`Span.end()`).
+    /// Ends this global span and restores the OTel active context from before `startGlobalSpan()`.
     public func endSpan() {
+        if CoralogixCustomGlobalSpanRegistry.shared.endGlobalSpanIfMatches(span) {
+            return
+        }
+        Log.w("endSpan() on global span that was not registered; ending span without registry restore")
         span.end()
     }
 }

--- a/Coralogix/Sources/CoralogixCustomSpans.swift
+++ b/Coralogix/Sources/CoralogixCustomSpans.swift
@@ -6,6 +6,14 @@
 //
 
 import Foundation
+import CoralogixInternal
+
+/// Browser SDK sets `EVENT_TYPE` to `custom-span` on global and nested custom spans (`coralogix-rum.ts`).
+private func stampCoralogixCustomSpanRUM(on span: inout any Span) {
+    span.setAttribute(key: Keys.eventType.rawValue, value: CoralogixEventType.customSpan.rawValue)
+    span.setAttribute(key: Keys.source.rawValue, value: Keys.code.rawValue)
+    span.setAttribute(key: Keys.severity.rawValue, value: AttributeValue.int(CoralogixLogSeverity.info.rawValue))
+}
 
 /// Auto-instrumentation categories that may be excluded from custom-tracer context behavior in future releases.
 public enum CoralogixIgnoredInstrument: Hashable {
@@ -39,6 +47,7 @@ public final class CoralogixCustomTracer {
             }
         }
         var otelSpan = builder.startSpan()
+        stampCoralogixCustomSpanRUM(on: &otelSpan)
         rum.enrichCustomSpanMetadata(to: &otelSpan)
         return CoralogixGlobalSpan(span: otelSpan, tracer: tracer)
     }
@@ -75,7 +84,8 @@ public final class CoralogixGlobalSpan {
                 builder = builder.setAttribute(key: key, value: value)
             }
         }
-        let child = builder.startSpan()
+        var child = builder.startSpan()
+        stampCoralogixCustomSpanRUM(on: &child)
         return CoralogixCustomSpan(span: child)
     }
 

--- a/Coralogix/Sources/CoralogixCustomSpans.swift
+++ b/Coralogix/Sources/CoralogixCustomSpans.swift
@@ -23,6 +23,7 @@ final class CoralogixCustomGlobalSpanRegistry {
     /// Ends the span and re-activates the OTel context from before `startGlobalSpan()` (single implementation for `endSpan` / `shutdown` / tests).
     private static func endGlobalSpanAndRestorePrevious(_ span: any Span, previous: (any Span)?) {
         span.end()
+        OpenTelemetry.instance.contextProvider.removeContextForSpan(span)
         if let previous {
             OpenTelemetry.instance.contextProvider.setActiveSpan(previous)
         }

--- a/Coralogix/Sources/CoralogixCustomSpans.swift
+++ b/Coralogix/Sources/CoralogixCustomSpans.swift
@@ -1,0 +1,139 @@
+//
+//  CoralogixCustomSpans.swift
+//  Coralogix
+//
+//  Public Custom Spans API surface (parity with Coralogix Browser SDK).
+//
+
+import Foundation
+
+/// Auto-instrumentation categories that may be excluded from custom-tracer context behavior in future releases.
+public enum CoralogixIgnoredInstrument: Hashable {
+    case networkRequests
+    case userInteractions
+    case errors
+}
+
+/// Tracer for manual global and nested custom spans (`getCustomTracer(ignoredInstruments:)` on `CoralogixRum`).
+public final class CoralogixCustomTracer {
+    internal weak var rum: CoralogixRum?
+
+    /// Instruments passed at creation; reserved for future propagation and instrumentation filtering.
+    public let ignoredInstruments: Set<CoralogixIgnoredInstrument>
+
+    internal init(rum: CoralogixRum, ignoredInstruments: Set<CoralogixIgnoredInstrument>) {
+        self.rum = rum
+        self.ignoredInstruments = ignoredInstruments
+    }
+
+    /// Starts a new root span (new trace). Returns `nil` if the SDK is not initialized or the `CoralogixRum` instance was deallocated.
+    public func startGlobalSpan(name: String, labels: [String: String]? = nil) -> CoralogixGlobalSpan? {
+        guard let rum = rum, rum.isInitialized else {
+            return nil
+        }
+        let tracer = rum.tracerProvider()
+        var builder = tracer.spanBuilder(spanName: name).setNoParent()
+        if let labels {
+            for (key, value) in labels {
+                builder = builder.setAttribute(key: key, value: value)
+            }
+        }
+        var otelSpan = builder.startSpan()
+        rum.enrichCustomSpanMetadata(to: &otelSpan)
+        return CoralogixGlobalSpan(span: otelSpan, tracer: tracer)
+    }
+}
+
+/// A root custom span created via `CoralogixCustomTracer.startGlobalSpan(name:labels:)`.
+public final class CoralogixGlobalSpan {
+    public let span: any Span
+    private let tracer: Tracer
+
+    internal init(span: any Span, tracer: Tracer) {
+        self.span = span
+        self.tracer = tracer
+    }
+
+    /// Runs `work` with this span installed as the active span for OpenTelemetry context (e.g. outbound trace propagation).
+    public func withContext<R>(_ work: () throws -> R) rethrows -> R {
+        let previous = OpenTelemetry.instance.contextProvider.activeSpan
+        OpenTelemetry.instance.contextProvider.setActiveSpan(span)
+        defer {
+            OpenTelemetry.instance.contextProvider.removeContextForSpan(span)
+            if let previous {
+                OpenTelemetry.instance.contextProvider.setActiveSpan(previous)
+            }
+        }
+        return try work()
+    }
+
+    /// Starts a child span of this global span.
+    public func startCustomSpan(name: String, labels: [String: String]? = nil) -> CoralogixCustomSpan {
+        var builder = tracer.spanBuilder(spanName: name).setParent(span)
+        if let labels {
+            for (key, value) in labels {
+                builder = builder.setAttribute(key: key, value: value)
+            }
+        }
+        let child = builder.startSpan()
+        return CoralogixCustomSpan(span: child)
+    }
+
+    /// Ends this span (`Span.end()`).
+    public func endSpan() {
+        span.end()
+    }
+}
+
+/// A nested custom span created via `CoralogixGlobalSpan.startCustomSpan(name:labels:)`.
+public final class CoralogixCustomSpan {
+    public let span: any Span
+
+    internal init(span: any Span) {
+        self.span = span
+    }
+
+    public func endSpan() {
+        span.end()
+    }
+
+    public func setAttribute(key: String, value: String) {
+        span.setAttribute(key: key, value: value)
+    }
+
+    public func setAttribute(key: String, value: Int) {
+        span.setAttribute(key: key, value: value)
+    }
+
+    public func setAttribute(key: String, value: Double) {
+        span.setAttribute(key: key, value: value)
+    }
+
+    public func setAttribute(key: String, value: Bool) {
+        span.setAttribute(key: key, value: value)
+    }
+
+    public func setAttribute(key: String, value: AttributeValue?) {
+        span.setAttribute(key: key, value: value)
+    }
+
+    public func addEvent(name: String) {
+        span.addEvent(name: name)
+    }
+
+    public func addEvent(name: String, timestamp: Date) {
+        span.addEvent(name: name, timestamp: timestamp)
+    }
+
+    public func addEvent(name: String, attributes: [String: AttributeValue]) {
+        span.addEvent(name: name, attributes: attributes)
+    }
+
+    public func addEvent(name: String, attributes: [String: AttributeValue], timestamp: Date) {
+        span.addEvent(name: name, attributes: attributes, timestamp: timestamp)
+    }
+
+    public func setStatus(_ status: Status) {
+        span.status = status
+    }
+}

--- a/Coralogix/Sources/CoralogixRum.swift
+++ b/Coralogix/Sources/CoralogixRum.swift
@@ -367,6 +367,13 @@ public class CoralogixRum {
         span.setAttribute(key: Keys.value.rawValue, value: value)
         span.end()
     }
+
+    /// Returns a tracer for manual custom spans (API naming aligned with the Coralogix Browser SDK: `startCustomSpan`, `endSpan`).
+    ///
+    /// - Parameter ignoredInstruments: Reserved for future use (filtering auto-instrumentation interaction with custom trace context).
+    public func getCustomTracer(ignoredInstruments: Set<CoralogixIgnoredInstrument> = []) -> CoralogixCustomTracer {
+        CoralogixCustomTracer(rum: self, ignoredInstruments: ignoredInstruments)
+    }
     
     // MARK: - Spans & Attributes
     internal var options: CoralogixExporterOptions? { return self.coralogixExporter?.getOptions() }
@@ -377,6 +384,26 @@ public class CoralogixRum {
         span.setAttribute(key: Keys.userName.rawValue, value: options.userContext?.userName ?? "")
         span.setAttribute(key: Keys.userEmail.rawValue, value: options.userContext?.userEmail ?? "")
         span.setAttribute(key: Keys.environment.rawValue, value: options.environment)
+    }
+
+    /// Session, user, and environment attributes for RUM correlation on manually created root spans.
+    internal func enrichCustomSpanMetadata(to span: inout any Span) {
+        if let sessionMetadata = self.coralogixExporter?.getSessionManager().sessionMetadata {
+            span.setAttribute(key: Keys.sessionCreationDate.rawValue, value: String(Int(sessionMetadata.sessionCreationDate)))
+            span.setAttribute(key: Keys.sessionId.rawValue, value: sessionMetadata.sessionId)
+        }
+        if let prevSessionMetadata = self.coralogixExporter?.getSessionManager().getPrevSessionMetadata() {
+            if let prevPid = prevSessionMetadata.oldPid {
+                span.setAttribute(key: Keys.prevPid.rawValue, value: prevPid)
+            }
+            if let prevSessionId = prevSessionMetadata.oldSessionId {
+                span.setAttribute(key: Keys.prevSessionId.rawValue, value: prevSessionId)
+            }
+            if let prevSessionCreationDate = prevSessionMetadata.oldSessionTimeInterval {
+                span.setAttribute(key: Keys.prevSessionCreationDate.rawValue, value: String(Int(prevSessionCreationDate)))
+            }
+        }
+        self.addUserMetadata(to: &span)
     }
     
     private func displayCoralogixWord() {

--- a/Coralogix/Sources/CoralogixRum.swift
+++ b/Coralogix/Sources/CoralogixRum.swift
@@ -308,6 +308,7 @@ public class CoralogixRum {
     }
     
     public func shutdown() {
+        CoralogixCustomGlobalSpanRegistry.shared.teardownIfNeeded()
         CoralogixRum.isInitialized = false
         self.coralogixExporter?.shutdown(explicitTimeout: nil)
         self.removeNotification()

--- a/Coralogix/Sources/CoralogixRum.swift
+++ b/Coralogix/Sources/CoralogixRum.swift
@@ -387,8 +387,13 @@ public class CoralogixRum {
         span.setAttribute(key: Keys.environment.rawValue, value: options.environment)
     }
 
-    /// Session, user, and environment attributes for RUM correlation on manually created root spans.
-    internal func enrichCustomSpanMetadata(to span: inout any Span) {
+    /// Current and previous session IDs plus user and environment — shared by `makeSpan` and manual custom spans.
+    internal func addRumCorrelationMetadata(to span: inout any Span) {
+        addSessionAndPrevSessionMetadata(to: &span)
+        addUserMetadata(to: &span)
+    }
+
+    private func addSessionAndPrevSessionMetadata(to span: inout any Span) {
         if let sessionMetadata = self.coralogixExporter?.getSessionManager().sessionMetadata {
             span.setAttribute(key: Keys.sessionCreationDate.rawValue, value: String(Int(sessionMetadata.sessionCreationDate)))
             span.setAttribute(key: Keys.sessionId.rawValue, value: sessionMetadata.sessionId)
@@ -404,7 +409,6 @@ public class CoralogixRum {
                 span.setAttribute(key: Keys.prevSessionCreationDate.rawValue, value: String(Int(prevSessionCreationDate)))
             }
         }
-        self.addUserMetadata(to: &span)
     }
     
     private func displayCoralogixWord() {
@@ -428,25 +432,7 @@ public class CoralogixRum {
         span.setAttribute(key: Keys.eventType.rawValue, value: event.rawValue)
         span.setAttribute(key: Keys.source.rawValue, value: source.rawValue)
         span.setAttribute(key: Keys.severity.rawValue, value: AttributeValue.int(severity.rawValue))
-        
-        if let sessionMetadata = self.coralogixExporter?.getSessionManager().sessionMetadata {
-            span.setAttribute(key: Keys.sessionCreationDate.rawValue, value: String(Int(sessionMetadata.sessionCreationDate)))
-            span.setAttribute(key: Keys.sessionId.rawValue, value: sessionMetadata.sessionId)
-        }
-        
-        if let prevSessionMetadata = self.coralogixExporter?.getSessionManager().getPrevSessionMetadata() {
-            if let prevPid = prevSessionMetadata.oldPid {
-                span.setAttribute(key: Keys.prevPid.rawValue, value: prevPid)
-            }
-            if let prevSessionId = prevSessionMetadata.oldSessionId {
-                span.setAttribute(key: Keys.prevSessionId.rawValue, value: prevSessionId)
-            }
-            if let prevSessionCreationDate = prevSessionMetadata.oldSessionTimeInterval {
-                span.setAttribute(key: Keys.prevSessionCreationDate.rawValue, value: String(Int(prevSessionCreationDate)))
-            }
-        }
-        
-        self.addUserMetadata(to: &span)
+        addRumCorrelationMetadata(to: &span)
         return span
     }
 }

--- a/Coralogix/Sources/Model/Contexts/EventContext.swift
+++ b/Coralogix/Sources/Model/Contexts/EventContext.swift
@@ -10,7 +10,8 @@ import CoralogixInternal
 struct EventContext {
     var type: CoralogixEventType = .unknown
     let source: String
-    var severity: Int = 0
+    /// Default **info** (3) when the span omits `severity` or it is not a valid integer (matches top-level log `severity`).
+    var severity: Int = CoralogixLogSeverity.info.rawValue
     
     init(otel: SpanDataProtocol) {
         if let type = otel.getAttribute(forKey: Keys.eventType.rawValue) as? String {
@@ -19,8 +20,9 @@ struct EventContext {
         
         self.source = otel.getAttribute(forKey: Keys.source.rawValue) as? String ?? ""
         
-        if let severity = otel.getAttribute(forKey: Keys.severity.rawValue) as? String {
-            self.severity = Int(severity) ?? 0
+        if let severityStr = otel.getAttribute(forKey: Keys.severity.rawValue) as? String,
+           let parsed = Int(severityStr) {
+            self.severity = parsed
         }
     }
     

--- a/Coralogix/Sources/Model/CxSpan.swift
+++ b/Coralogix/Sources/Model/CxSpan.swift
@@ -12,7 +12,7 @@ public class CxSpan {
     let applicationName: String
     let subsystemName: String
     let isErrorWithStacktrace: Bool = false
-    var severity: Int = 0
+    var severity: Int
     var cxRum: CxRum
     var instrumentationData: InstrumentationData?
     var beforeSend: (([String: Any]) -> [String: Any]?)?
@@ -33,9 +33,6 @@ public class CxSpan {
         self.subsystemName = Keys.cxRum.rawValue
         self.beforeSend = options.beforeSend
         self.sessionManager = sessionManager
-        if let severity = otel.getAttribute(forKey: Keys.severity.rawValue) as? String {
-            self.severity = Int(severity) ?? 0
-        }
 
         let rumBuilder = CxRumBuilder(otel: otel,
                                       versionMetadata: versionMetadata,
@@ -49,6 +46,7 @@ public class CxSpan {
             return nil
         }
         self.cxRum = cxRum
+        self.severity = cxRum.eventContext.severity
         
         if cxRum.eventContext.type == CoralogixEventType.networkRequest {
             self.instrumentationData = InstrumentationData(otel: otel, cxRum: cxRum, viewManager: viewManager)

--- a/Coralogix/Sources/Model/CxSpan.swift
+++ b/Coralogix/Sources/Model/CxSpan.swift
@@ -48,7 +48,8 @@ public class CxSpan {
         self.cxRum = cxRum
         self.severity = cxRum.eventContext.severity
         
-        if cxRum.eventContext.type == CoralogixEventType.networkRequest {
+        // `instrumentation_data.otelSpan` enables Tracing ingestion (Browser: traces-exporter + markSpanAsOtelToSend).
+        if cxRum.eventContext.type == .networkRequest || cxRum.eventContext.type == .customSpan {
             self.instrumentationData = InstrumentationData(otel: otel, cxRum: cxRum, viewManager: viewManager)
         }
     }
@@ -146,7 +147,7 @@ public class CxSpan {
     }
     
     private func addInstrumentationData(to result: inout [String: Any]) {
-        if cxRum.eventContext.type == CoralogixEventType.networkRequest,
+        if cxRum.eventContext.type == .networkRequest || cxRum.eventContext.type == .customSpan,
            let instrumentationData = self.instrumentationData?.getDictionary() {
             result[Keys.instrumentationData.rawValue] = instrumentationData
         }

--- a/Coralogix/Sources/Model/InstrumentationData.swift
+++ b/Coralogix/Sources/Model/InstrumentationData.swift
@@ -185,7 +185,32 @@ struct OtelSpan {
 
         return attrs
     }
-    
+
+    /// Matches Browser `timestampToNanosString` (concat of epoch seconds + 9-digit nanos) for Tracing extractors.
+    private static func otlpUnixNanoString(hrTime: [UInt64]) -> String {
+        guard hrTime.count >= 2 else { return "0" }
+        let sec = hrTime[0]
+        let nanos = hrTime[1]
+        return "\(sec)" + String(format: "%09llu", nanos)
+    }
+
+    /// Browser `mapStatusCodeToOtlp` (traces-exporter.utils.ts).
+    private static func otlpStatusCode(from statusDict: [String: Any]) -> [String: Any] {
+        let raw = statusDict[Keys.code.rawValue]
+        let code: Int = {
+            if let i = raw as? Int { return i }
+            if let s = raw as? String, let i = Int(s) { return i }
+            return 0
+        }()
+        let name: String
+        switch code {
+        case 1: name = Keys.otlpStatusCodeOk.rawValue
+        case 2: name = Keys.otlpStatusCodeError.rawValue
+        default: name = Keys.otlpStatusCodeUnset.rawValue
+        }
+        return [Keys.code.rawValue: name]
+    }
+
     func getDictionary() -> [String: Any] {
         var result = [String: Any]()
         result[Keys.spanId.rawValue] = self.spanId
@@ -199,6 +224,18 @@ struct OtelSpan {
         result[Keys.kind.rawValue] = self.kind
         result[Keys.duration.rawValue] = self.duration
         if let sessionId = self.sessionId { result[Keys.keySessionId.rawValue] = sessionId }
+
+        // OTLP-shaped duplicates (Browser mapCxSpanToOtlpSpan) — Tracing may only read these from RUM logs.
+        result[Keys.otlpTraceId.rawValue] = self.traceId
+        result[Keys.otlpSpanId.rawValue] = self.spanId
+        if let parentSpanId = self.parentSpanId {
+            result[Keys.otlpParentSpanId.rawValue] = parentSpanId
+        }
+        result[Keys.otlpStartTimeUnixNano.rawValue] = Self.otlpUnixNanoString(hrTime: self.startTime)
+        result[Keys.otlpEndTimeUnixNano.rawValue] = Self.otlpUnixNanoString(hrTime: self.endTime)
+        result[Keys.otlpKindString.rawValue] = Keys.otlpSpanKindClient.rawValue
+        result[Keys.otlpStatus.rawValue] = Self.otlpStatusCode(from: self.status)
+
         return result
     }
 }

--- a/CoralogixInternal/Sources/Keys.swift
+++ b/CoralogixInternal/Sources/Keys.swift
@@ -141,6 +141,18 @@ public enum Keys: String {
     case endTime
     case status
     case kind
+    /// OTLP-shaped mirror keys on `instrumentation_data.otelSpan` (Browser `mapCxSpanToOtlpSpan` / Tracing extractors).
+    case otlpTraceId = "trace_id"
+    case otlpSpanId = "span_id"
+    case otlpParentSpanId = "parent_span_id"
+    case otlpStartTimeUnixNano = "start_time_unix_nano"
+    case otlpEndTimeUnixNano = "end_time_unix_nano"
+    case otlpKindString = "kind_string"
+    case otlpStatus = "status_otlp"
+    case otlpSpanKindClient = "SPAN_KIND_CLIENT"
+    case otlpStatusCodeUnset = "STATUS_CODE_UNSET"
+    case otlpStatusCodeOk = "STATUS_CODE_OK"
+    case otlpStatusCodeError = "STATUS_CODE_ERROR"
     case tapName
     case tapCount
     case tapAttributes

--- a/CoralogixInternal/Sources/Keys.swift
+++ b/CoralogixInternal/Sources/Keys.swift
@@ -281,5 +281,7 @@ public enum CoralogixEventType: String {
     case lifeCycle = "life-cycle"
     case screenshot
     case customMeasurement = "custom-measurement"
+    /// Manual spans from `getCustomTracer()` (parity with Browser SDK `CoralogixEventType.CUSTOM_SPAN`).
+    case customSpan = "custom-span"
     case unknown
 }

--- a/Example/DemoApp.xcodeproj/project.pbxproj
+++ b/Example/DemoApp.xcodeproj/project.pbxproj
@@ -75,6 +75,7 @@
 		E6FD68F82D01D5570066BDE8 /* CreditCardInputCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6FD68F72D01D5570066BDE8 /* CreditCardInputCell.swift */; };
 		E6FDDA2D2DF176DC0005F274 /* ClockViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6FDDA2C2DF176DC0005F274 /* ClockViewController.swift */; };
 		E6FDDA2E2DF176DC0005F275 /* SchemaValidationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6FDDA312DF176DC0005F275 /* SchemaValidationViewController.swift */; };
+		E6C359522F04000510035951 /* CustomSpansViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6C359512F04000510035951 /* CustomSpansViewController.swift */; };
 		E6FDDA2F2DF176DC0005F274 /* ClockViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6FDDA2C2DF176DC0005F274 /* ClockViewController.swift */; };
 /* End PBXBuildFile section */
 
@@ -167,6 +168,7 @@
 		E6FD68F72D01D5570066BDE8 /* CreditCardInputCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreditCardInputCell.swift; sourceTree = "<group>"; };
 		E6FDDA2C2DF176DC0005F274 /* ClockViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClockViewController.swift; sourceTree = "<group>"; };
 		E6FDDA312DF176DC0005F275 /* SchemaValidationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaValidationViewController.swift; sourceTree = "<group>"; };
+		E6C359512F04000510035951 /* CustomSpansViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomSpansViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -313,6 +315,7 @@
 				E674E7F72CD7C6480041784E /* SessionReplayViewController.swift */,
 				E6FDDA2C2DF176DC0005F274 /* ClockViewController.swift */,
 				E6FDDA312DF176DC0005F275 /* SchemaValidationViewController.swift */,
+				E6C359512F04000510035951 /* CustomSpansViewController.swift */,
 				E6E515FD2EBB8644008EC19A /* MaskViewController.swift */,
 				E6B60A052DB4EAAC003AD35D /* Assets.xcassets */,
 				E68681AA2BFA279500B127E7 /* Main.storyboard */,
@@ -614,6 +617,7 @@
 				E66938532C7489050002335F /* SdkViewController.swift in Sources */,
 				E6FDDA2D2DF176DC0005F274 /* ClockViewController.swift in Sources */,
 				E6FDDA2E2DF176DC0005F275 /* SchemaValidationViewController.swift in Sources */,
+				E6C359522F04000510035951 /* CustomSpansViewController.swift in Sources */,
 				E669384F2C747E860002335F /* CustomView.swift in Sources */,
 				E6E515FE2EBB8644008EC19A /* MaskViewController.swift in Sources */,
 				E66938572C74A8830002335F /* UserActionsViewController.swift in Sources */,

--- a/Example/DemoAppSwift/CustomSpansViewController.swift
+++ b/Example/DemoAppSwift/CustomSpansViewController.swift
@@ -103,66 +103,34 @@ final class CustomSpansViewController: UITableViewController {
         navigationItem.title = "Custom Spans"
         navigationController?.navigationBar.prefersLargeTitles = false
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: "cell")
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "introCell")
         tableView.rowHeight = UITableView.automaticDimension
-        tableView.estimatedRowHeight = 100
-        installIntroHeader()
+        // Long subtitles; estimates far below real height break UITableView content sizing (gaps / clipped rows).
+        tableView.estimatedRowHeight = 220
     }
 
-    override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
-        layoutIntroHeaderIfNeeded()
-    }
-
-    private func installIntroHeader() {
-        let container = UIView()
-        container.backgroundColor = .clear
-        let label = UILabel()
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.numberOfLines = 0
-        label.attributedText = Self.introAttributedText
-        container.addSubview(label)
-        NSLayoutConstraint.activate([
-            label.topAnchor.constraint(equalTo: container.topAnchor, constant: 12),
-            label.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 20),
-            label.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -20),
-            label.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: 8)
-        ])
-        tableView.tableHeaderView = container
-        layoutIntroHeaderIfNeeded()
-    }
-
-    /// Avoid reassigning `tableHeaderView` every layout pass (that froze navigation).
-    private var introHeaderLaidOutSize: CGSize = .zero
-
-    private func layoutIntroHeaderIfNeeded() {
-        guard let header = tableView.tableHeaderView else { return }
-        let width = tableView.bounds.width
-        guard width > 0 else { return }
-
-        header.frame = CGRect(x: 0, y: 0, width: width, height: 0)
-        header.layoutIfNeeded()
-
-        let height = header.systemLayoutSizeFitting(
-            CGSize(width: width, height: 0),
-            withHorizontalFittingPriority: .required,
-            verticalFittingPriority: .fittingSizeLevel
-        ).height
-
-        if abs(introHeaderLaidOutSize.width - width) < 0.5, abs(introHeaderLaidOutSize.height - height) < 0.5 {
-            return
-        }
-        introHeaderLaidOutSize = CGSize(width: width, height: height)
-        header.frame = CGRect(x: 0, y: 0, width: width, height: height)
-        tableView.tableHeaderView = header
-    }
-
-    override func numberOfSections(in tableView: UITableView) -> Int { 1 }
+    override func numberOfSections(in tableView: UITableView) -> Int { 2 }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        items.count
+        section == 0 ? 1 : items.count
+    }
+
+    override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        section == 1 ? "Demos" : nil
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        if indexPath.section == 0 {
+            let cell = tableView.dequeueReusableCell(withIdentifier: "introCell", for: indexPath)
+            cell.selectionStyle = .none
+            cell.accessoryType = .none
+            var config = UIListContentConfiguration.cell()
+            config.attributedText = Self.introAttributedText
+            config.textProperties.numberOfLines = 0
+            cell.contentConfiguration = config
+            return cell
+        }
+
         let item = items[indexPath.row]
         let cell = tableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath)
         var config = UIListContentConfiguration.subtitleCell()
@@ -180,6 +148,7 @@ final class CustomSpansViewController: UITableViewController {
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
+        guard indexPath.section == 1 else { return }
         items[indexPath.row].action()
     }
 

--- a/Example/DemoAppSwift/CustomSpansViewController.swift
+++ b/Example/DemoAppSwift/CustomSpansViewController.swift
@@ -1,0 +1,139 @@
+//
+//  CustomSpansViewController.swift
+//  DemoAppSwift
+//
+//  Manual exercises for CoralogixCustomTracer / CoralogixGlobalSpan / CoralogixCustomSpan.
+//
+
+import UIKit
+import Coralogix
+
+final class CustomSpansViewController: UITableViewController {
+
+    private struct DemoItem {
+        let title: String
+        let subtitle: String
+        let systemImageName: String
+        let action: () -> Void
+    }
+
+    private lazy var items: [DemoItem] = [
+        DemoItem(
+            title: "Simple global + child spans",
+            subtitle: "Labels, attributes, event, status, endSpan",
+            systemImageName: "point.3.connected.trianglepath.dotted",
+            action: { [weak self] in self?.runSimpleFlow(useIgnoredTracer: false) }
+        ),
+        DemoItem(
+            title: "withContext + GET request",
+            subtitle: "Sets active span, then starts jsonplaceholder GET",
+            systemImageName: "network",
+            action: { [weak self] in self?.runWithContextNetwork() }
+        ),
+        DemoItem(
+            title: "Tracer with ignoredInstruments",
+            subtitle: "getCustomTracer(ignoredInstruments: [.networkRequests, .errors])",
+            systemImageName: "eye.slash",
+            action: { [weak self] in self?.runSimpleFlow(useIgnoredTracer: true) }
+        )
+    ]
+
+    init() {
+        super.init(style: .insetGrouped)
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        navigationItem.title = "Custom Spans"
+        navigationController?.navigationBar.prefersLargeTitles = false
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "cell")
+    }
+
+    override func numberOfSections(in tableView: UITableView) -> Int { 1 }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        items.count
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let item = items[indexPath.row]
+        let cell = tableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath)
+        var config = UIListContentConfiguration.subtitleCell()
+        config.text = item.title
+        config.secondaryText = item.subtitle
+        config.image = UIImage(systemName: item.systemImageName)
+        config.imageProperties.preferredSymbolConfiguration =
+            UIImage.SymbolConfiguration(pointSize: 20, weight: .medium)
+        config.secondaryTextProperties.color = .secondaryLabel
+        cell.contentConfiguration = config
+        cell.accessoryType = .none
+        return cell
+    }
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        items[indexPath.row].action()
+    }
+
+    // MARK: - Demos
+
+    private func runSimpleFlow(useIgnoredTracer: Bool) {
+        let rum = CoralogixRumManager.shared.sdk
+        guard rum.isInitialized else {
+            presentToast("SDK not initialized")
+            return
+        }
+        let tracer: CoralogixCustomTracer
+        if useIgnoredTracer {
+            tracer = rum.getCustomTracer(ignoredInstruments: [.networkRequests, .errors])
+        } else {
+            tracer = rum.getCustomTracer()
+        }
+        guard let global = tracer.startGlobalSpan(
+            name: "demo.custom.global",
+            labels: ["demo.screen": "CustomSpans"]
+        ) else {
+            presentToast("startGlobalSpan returned nil")
+            return
+        }
+        let child = global.startCustomSpan(name: "demo.custom.child")
+        child.setAttribute(key: "demo.step", value: "authorize")
+        child.addEvent(name: "demo.checkpoint")
+        child.setStatus(.ok)
+        child.endSpan()
+        global.endSpan()
+        presentToast(useIgnoredTracer ? "Finished (ignored-instruments tracer)" : "Finished simple flow")
+    }
+
+    private func runWithContextNetwork() {
+        let rum = CoralogixRumManager.shared.sdk
+        guard rum.isInitialized else {
+            presentToast("SDK not initialized")
+            return
+        }
+        guard let global = rum.getCustomTracer().startGlobalSpan(
+            name: "demo.custom.with_context",
+            labels: ["demo.flow": "network"]
+        ) else {
+            presentToast("startGlobalSpan returned nil")
+            return
+        }
+        global.withContext {
+            NetworkSim.sendSuccesfullRequest()
+        }
+        global.endSpan()
+        presentToast("GET started under withContext; global span ended")
+    }
+
+    private func presentToast(_ message: String) {
+        let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+        present(alert, animated: true)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) {
+            alert.dismiss(animated: true)
+        }
+    }
+}

--- a/Example/DemoAppSwift/CustomSpansViewController.swift
+++ b/Example/DemoAppSwift/CustomSpansViewController.swift
@@ -20,15 +20,21 @@ final class CustomSpansViewController: UITableViewController {
     private lazy var items: [DemoItem] = [
         DemoItem(
             title: "Simple global + child spans",
-            subtitle: "Labels, attributes, event, status, endSpan",
+            subtitle: "Global becomes active OTel context; child shares traceId; then endSpan",
             systemImageName: "point.3.connected.trianglepath.dotted",
             action: { [weak self] in self?.runSimpleFlow(useIgnoredTracer: false) }
         ),
         DemoItem(
             title: "withContext + GET request",
-            subtitle: "Sets active span, then starts jsonplaceholder GET",
+            subtitle: "Global already active; withContext wraps GET (propagation while global open)",
             systemImageName: "network",
             action: { [weak self] in self?.runWithContextNetwork() }
+        ),
+        DemoItem(
+            title: "Second startGlobalSpan rejected",
+            subtitle: "Only one global at a time; second call returns nil until first endSpan",
+            systemImageName: "exclamationmark.triangle",
+            action: { [weak self] in self?.runSecondGlobalRejectedDemo() }
         ),
         DemoItem(
             title: "Tracer with ignoredInstruments",
@@ -107,6 +113,31 @@ final class CustomSpansViewController: UITableViewController {
         child.endSpan()
         global.endSpan()
         presentToast(useIgnoredTracer ? "Finished (ignored-instruments tracer)" : "Finished simple flow")
+    }
+
+    private func runSecondGlobalRejectedDemo() {
+        let rum = CoralogixRumManager.shared.sdk
+        guard rum.isInitialized else {
+            presentToast("SDK not initialized")
+            return
+        }
+        let tracer = rum.getCustomTracer()
+        guard let first = tracer.startGlobalSpan(name: "demo.custom.first_global") else {
+            presentToast("Unexpected: first startGlobalSpan failed")
+            return
+        }
+        if tracer.startGlobalSpan(name: "demo.custom.should_fail") != nil {
+            presentToast("Bug: second startGlobalSpan should return nil")
+            first.endSpan()
+            return
+        }
+        first.endSpan()
+        guard let after = tracer.startGlobalSpan(name: "demo.custom.after_end") else {
+            presentToast("Unexpected: global after endSpan should succeed")
+            return
+        }
+        after.endSpan()
+        presentToast("OK: 2nd global rejected; new global after endSpan works")
     }
 
     private func runWithContextNetwork() {

--- a/Example/DemoAppSwift/CustomSpansViewController.swift
+++ b/Example/DemoAppSwift/CustomSpansViewController.swift
@@ -17,28 +17,74 @@ final class CustomSpansViewController: UITableViewController {
         let action: () -> Void
     }
 
+    /// Shown above the list so the demos make sense without reading SDK docs.
+    private static let introAttributedText: NSAttributedString = {
+        let body = UIFont.preferredFont(forTextStyle: .footnote)
+        let bold = UIFontDescriptor.preferredFontDescriptor(withTextStyle: .footnote)
+            .withSymbolicTraits(.traitBold)
+        let boldFont = bold.map { UIFont(descriptor: $0, size: 0) } ?? body
+
+        let s = NSMutableAttributedString()
+        func add(_ text: String, font: UIFont) {
+            s.append(NSAttributedString(string: text, attributes: [.font: font, .foregroundColor: UIColor.secondaryLabel]))
+        }
+
+        add("What you’re looking at\n", font: boldFont)
+        add(
+            "Custom spans are manual RUM spans (exported like the Browser SDK, type custom-span). "
+                + "A global span is the “root” for a flow; nested spans are children. "
+                + "Only one global may exist at a time.\n\n",
+            font: body
+        )
+        add("Why “global” matters\n", font: boldFont)
+        add(
+            "startGlobalSpan registers that span as OpenTelemetry’s active context. "
+                + "Auto-instrumentation (e.g. URLSession) can then use the same traceId until you call endSpan(), "
+                + "which restores the previous active span.\n\n",
+            font: body
+        )
+        add("withContext\n", font: boldFont)
+        add(
+            "Runs a closure while the global is the logical “current” span. "
+                + "If the global is already the active OTel span (right after startGlobalSpan), the SDK does not swap context—it just runs your code.\n\n",
+            font: body
+        )
+        add("Tap a row below to run a scripted sequence; check Coralogix for span names and the shared trace.",
+            font: body
+        )
+        return s
+    }()
+
     private lazy var items: [DemoItem] = [
         DemoItem(
             title: "Simple global + child spans",
-            subtitle: "Global becomes active OTel context; child shares traceId; then endSpan",
+            subtitle:
+                "Simulates a small user flow: startGlobalSpan → startCustomSpan (child) → set attribute, event, status → end child → end global. "
+                + "You should see two custom-span events on one trace in Coralogix.",
             systemImageName: "point.3.connected.trianglepath.dotted",
             action: { [weak self] in self?.runSimpleFlow(useIgnoredTracer: false) }
         ),
         DemoItem(
             title: "withContext + GET request",
-            subtitle: "Global already active; withContext wraps GET (propagation while global open)",
+            subtitle:
+                "Simulates doing work (here a demo GET) while the global span is open. "
+                + "Shows that withContext is safe when the global is already active; the HTTP span should still relate to the same trace as the global.",
             systemImageName: "network",
             action: { [weak self] in self?.runWithContextNetwork() }
         ),
         DemoItem(
             title: "Second startGlobalSpan rejected",
-            subtitle: "Only one global at a time; second call returns nil until first endSpan",
+            subtitle:
+                "Simulates the Browser rule: with a global still open, a second startGlobalSpan returns nil (no second root). "
+                + "After endSpan(), a new global can start—proves the slot was released.",
             systemImageName: "exclamationmark.triangle",
             action: { [weak self] in self?.runSecondGlobalRejectedDemo() }
         ),
         DemoItem(
             title: "Tracer with ignoredInstruments",
-            subtitle: "getCustomTracer(ignoredInstruments: [.networkRequests, .errors])",
+            subtitle:
+                "Same span sequence as the first row, but using getCustomTracer(ignoredInstruments: [.networkRequests, .errors]). "
+                + "Today this matches the default tracer; the set is reserved for future control over how auto-instrumentation joins custom context.",
             systemImageName: "eye.slash",
             action: { [weak self] in self?.runSimpleFlow(useIgnoredTracer: true) }
         )
@@ -57,6 +103,57 @@ final class CustomSpansViewController: UITableViewController {
         navigationItem.title = "Custom Spans"
         navigationController?.navigationBar.prefersLargeTitles = false
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: "cell")
+        tableView.rowHeight = UITableView.automaticDimension
+        tableView.estimatedRowHeight = 100
+        installIntroHeader()
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        layoutIntroHeaderIfNeeded()
+    }
+
+    private func installIntroHeader() {
+        let container = UIView()
+        container.backgroundColor = .clear
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.numberOfLines = 0
+        label.attributedText = Self.introAttributedText
+        container.addSubview(label)
+        NSLayoutConstraint.activate([
+            label.topAnchor.constraint(equalTo: container.topAnchor, constant: 12),
+            label.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 20),
+            label.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -20),
+            label.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: 8)
+        ])
+        tableView.tableHeaderView = container
+        layoutIntroHeaderIfNeeded()
+    }
+
+    /// Avoid reassigning `tableHeaderView` every layout pass (that froze navigation).
+    private var introHeaderLaidOutSize: CGSize = .zero
+
+    private func layoutIntroHeaderIfNeeded() {
+        guard let header = tableView.tableHeaderView else { return }
+        let width = tableView.bounds.width
+        guard width > 0 else { return }
+
+        header.frame = CGRect(x: 0, y: 0, width: width, height: 0)
+        header.layoutIfNeeded()
+
+        let height = header.systemLayoutSizeFitting(
+            CGSize(width: width, height: 0),
+            withHorizontalFittingPriority: .required,
+            verticalFittingPriority: .fittingSizeLevel
+        ).height
+
+        if abs(introHeaderLaidOutSize.width - width) < 0.5, abs(introHeaderLaidOutSize.height - height) < 0.5 {
+            return
+        }
+        introHeaderLaidOutSize = CGSize(width: width, height: height)
+        header.frame = CGRect(x: 0, y: 0, width: width, height: height)
+        tableView.tableHeaderView = header
     }
 
     override func numberOfSections(in tableView: UITableView) -> Int { 1 }
@@ -75,6 +172,7 @@ final class CustomSpansViewController: UITableViewController {
         config.imageProperties.preferredSymbolConfiguration =
             UIImage.SymbolConfiguration(pointSize: 20, weight: .medium)
         config.secondaryTextProperties.color = .secondaryLabel
+        config.secondaryTextProperties.numberOfLines = 0
         cell.contentConfiguration = config
         cell.accessoryType = .none
         return cell

--- a/Example/DemoAppSwift/MainViewController.swift
+++ b/Example/DemoAppSwift/MainViewController.swift
@@ -33,6 +33,12 @@ final class MainViewController: UITableViewController {
             key: .sdkFunctions
         ),
         .init(
+            title: "Custom spans",
+            subtitle: "Manual global & nested spans (Browser API parity)",
+            systemImageName: "timeline.selection",
+            key: .customSpans
+        ),
+        .init(
             title: "User actions",
             subtitle: "Buttons, screens & custom events",
             systemImageName: "hand.tap",
@@ -239,6 +245,8 @@ final class MainViewController: UITableViewController {
             vc = ErrorViewController()
         case .sdkFunctions:
             vc = SdkViewController()
+        case .customSpans:
+            vc = CustomSpansViewController()
         case .userActionsInstumentation:
             vc = UserActionsViewController()
         case .sessionReplay:

--- a/Example/DemoAppUITests/UserInteractionUITests.swift
+++ b/Example/DemoAppUITests/UserInteractionUITests.swift
@@ -71,6 +71,11 @@ final class UserInteractionUITests: XCTestCase {
 
     override func tearDownWithError() throws {
         app.terminate()
+        // Give the OS time to fully wind down the process before the next
+        // test's setUp calls app.launch(), which internally terminates any
+        // running instance — without this gap, launch() can fail with
+        // "Failed to terminate <bundle-id>" on slow CI machines.
+        Thread.sleep(forTimeInterval: isCI ? 3.0 : 1.0)
         app = nil
         try super.tearDownWithError()
     }

--- a/Example/Shared/CoralogixRumManager.swift
+++ b/Example/Shared/CoralogixRumManager.swift
@@ -51,7 +51,7 @@ final class CoralogixRumManager {
 //            return editableCxRum
 //        },
                                                enableSwizzling: true,
-                                               proxyUrl: Envs.PROXY_URL.rawValue, // remove if not need to use proxy
+            //                                   proxyUrl: Envs.PROXY_URL.rawValue, // remove if not need to use proxy
                                                mobileVitals:[.cpuDetector: false,
                                                              .warmDetector: false,
                                                              .coldDetector: false,

--- a/Example/Shared/CoralogixRumManager.swift
+++ b/Example/Shared/CoralogixRumManager.swift
@@ -51,7 +51,7 @@ final class CoralogixRumManager {
 //            return editableCxRum
 //        },
                                                enableSwizzling: true,
-            //                                   proxyUrl: Envs.PROXY_URL.rawValue, // remove if not need to use proxy
+                                               proxyUrl: Envs.PROXY_URL.rawValue, // remove if not need to use proxy
                                                mobileVitals:[.cpuDetector: false,
                                                              .warmDetector: false,
                                                              .coldDetector: false,

--- a/Example/Shared/Keys.swift
+++ b/Example/Shared/Keys.swift
@@ -64,4 +64,5 @@ enum Keys: String {
     case unregisterMaskRegion = "Unregister mask region"
     case testSessionSampler   = "Test Session Sampler"
     case requestWithHeaderCapture = "Request with header/payload capture"
+    case customSpans = "Custom Spans"
 }

--- a/Tests/CoralogixRumTests/CoralogixCustomSpansTests.swift
+++ b/Tests/CoralogixRumTests/CoralogixCustomSpansTests.swift
@@ -1,0 +1,116 @@
+import XCTest
+import CoralogixInternal
+@testable import Coralogix
+
+final class CoralogixCustomSpansTests: XCTestCase {
+    private var options: CoralogixExporterOptions?
+
+    override func setUpWithError() throws {
+        options = CoralogixExporterOptions(
+            coralogixDomain: CoralogixDomain.US2,
+            userContext: nil,
+            environment: "PROD",
+            application: "TestApp-CustomSpans",
+            version: "1.0",
+            publicKey: "token",
+            ignoreUrls: [],
+            ignoreErrors: [],
+            labels: [:],
+            sessionSampleRate: 100,
+            debug: true
+        )
+    }
+
+    override func tearDownWithError() throws {
+        options = nil
+        CoralogixRum.isInitialized = false
+        RunLoop.main.run(until: Date().addingTimeInterval(0.05))
+    }
+
+    func testGetCustomTracerPreservesIgnoredInstruments() {
+        let rum = CoralogixRum(options: options!)
+        let instruments: Set<CoralogixIgnoredInstrument> = [.networkRequests, .errors]
+        let tracer = rum.getCustomTracer(ignoredInstruments: instruments)
+        XCTAssertEqual(tracer.ignoredInstruments, instruments)
+    }
+
+    func testStartGlobalSpanReturnsNilWhenSdkNotInitialized() {
+        CoralogixRum.isInitialized = false
+        let offOptions = CoralogixExporterOptions(
+            coralogixDomain: CoralogixDomain.US2,
+            userContext: nil,
+            environment: "PROD",
+            application: "Off",
+            version: "1.0",
+            publicKey: "token",
+            ignoreUrls: [],
+            ignoreErrors: [],
+            labels: [:],
+            sessionSampleRate: 0,
+            debug: true
+        )
+        let rum = CoralogixRum(options: offOptions)
+        XCTAssertFalse(rum.isInitialized)
+        let tracer = rum.getCustomTracer()
+        XCTAssertNil(tracer.startGlobalSpan(name: "root"))
+    }
+
+    func testStartGlobalSpanAppliesNameLabelsAndSessionMetadata() {
+        let rum = CoralogixRum(options: options!)
+        let tracer = rum.getCustomTracer()
+        guard let global = tracer.startGlobalSpan(name: "checkout", labels: ["flow": "standard"]) else {
+            return XCTFail("Expected global span")
+        }
+        guard let readable = global.span as? ReadableSpan else {
+            return XCTFail("Expected ReadableSpan")
+        }
+        let data = readable.toSpanData()
+        XCTAssertEqual(data.name, "checkout")
+        XCTAssertEqual(data.attributes["flow"], .string("standard"))
+        XCTAssertNotNil(data.attributes[Keys.sessionId.rawValue])
+    }
+
+    func testStartCustomSpanIsChildOfGlobalSpan() {
+        let rum = CoralogixRum(options: options!)
+        let tracer = rum.getCustomTracer()
+        guard let global = tracer.startGlobalSpan(name: "parent") else {
+            return XCTFail("Expected global span")
+        }
+        let custom = global.startCustomSpan(name: "child")
+        guard let childReadable = custom.span as? ReadableSpan else {
+            return XCTFail("Expected ReadableSpan")
+        }
+        let childData = childReadable.toSpanData()
+        XCTAssertEqual(childData.traceId, global.span.context.traceId)
+        XCTAssertNotEqual(childData.spanId, global.span.context.spanId)
+    }
+
+    func testWithContextSetsActiveSpan() {
+        let rum = CoralogixRum(options: options!)
+        let tracer = rum.getCustomTracer()
+        guard let global = tracer.startGlobalSpan(name: "ctx") else {
+            return XCTFail("Expected global span")
+        }
+        let before = OpenTelemetry.instance.contextProvider.activeSpan
+        global.withContext {
+            XCTAssertTrue(OpenTelemetry.instance.contextProvider.activeSpan === global.span)
+        }
+        XCTAssertEqual(
+            OpenTelemetry.instance.contextProvider.activeSpan?.context.spanId,
+            before?.context.spanId
+        )
+    }
+
+    func testCustomSpanSetStatusAndEndSpan() {
+        let rum = CoralogixRum(options: options!)
+        let tracer = rum.getCustomTracer()
+        guard let global = tracer.startGlobalSpan(name: "g") else {
+            return XCTFail("Expected global span")
+        }
+        let custom = global.startCustomSpan(name: "c")
+        custom.setStatus(.ok)
+        XCTAssertTrue(custom.span.status.isOk)
+        custom.endSpan()
+        global.endSpan()
+    }
+}

--- a/Tests/CoralogixRumTests/CoralogixCustomSpansTests.swift
+++ b/Tests/CoralogixRumTests/CoralogixCustomSpansTests.swift
@@ -62,6 +62,8 @@ final class CoralogixCustomSpansTests: XCTestCase {
         guard let global = tracer.startGlobalSpan(name: "g") else {
             return XCTFail("Expected global span")
         }
+        defer { global.endSpan() }
+
         guard let globalData = (global.span as? any ReadableSpan)?.toSpanData() else {
             return XCTFail("Expected ReadableSpan")
         }
@@ -70,6 +72,8 @@ final class CoralogixCustomSpansTests: XCTestCase {
         XCTAssertEqual(globalData.attributes[Keys.severity.rawValue], .int(CoralogixLogSeverity.info.rawValue))
 
         let child = global.startCustomSpan(name: "c")
+        defer { child.endSpan() }
+
         guard let childData = (child.span as? any ReadableSpan)?.toSpanData() else {
             return XCTFail("Expected ReadableSpan")
         }
@@ -107,6 +111,8 @@ final class CoralogixCustomSpansTests: XCTestCase {
         guard let global = tracer.startGlobalSpan(name: "checkout", labels: ["flow": "standard"]) else {
             return XCTFail("Expected global span")
         }
+        defer { global.endSpan() }
+
         guard let readable = global.span as? any ReadableSpan else {
             return XCTFail("Expected ReadableSpan")
         }
@@ -171,7 +177,11 @@ final class CoralogixCustomSpansTests: XCTestCase {
         guard let global = tracer.startGlobalSpan(name: "parent") else {
             return XCTFail("Expected global span")
         }
+        defer { global.endSpan() }
+
         let custom = global.startCustomSpan(name: "child")
+        defer { custom.endSpan() }
+
         guard let childReadable = custom.span as? any ReadableSpan else {
             return XCTFail("Expected ReadableSpan")
         }

--- a/Tests/CoralogixRumTests/CoralogixCustomSpansTests.swift
+++ b/Tests/CoralogixRumTests/CoralogixCustomSpansTests.swift
@@ -55,6 +55,28 @@ final class CoralogixCustomSpansTests: XCTestCase {
         XCTAssertNil(tracer.startGlobalSpan(name: "root"))
     }
 
+    func testCustomSpansStampEventTypeSourceSeverityLikeBrowserSdk() {
+        let rum = CoralogixRum(options: options!)
+        let tracer = rum.getCustomTracer()
+        guard let global = tracer.startGlobalSpan(name: "g") else {
+            return XCTFail("Expected global span")
+        }
+        guard let globalData = (global.span as? ReadableSpan)?.toSpanData() else {
+            return XCTFail("Expected ReadableSpan")
+        }
+        XCTAssertEqual(globalData.attributes[Keys.eventType.rawValue], .string(CoralogixEventType.customSpan.rawValue))
+        XCTAssertEqual(globalData.attributes[Keys.source.rawValue], .string(Keys.code.rawValue))
+        XCTAssertEqual(globalData.attributes[Keys.severity.rawValue], .int(CoralogixLogSeverity.info.rawValue))
+
+        let child = global.startCustomSpan(name: "c")
+        guard let childData = (child.span as? ReadableSpan)?.toSpanData() else {
+            return XCTFail("Expected ReadableSpan")
+        }
+        XCTAssertEqual(childData.attributes[Keys.eventType.rawValue], .string(CoralogixEventType.customSpan.rawValue))
+        XCTAssertEqual(childData.attributes[Keys.source.rawValue], .string(Keys.code.rawValue))
+        XCTAssertEqual(childData.attributes[Keys.severity.rawValue], .int(CoralogixLogSeverity.info.rawValue))
+    }
+
     func testStartGlobalSpanAppliesNameLabelsAndSessionMetadata() {
         let rum = CoralogixRum(options: options!)
         let tracer = rum.getCustomTracer()

--- a/Tests/CoralogixRumTests/CoralogixCustomSpansTests.swift
+++ b/Tests/CoralogixRumTests/CoralogixCustomSpansTests.swift
@@ -62,7 +62,7 @@ final class CoralogixCustomSpansTests: XCTestCase {
         guard let global = tracer.startGlobalSpan(name: "g") else {
             return XCTFail("Expected global span")
         }
-        guard let globalData = (global.span as? ReadableSpan)?.toSpanData() else {
+        guard let globalData = (global.span as? any ReadableSpan)?.toSpanData() else {
             return XCTFail("Expected ReadableSpan")
         }
         XCTAssertEqual(globalData.attributes[Keys.eventType.rawValue], .string(CoralogixEventType.customSpan.rawValue))
@@ -70,7 +70,7 @@ final class CoralogixCustomSpansTests: XCTestCase {
         XCTAssertEqual(globalData.attributes[Keys.severity.rawValue], .int(CoralogixLogSeverity.info.rawValue))
 
         let child = global.startCustomSpan(name: "c")
-        guard let childData = (child.span as? ReadableSpan)?.toSpanData() else {
+        guard let childData = (child.span as? any ReadableSpan)?.toSpanData() else {
             return XCTFail("Expected ReadableSpan")
         }
         XCTAssertEqual(childData.attributes[Keys.eventType.rawValue], .string(CoralogixEventType.customSpan.rawValue))
@@ -85,11 +85,11 @@ final class CoralogixCustomSpansTests: XCTestCase {
         guard let global = tracer.startGlobalSpan(name: "g") else {
             return XCTFail("Expected global span")
         }
-        guard let globalData = (global.span as? ReadableSpan)?.toSpanData() else {
+        guard let globalData = (global.span as? any ReadableSpan)?.toSpanData() else {
             return XCTFail("Expected ReadableSpan")
         }
         let child = global.startCustomSpan(name: "c")
-        guard let childData = (child.span as? ReadableSpan)?.toSpanData() else {
+        guard let childData = (child.span as? any ReadableSpan)?.toSpanData() else {
             return XCTFail("Expected ReadableSpan")
         }
         XCTAssertEqual(childData.attributes[Keys.sessionId.rawValue], globalData.attributes[Keys.sessionId.rawValue])
@@ -107,7 +107,7 @@ final class CoralogixCustomSpansTests: XCTestCase {
         guard let global = tracer.startGlobalSpan(name: "checkout", labels: ["flow": "standard"]) else {
             return XCTFail("Expected global span")
         }
-        guard let readable = global.span as? ReadableSpan else {
+        guard let readable = global.span as? any ReadableSpan else {
             return XCTFail("Expected ReadableSpan")
         }
         let data = readable.toSpanData()
@@ -140,7 +140,7 @@ final class CoralogixCustomSpansTests: XCTestCase {
         guard let global = tracer.startGlobalSpan(name: "g", labels: ["tier": "global", "fromGlobal": "yes"]) else {
             return XCTFail("Expected global span")
         }
-        guard let globalJson = (global.span as? ReadableSpan)?.toSpanData().attributes[Keys.customLabels.rawValue],
+        guard let globalJson = (global.span as? any ReadableSpan)?.toSpanData().attributes[Keys.customLabels.rawValue],
               case let .string(globalStr) = globalJson,
               let globalDict = Helper.convertJsonStringToDict(jsonString: globalStr)
         else {
@@ -151,7 +151,7 @@ final class CoralogixCustomSpansTests: XCTestCase {
         XCTAssertEqual(globalDict["fromGlobal"] as? String, "yes")
 
         let child = global.startCustomSpan(name: "c", labels: ["tier": "child", "fromChild": "c"])
-        guard let childJson = (child.span as? ReadableSpan)?.toSpanData().attributes[Keys.customLabels.rawValue],
+        guard let childJson = (child.span as? any ReadableSpan)?.toSpanData().attributes[Keys.customLabels.rawValue],
               case let .string(childStr) = childJson,
               let childDict = Helper.convertJsonStringToDict(jsonString: childStr)
         else {
@@ -172,7 +172,7 @@ final class CoralogixCustomSpansTests: XCTestCase {
             return XCTFail("Expected global span")
         }
         let custom = global.startCustomSpan(name: "child")
-        guard let childReadable = custom.span as? ReadableSpan else {
+        guard let childReadable = custom.span as? any ReadableSpan else {
             return XCTFail("Expected ReadableSpan")
         }
         let childData = childReadable.toSpanData()
@@ -221,7 +221,7 @@ final class CoralogixCustomSpansTests: XCTestCase {
     func testEndSpanRestoresPreviousActiveSpan() {
         let rum = CoralogixRum(options: options!)
         let tracer = rum.tracerProvider()
-        var markerBuilder = tracer.spanBuilder(spanName: "marker")
+        let markerBuilder = tracer.spanBuilder(spanName: "marker")
         _ = markerBuilder.setActive(true)
         let marker = markerBuilder.startSpan()
         XCTAssertTrue(

--- a/Tests/CoralogixRumTests/CoralogixCustomSpansTests.swift
+++ b/Tests/CoralogixRumTests/CoralogixCustomSpansTests.swift
@@ -112,8 +112,57 @@ final class CoralogixCustomSpansTests: XCTestCase {
         }
         let data = readable.toSpanData()
         XCTAssertEqual(data.name, "checkout")
-        XCTAssertEqual(data.attributes["flow"], .string("standard"))
+        guard case let .string(json)? = data.attributes[Keys.customLabels.rawValue],
+              let dict = Helper.convertJsonStringToDict(jsonString: json) else {
+            return XCTFail("Expected custom_labels JSON on span")
+        }
+        XCTAssertEqual(dict["flow"] as? String, "standard")
         XCTAssertNotNil(data.attributes[Keys.sessionId.rawValue])
+    }
+
+    /// CX-35953: SDK `labels` → `startGlobalSpan` labels → `startCustomSpan` labels (each level overrides on key clash).
+    func testCustomSpanLabelsThreeLevelMergeIntoCustomLabelsJSON() {
+        let opts = CoralogixExporterOptions(
+            coralogixDomain: CoralogixDomain.US2,
+            userContext: nil,
+            environment: "PROD",
+            application: "TestApp-CustomSpans",
+            version: "1.0",
+            publicKey: "token",
+            ignoreUrls: [],
+            ignoreErrors: [],
+            labels: ["tier": "sdk", "onlySdk": "1"],
+            sessionSampleRate: 100,
+            debug: true
+        )
+        let rum = CoralogixRum(options: opts)
+        let tracer = rum.getCustomTracer()
+        guard let global = tracer.startGlobalSpan(name: "g", labels: ["tier": "global", "fromGlobal": "yes"]) else {
+            return XCTFail("Expected global span")
+        }
+        guard let globalJson = (global.span as? ReadableSpan)?.toSpanData().attributes[Keys.customLabels.rawValue],
+              case let .string(globalStr) = globalJson,
+              let globalDict = Helper.convertJsonStringToDict(jsonString: globalStr)
+        else {
+            return XCTFail("Expected global custom_labels")
+        }
+        XCTAssertEqual(globalDict["tier"] as? String, "global")
+        XCTAssertEqual(globalDict["onlySdk"] as? String, "1")
+        XCTAssertEqual(globalDict["fromGlobal"] as? String, "yes")
+
+        let child = global.startCustomSpan(name: "c", labels: ["tier": "child", "fromChild": "c"])
+        guard let childJson = (child.span as? ReadableSpan)?.toSpanData().attributes[Keys.customLabels.rawValue],
+              case let .string(childStr) = childJson,
+              let childDict = Helper.convertJsonStringToDict(jsonString: childStr)
+        else {
+            return XCTFail("Expected child custom_labels")
+        }
+        XCTAssertEqual(childDict["tier"] as? String, "child")
+        XCTAssertEqual(childDict["onlySdk"] as? String, "1")
+        XCTAssertEqual(childDict["fromGlobal"] as? String, "yes")
+        XCTAssertEqual(childDict["fromChild"] as? String, "c")
+        child.endSpan()
+        global.endSpan()
     }
 
     func testStartCustomSpanIsChildOfGlobalSpan() {

--- a/Tests/CoralogixRumTests/CoralogixCustomSpansTests.swift
+++ b/Tests/CoralogixRumTests/CoralogixCustomSpansTests.swift
@@ -22,6 +22,7 @@ final class CoralogixCustomSpansTests: XCTestCase {
     }
 
     override func tearDownWithError() throws {
+        CoralogixCustomGlobalSpanRegistry.shared.teardownIfNeeded()
         options = nil
         CoralogixRum.isInitialized = false
         RunLoop.main.run(until: Date().addingTimeInterval(0.05))
@@ -113,14 +114,59 @@ final class CoralogixCustomSpansTests: XCTestCase {
         guard let global = tracer.startGlobalSpan(name: "ctx") else {
             return XCTFail("Expected global span")
         }
+        XCTAssertTrue(
+            (OpenTelemetry.instance.contextProvider.activeSpan as AnyObject?) === (global.span as AnyObject),
+            "startGlobalSpan must register the span as active OTel context"
+        )
         let before = OpenTelemetry.instance.contextProvider.activeSpan
         global.withContext {
-            XCTAssertTrue(OpenTelemetry.instance.contextProvider.activeSpan === global.span)
+            XCTAssertTrue(
+                (OpenTelemetry.instance.contextProvider.activeSpan as AnyObject?) === (global.span as AnyObject),
+                "withContext must keep global as active when it already was"
+            )
         }
         XCTAssertEqual(
             OpenTelemetry.instance.contextProvider.activeSpan?.context.spanId,
             before?.context.spanId
         )
+        global.endSpan()
+    }
+
+    func testSecondStartGlobalSpanReturnsNilUntilFirstEnds() {
+        let rum = CoralogixRum(options: options!)
+        let tracer = rum.getCustomTracer()
+        guard let first = tracer.startGlobalSpan(name: "first") else {
+            return XCTFail("Expected first global span")
+        }
+        XCTAssertNil(tracer.startGlobalSpan(name: "second"))
+        first.endSpan()
+        guard let third = tracer.startGlobalSpan(name: "third") else {
+            return XCTFail("Expected new global after first ended")
+        }
+        third.endSpan()
+    }
+
+    func testEndSpanRestoresPreviousActiveSpan() {
+        let rum = CoralogixRum(options: options!)
+        let tracer = rum.tracerProvider()
+        var markerBuilder = tracer.spanBuilder(spanName: "marker")
+        _ = markerBuilder.setActive(true)
+        let marker = markerBuilder.startSpan()
+        XCTAssertTrue(
+            (OpenTelemetry.instance.contextProvider.activeSpan as AnyObject?) === (marker as AnyObject)
+        )
+        guard let global = rum.getCustomTracer().startGlobalSpan(name: "global") else {
+            return XCTFail("Expected global span")
+        }
+        XCTAssertTrue(
+            (OpenTelemetry.instance.contextProvider.activeSpan as AnyObject?) === (global.span as AnyObject)
+        )
+        global.endSpan()
+        XCTAssertTrue(
+            (OpenTelemetry.instance.contextProvider.activeSpan as AnyObject?) === (marker as AnyObject),
+            "endSpan must restore OTel context from before startGlobalSpan"
+        )
+        marker.end()
     }
 
     func testCustomSpanSetStatusAndEndSpan() {

--- a/Tests/CoralogixRumTests/CoralogixCustomSpansTests.swift
+++ b/Tests/CoralogixRumTests/CoralogixCustomSpansTests.swift
@@ -78,6 +78,29 @@ final class CoralogixCustomSpansTests: XCTestCase {
         XCTAssertEqual(childData.attributes[Keys.severity.rawValue], .int(CoralogixLogSeverity.info.rawValue))
     }
 
+    /// Nested custom spans must carry session/user attributes so `SessionContext` succeeds during export (otherwise the child is dropped and only the global appears in RUM).
+    func testStartCustomSpanIncludesSessionMetadataLikeGlobal() {
+        let rum = CoralogixRum(options: options!)
+        let tracer = rum.getCustomTracer()
+        guard let global = tracer.startGlobalSpan(name: "g") else {
+            return XCTFail("Expected global span")
+        }
+        guard let globalData = (global.span as? ReadableSpan)?.toSpanData() else {
+            return XCTFail("Expected ReadableSpan")
+        }
+        let child = global.startCustomSpan(name: "c")
+        guard let childData = (child.span as? ReadableSpan)?.toSpanData() else {
+            return XCTFail("Expected ReadableSpan")
+        }
+        XCTAssertEqual(childData.attributes[Keys.sessionId.rawValue], globalData.attributes[Keys.sessionId.rawValue])
+        XCTAssertEqual(
+            childData.attributes[Keys.sessionCreationDate.rawValue],
+            globalData.attributes[Keys.sessionCreationDate.rawValue]
+        )
+        child.endSpan()
+        global.endSpan()
+    }
+
     func testStartGlobalSpanAppliesNameLabelsAndSessionMetadata() {
         let rum = CoralogixRum(options: options!)
         let tracer = rum.getCustomTracer()

--- a/Tests/CoralogixRumTests/EventContextTests.swift
+++ b/Tests/CoralogixRumTests/EventContextTests.swift
@@ -50,6 +50,16 @@ final class EventContextTests: XCTestCase {
         XCTAssertEqual(context.type, CoralogixEventType.unknown)
     }
     
+    func testEventContextMissingSeverityDefaultsToInfo() {
+        let attributes: [String: Any] = [
+            Keys.eventType.rawValue: AttributeValue("log"),
+            Keys.source.rawValue: AttributeValue("code")
+        ]
+        let mockSpanData = MockSpanData(attributes: attributes)
+        let context = EventContext(otel: mockSpanData)
+        XCTAssertEqual(context.severity, CoralogixLogSeverity.info.rawValue)
+    }
+
     func testEventContextWithMalformedData() {
         // Mock data with a non-integer severity value
         let attributes: [String: Any] = [
@@ -62,8 +72,8 @@ final class EventContextTests: XCTestCase {
         // Initialize EventContext
         let context = EventContext(otel: mockSpanData)
         
-        // Severity should fallback to 0
-        XCTAssertEqual(context.severity, 0)
+        // Unparseable severity falls back to info (3), same as a missing attribute
+        XCTAssertEqual(context.severity, CoralogixLogSeverity.info.rawValue)
     }
     
     func testGetDictionary() {

--- a/Tests/CoralogixRumTests/InstrumentationDataTests.swift
+++ b/Tests/CoralogixRumTests/InstrumentationDataTests.swift
@@ -109,6 +109,16 @@ final class InstrumentationDataTests: XCTestCase {
         XCTAssertNotNil(dict[Keys.duration.rawValue])
         XCTAssertEqual(dict[Keys.keySessionId.rawValue] as? String, "session_001")
         XCTAssertNil(dict[Keys.parentSpanId.rawValue], "parentSpanId should be absent for root spans")
+
+        XCTAssertEqual(dict[Keys.otlpTraceId.rawValue] as? String, "trace123")
+        XCTAssertEqual(dict[Keys.otlpSpanId.rawValue] as? String, "span123")
+        XCTAssertEqual(dict[Keys.otlpKindString.rawValue] as? String, Keys.otlpSpanKindClient.rawValue)
+        XCTAssertNotNil(dict[Keys.otlpStartTimeUnixNano.rawValue] as? String)
+        XCTAssertNotNil(dict[Keys.otlpEndTimeUnixNano.rawValue] as? String)
+        XCTAssertEqual(
+            (dict[Keys.otlpStatus.rawValue] as? [String: Any])?[Keys.code.rawValue] as? String,
+            Keys.otlpStatusCodeUnset.rawValue
+        )
     }
 
     func testInitializationWithAttributes() throws {

--- a/Tests/CoralogixRumTests/SpanTests.swift
+++ b/Tests/CoralogixRumTests/SpanTests.swift
@@ -120,7 +120,55 @@ final class SpanTests: XCTestCase {
             XCTAssertNotNil(dict[Keys.instrumentationData.rawValue])
         }
     }
-    
+
+    /// Custom spans include `instrumentation_data.otelSpan` like the Browser SDK so Coralogix Tracing can ingest them.
+    func testInitializationWithInstrumentationDataForCustomSpan() {
+        guard let options = options else { return XCTFail("Failed to load options") }
+
+        mockSpanData = MockSpanData(
+            attributes: [
+                Keys.severity.rawValue: AttributeValue("3"),
+                Keys.eventType.rawValue: AttributeValue(CoralogixEventType.customSpan.rawValue),
+                Keys.source.rawValue: AttributeValue(Keys.code.rawValue),
+                Keys.environment.rawValue: AttributeValue("prod"),
+                Keys.userId.rawValue: AttributeValue("12345"),
+                Keys.userName.rawValue: AttributeValue("John Doe"),
+                Keys.userEmail.rawValue: AttributeValue("john.doe@example.com"),
+                Keys.sessionId.rawValue: AttributeValue("session_001"),
+                Keys.sessionCreationDate.rawValue: AttributeValue(1609459200)
+            ],
+            startTime: statTime,
+            endTime: endTime,
+            spanId: "20",
+            traceId: "30",
+            name: "demo.custom.global",
+            kind: 1,
+            statusCode: ["status": "ok"],
+            resources: ["a": AttributeValue("1"), "b": AttributeValue("2"), "c": AttributeValue("3")]
+        )
+
+        guard let cxSpan = CxSpan(
+            otel: mockSpanData,
+            versionMetadata: mockVersionMetadata,
+            sessionManager: mockSessionManager,
+            networkManager: mockNetworkManager,
+            viewManager: mockViewManager,
+            metricsManager: mockCxMetricsManager,
+            options: options
+        ) else {
+            return XCTFail("CxSpan init failed")
+        }
+        XCTAssertNotNil(cxSpan.instrumentationData)
+        guard let dict = cxSpan.getDictionary(),
+              let inst = dict[Keys.instrumentationData.rawValue] as? [String: Any],
+              let otelSpan = inst[Keys.otelSpan.rawValue] as? [String: Any] else {
+            return XCTFail("Expected instrumentation_data.otelSpan on custom-span log")
+        }
+        XCTAssertEqual(otelSpan[Keys.name.rawValue] as? String, "demo.custom.global")
+        XCTAssertEqual(otelSpan[Keys.traceId.rawValue] as? String, "30")
+        XCTAssertEqual(otelSpan[Keys.spanId.rawValue] as? String, "20")
+    }
+
 //    func testGetDictionary() {
 //        guard let options = options else { return XCTFail("Failed to load options") }
 //


### PR DESCRIPTION
## Summary

Adds a **Custom Spans** public API aligned with the Coralogix Browser SDK (`getCustomTracer`, `startGlobalSpan`, `startCustomSpan`, `endSpan`, `withContext`), a process-wide global span registry with OpenTelemetry active context, **3-level label merge** into `custom_labels` (CX-35953), and **RUM / tracing parity**: `event_type` `custom-span`, `instrumentation_data.otelSpan` for custom spans, plus OTLP-shaped mirror fields on `otelSpan` for backend extractors. Includes docs (`CORALOGIX_RUM.md`), Demo app screen, and unit tests.

## Code review (AI pre-merge)

Scope: new or modified code on this branch vs `master`.

### `Coralogix/Sources/CoralogixCustomSpans.swift`

- **Suggestion:** `withContext` manipulates OTel active span without the registry lock. If multi-threaded use is expected, document main-thread-only usage or add synchronization; otherwise acceptable for typical UI/RUM usage.
- **Nit (optional):** Document that callers should use `endSpan()` or rely on `shutdown()` so active context is restored.

### `Coralogix/Sources/CoralogixRum.swift`

- **Issue:** None noted in the new code. Shared **`addRumCorrelationMetadata`** / **`addSessionAndPrevSessionMetadata`** deduplicate session and user metadata with `makeSpan` (addresses prior drift risk).

### `Coralogix/Sources/Model/Contexts/EventContext.swift`

- **Issue:** Default `severity` is now **info** when the attribute is missing or not parseable, instead of **0**. This applies to **all** event types using `EventContext`, not only custom spans. Confirm downstream consumers do not rely on `0` meaning “unset.”

### `Coralogix/Sources/Model/CxSpan.swift`

- **Suggestion:** `instrumentation_data` for `custom-span` matches the network path; no issues in the new conditions.

### `Coralogix/Sources/Model/InstrumentationData.swift`

- **Suggestion:** OTLP `kind_string` is always `SPAN_KIND_CLIENT`, consistent with `SpanData.getKind()` in this SDK today; if span kinds ever diverge, mirrors may need to follow real kind.

### `CoralogixInternal/Sources/Keys.swift`

- **Nit (optional):** New OTLP mirror keys and `customSpan` event type are clear.

### `Coralogix/Docs/CORALOGIX_RUM.md`

- **Suggestion:** The note that iOS uses the RUM logs endpoint and tracing may depend on backend/pipeline is helpful.

### `Example/DemoAppSwift/CustomSpansViewController.swift`

- **Nit (optional):** The “second global” demo uses a toast message containing the word “Bug” when asserting behavior—fine for internal demo.

### Tests

- **Suggestion:** If test bundles run in parallel in CI, shared `CoralogixRum.isInitialized` / registry teardown could interact; current pattern is acceptable for serial runs.

### Overall

The new custom-span API, registry behavior, label merge, and instrumentation/export paths are consistent with stated Browser parity and tests. **No blocking issues** beyond confirming the **EventContext severity default** change is acceptable product-wide.

---

**Tickets:** CX-35951, CX-35952, CX-35953


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manual OpenTelemetry-style custom spans for iOS RUM: single global span, nested child spans, context propagation, label-merge semantics, and lifecycle APIs.

* **Documentation**
  * New guide covering custom spans, expected event fields, label precedence, OTLP-style payloads, and usage examples.

* **Example Updates**
  * Demo app screen with interactive scripted demos for global/child span scenarios.

* **Bug Fixes / Behaviour**
  * Severity now defaults to "info" when missing or malformed.

* **Tests**
  * Added end-to-end and unit tests for custom spans, OTLP fields, label merging, and context handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->