### PR TITLE
CX-35954/CX-35955: Global span trace propagation and ignoredInstruments for auto spans

### DIFF
--- a/Coralogix.podspec
+++ b/Coralogix.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "Coralogix"
-  spec.version      = "2.4.1"
+  spec.version      = "2.5.0"
   spec.summary      = "Coralogix OpenTelemetry pod for iOS."
 
   spec.description  = <<-DESC
@@ -29,7 +29,7 @@ Pod::Spec.new do |spec|
 
   spec.static_framework = true
   spec.dependency 'PLCrashReporter', '~> 1.12'
-  spec.dependency 'CoralogixInternal', '2.4.1'
+  spec.dependency 'CoralogixInternal', '2.5.0'
 
   spec.test_spec 'Tests' do |test|
     test.source_files = 'Tests/CoralogixRumTests/**/*.swift'

--- a/Coralogix/Docs/CORALOGIX_RUM.md
+++ b/Coralogix/Docs/CORALOGIX_RUM.md
@@ -314,6 +314,8 @@ The Custom Spans API mirrors the Coralogix Browser SDK naming (`startCustomSpan`
 
 Only **one** global custom span may exist at a time (same as the Browser SDK). `startGlobalSpan` registers it as the **active OpenTelemetry span**, so auto-instrumented spans and network propagation can share the same `traceId` until `endSpan()` (which restores the prior active context). `withContext` is a no-op when the global span is already active. `shutdown()` clears a leaked global registration.
 
+**`getCustomTracer()` guards (CX-35956, Browser parity):** Returns `nil` if the SDK is not initialized; if `traceParentInHeader` is missing or `enable` is not `true` (see `TraceParentInHeader` / `Keys.enable`); or if a custom tracer was already obtained in this SDK lifecycle. A second successful `getCustomTracer()` is only possible after `shutdown()` reinitializes the slot. `startGlobalSpan` returns `nil` when a global span is already active (warning log: global span already exists).
+
 **Label merge (CX-35953, Browser parity):** Labels from `CoralogixRum` init / `setLabels` (SDK level), then `startGlobalSpan(name:labels:)`, then `startCustomSpan(name:labels:)`—each step overrides the same key from the previous. The merged map is stored on the span as a JSON string attribute **`custom_labels`**, same as the Browser SDK’s `setCustomLabelsForSpan` / `getCustomMergedLabels`. RUM `text.cx_rum.labels` is built from SDK options merged with that attribute (see `Helper.getLabels`).
 
 **Tracing:** Each exported custom-span log includes **`instrumentation_data.otelSpan`** with mobile fields plus **OTLP-style mirrors** used by the Browser trace converter (`trace_id`, `span_id`, `parent_span_id`, `start_time_unix_nano`, `end_time_unix_nano`, `kind_string`, `status_otlp`). The Browser SDK also sends a **separate** OTLP payload via optional `tracesExporter`; iOS only uses the RUM logs endpoint. If spans still do not appear under **Tracing**, confirm with Coralogix that your account indexes `instrumentation_data` from **mobile** RUM (pipeline may differ from web).
@@ -321,14 +323,14 @@ Only **one** global custom span may exist at a time (same as the Browser SDK). `
 ### Types
 
 - `CoralogixIgnoredInstrument` — `.networkRequests`, `.userInteractions`, `.errors` (values are reserved for future behavior when combining auto-instrumentation with custom traces).
-- `CoralogixCustomTracer` — from `getCustomTracer(ignoredInstruments:)`.
+- `CoralogixCustomTracer` — from `getCustomTracer(ignoredInstruments:)` (optional; see CX-35956 guards above).
 - `CoralogixGlobalSpan` — root span from `startGlobalSpan(name:labels:)`; exposes `span`, `withContext(_:)`, `startCustomSpan(name:labels:)`, `endSpan()`.
 - `CoralogixCustomSpan` — nested span; exposes `span`, `endSpan()`, `setAttribute`, `addEvent`, `setStatus`.
 
 ### Example
 
 ```swift
-let tracer = coralogixRum.getCustomTracer(ignoredInstruments: [.networkRequests])
+guard let tracer = coralogixRum.getCustomTracer(ignoredInstruments: [.networkRequests]) else { return }
 guard let global = tracer.startGlobalSpan(name: "checkout", labels: ["step": "payment"]) else { return }
 
 global.withContext {
@@ -340,7 +342,7 @@ global.withContext {
 global.endSpan()
 ```
 
-`startGlobalSpan` returns `nil` if the SDK did not finish initialization (for example, sampling disabled the SDK).
+`startGlobalSpan` returns `nil` if the SDK did not finish initialization (for example, sampling disabled the SDK), or if a global span is already active.
 
 ## About Method Swizzling and SwiftUI Modifiers
 ### Method Swizzling

--- a/Coralogix/Docs/CORALOGIX_RUM.md
+++ b/Coralogix/Docs/CORALOGIX_RUM.md
@@ -68,6 +68,7 @@ Identify if your app project contains an `AppDelegate` file or a `SceneDelegate`
                                                ignoreErrors: [],
                                                labels: ["String" : Any],
                                                sessionSampleRate: 100,
+                                               traceParentInHeader: ["enable": true],
                                                debug: false)
         self.coralogixRum = CoralogixRum(options: options)
         
@@ -314,7 +315,7 @@ The Custom Spans API mirrors the Coralogix Browser SDK naming (`startCustomSpan`
 
 Only **one** global custom span may exist at a time (same as the Browser SDK). `startGlobalSpan` registers it as the **active OpenTelemetry span**, so auto-instrumented spans and network propagation can share the same `traceId` until `endSpan()` (which restores the prior active context). `withContext` is a no-op when the global span is already active. `shutdown()` clears a leaked global registration.
 
-**`getCustomTracer()` guards (CX-35956, Browser parity):** Returns `nil` if the SDK is not initialized; if `traceParentInHeader` is missing or `enable` is not `true` (see `TraceParentInHeader` / `Keys.enable`); or if a custom tracer was already obtained in this SDK lifecycle. A second successful `getCustomTracer()` is only possible after `shutdown()` reinitializes the slot. `startGlobalSpan` returns `nil` when a global span is already active (warning log: global span already exists).
+**`getCustomTracer()` opt-in and guards (CX-35956, Browser parity):** Custom spans are **opt-in** via exporter options: set **`traceParentInHeader`** to a dictionary with the public key **`"enable"`** and value **`true`** (for example `traceParentInHeader: ["enable": true]` in Swift). The SDK reads that flag from your options dictionary; you do **not** reference internal types such as `TraceParentInHeader` or the `Keys` enum in app code. **`getCustomTracer()`** returns **`nil`** unless the SDK is initialized, **`traceParentInHeader`** is present with **`enable`** set to **`true`**, and a custom tracer has **not** already been issued in this SDK lifecycle (only **`shutdown()`** resets that slot so another `getCustomTracer()` can succeed). **`startGlobalSpan`** returns **`nil`** when a global span is already active (warning log: global span already exists).
 
 **Label merge (CX-35953, Browser parity):** Labels from `CoralogixRum` init / `setLabels` (SDK level), then `startGlobalSpan(name:labels:)`, then `startCustomSpan(name:labels:)`—each step overrides the same key from the previous. The merged map is stored on the span as a JSON string attribute **`custom_labels`**, same as the Browser SDK’s `setCustomLabelsForSpan` / `getCustomMergedLabels`. RUM `text.cx_rum.labels` is built from SDK options merged with that attribute (see `Helper.getLabels`).
 

--- a/Coralogix/Sources/CoralogixCustomSpans.swift
+++ b/Coralogix/Sources/CoralogixCustomSpans.swift
@@ -154,7 +154,7 @@ public final class CoralogixCustomTracer {
         rum.addRumCorrelationMetadata(to: &otelSpan)
         setMergedCustomLabelsJSON(merged: mergedSdkAndGlobal, on: &otelSpan)
         guard CoralogixCustomGlobalSpanRegistry.shared.registerGlobalSpan(otelSpan, ignoredInstruments: ignoredInstruments) else {
-            Log.w("Global custom span already active — startGlobalSpan ignored; ending orphan span")
+            Log.w("Global span already exists")
             otelSpan.end()
             return nil
         }

--- a/Coralogix/Sources/CoralogixCustomSpans.swift
+++ b/Coralogix/Sources/CoralogixCustomSpans.swift
@@ -48,7 +48,7 @@ final class CoralogixCustomGlobalSpanRegistry {
     /// Ends the registry entry for this span: clears state, ends the span, restores previous active context. Returns `false` if `span` is not the registered global.
     func endGlobalSpanIfMatches(_ span: any Span) -> Bool {
         lock.lock()
-        let isMatch = (registeredGlobal as AnyObject?) === (span as AnyObject)
+        let isMatch = registeredGlobal?.context.spanId == span.context.spanId
         let previous = spanActiveBeforeGlobal
         if isMatch {
             registeredGlobal = nil
@@ -189,7 +189,7 @@ public final class CoralogixGlobalSpan {
 
     private func isRegisteredGlobalActiveInOTel() -> Bool {
         let active = OpenTelemetry.instance.contextProvider.activeSpan
-        return (active as AnyObject?) === (span as AnyObject)
+        return active?.context.spanId == span.context.spanId
     }
 
     /// Runs `work` with this span as the active OTel context. If it is already active (after `startGlobalSpan`), runs `work` without removing it from context.

--- a/Coralogix/Sources/CoralogixCustomSpans.swift
+++ b/Coralogix/Sources/CoralogixCustomSpans.swift
@@ -168,6 +168,10 @@ public final class CoralogixCustomTracer {
 }
 
 /// A root custom span created via `CoralogixCustomTracer.startGlobalSpan(name:labels:)`.
+///
+/// - Note: This class holds a weak reference to `CoralogixRum`. If the SDK is deallocated while
+///   a global span is still in use, `startCustomSpan` will still work but RUM correlation metadata
+///   will not be added to child spans.
 public final class CoralogixGlobalSpan {
     public let span: any Span
     private let tracer: Tracer

--- a/Coralogix/Sources/CoralogixCustomSpans.swift
+++ b/Coralogix/Sources/CoralogixCustomSpans.swift
@@ -17,6 +17,8 @@ final class CoralogixCustomGlobalSpanRegistry {
     private let lock = NSLock()
     private weak var registeredGlobal: (any Span)?
     private weak var spanActiveBeforeGlobal: (any Span)?
+    /// `ignoredInstruments` from the `CoralogixCustomTracer` that started the active global span (CX-35955).
+    private var ignoredInstruments: Set<CoralogixIgnoredInstrument> = []
 
     private init() {}
 
@@ -30,7 +32,7 @@ final class CoralogixCustomGlobalSpanRegistry {
     }
 
     /// Returns `false` if a global custom span is already registered (second `startGlobalSpan` is ignored, like the Browser SDK).
-    func registerGlobalSpan(_ span: any Span) -> Bool {
+    func registerGlobalSpan(_ span: any Span, ignoredInstruments: Set<CoralogixIgnoredInstrument>) -> Bool {
         lock.lock()
         defer { lock.unlock() }
         if registeredGlobal != nil {
@@ -38,6 +40,7 @@ final class CoralogixCustomGlobalSpanRegistry {
         }
         spanActiveBeforeGlobal = OpenTelemetry.instance.contextProvider.activeSpan
         registeredGlobal = span
+        self.ignoredInstruments = ignoredInstruments
         OpenTelemetry.instance.contextProvider.setActiveSpan(span)
         return true
     }
@@ -50,6 +53,7 @@ final class CoralogixCustomGlobalSpanRegistry {
         if isMatch {
             registeredGlobal = nil
             spanActiveBeforeGlobal = nil
+            ignoredInstruments = []
         }
         lock.unlock()
         guard isMatch else {
@@ -66,6 +70,14 @@ final class CoralogixCustomGlobalSpanRegistry {
         return registeredGlobal
     }
 
+    /// CX-35955: If the active global was started with this instrument in `ignoredInstruments`, the corresponding auto span must **not** inherit the global trace (`setNoParent()`).
+    internal func shouldBreakTraceInheritance(for instrument: CoralogixIgnoredInstrument) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard registeredGlobal != nil else { return false }
+        return ignoredInstruments.contains(instrument)
+    }
+
     /// Clears any registered global custom span (`shutdown` and unit tests). Ends the span if still active and restores the pre-global OTel context.
     internal func teardownIfNeeded() {
         lock.lock()
@@ -73,6 +85,7 @@ final class CoralogixCustomGlobalSpanRegistry {
         let previous = spanActiveBeforeGlobal
         registeredGlobal = nil
         spanActiveBeforeGlobal = nil
+        ignoredInstruments = []
         lock.unlock()
         guard let g else { return }
         Self.endGlobalSpanAndRestorePrevious(g, previous: previous)
@@ -140,7 +153,7 @@ public final class CoralogixCustomTracer {
         stampCoralogixCustomSpanRUM(on: &otelSpan)
         rum.addRumCorrelationMetadata(to: &otelSpan)
         setMergedCustomLabelsJSON(merged: mergedSdkAndGlobal, on: &otelSpan)
-        guard CoralogixCustomGlobalSpanRegistry.shared.registerGlobalSpan(otelSpan) else {
+        guard CoralogixCustomGlobalSpanRegistry.shared.registerGlobalSpan(otelSpan, ignoredInstruments: ignoredInstruments) else {
             Log.w("Global custom span already active — startGlobalSpan ignored; ending orphan span")
             otelSpan.end()
             return nil

--- a/Coralogix/Sources/CoralogixCustomSpans.swift
+++ b/Coralogix/Sources/CoralogixCustomSpans.swift
@@ -59,6 +59,13 @@ final class CoralogixCustomGlobalSpanRegistry {
         return true
     }
 
+    /// When `OpenTelemetry.instance.contextProvider.activeSpan` is `nil` (e.g. URLSession callback or `DispatchQueue` work on another activity) but a global custom span is still registered, auto-instrumented spans should parent under that span so traceId / parentSpanId match the global trace (CX-35954).
+    internal func registeredGlobalForAutoInstrumentationParent() -> (any Span)? {
+        lock.lock()
+        defer { lock.unlock() }
+        return registeredGlobal
+    }
+
     /// Clears any registered global custom span (`shutdown` and unit tests). Ends the span if still active and restores the pre-global OTel context.
     internal func teardownIfNeeded() {
         lock.lock()

--- a/Coralogix/Sources/CoralogixRum.swift
+++ b/Coralogix/Sources/CoralogixRum.swift
@@ -431,7 +431,13 @@ public class CoralogixRum {
     }
     
     internal func makeSpan(event: CoralogixEventType, source: Keys, severity: CoralogixLogSeverity) -> any Span {
-        var span = tracerProvider().spanBuilder(spanName: Keys.iosSdk.rawValue).startSpan()
+        var builder = tracerProvider().spanBuilder(spanName: Keys.iosSdk.rawValue)
+        // CX-35954: same as URLSessionLogger — parent under registered global when activeSpan is nil (async / different activity).
+        if OpenTelemetry.instance.contextProvider.activeSpan == nil,
+           let global = CoralogogixCustomGlobalSpanRegistry.shared.registeredGlobalForAutoInstrumentationParent() {
+            _ = builder.setParent(global)
+        }
+        var span = builder.startSpan()
         span.setAttribute(key: Keys.eventType.rawValue, value: event.rawValue)
         span.setAttribute(key: Keys.source.rawValue, value: source.rawValue)
         span.setAttribute(key: Keys.severity.rawValue, value: AttributeValue.int(severity.rawValue))

--- a/Coralogix/Sources/CoralogixRum.swift
+++ b/Coralogix/Sources/CoralogixRum.swift
@@ -40,6 +40,14 @@ public class CoralogixRum {
     
     static var isInitialized = false
     static var mobileSDK: MobileSDK = MobileSDK()
+
+    /// CX-35956: `getCustomTracer()` may succeed only once per SDK lifecycle (`shutdown()` clears).
+    private static var customTracerIssued = false
+
+    /// Resets CX-35956 singleton state when tests reinitialize the SDK in-process without calling `shutdown()`.
+    internal static func resetCustomTracerIssuanceForTesting() {
+        customTracerIssued = false
+    }
     
     public init(
         options: CoralogixExporterOptions,
@@ -312,6 +320,7 @@ public class CoralogixRum {
     
     public func shutdown() {
         CoralogixCustomGlobalSpanRegistry.shared.teardownIfNeeded()
+        CoralogixRum.customTracerIssued = false
         CoralogixRum.isInitialized = false
         self.coralogixExporter?.shutdown(explicitTimeout: nil)
         self.removeNotification()
@@ -374,9 +383,34 @@ public class CoralogixRum {
 
     /// Returns a tracer for manual custom spans (API naming aligned with the Coralogix Browser SDK: `startCustomSpan`, `endSpan`).
     ///
+    /// CX-35956: Returns `nil` when the SDK is not initialized, `traceParentInHeader` is not configured with `enable: true`,
+    /// or a custom tracer was already obtained (singleton until `shutdown()`).
+    ///
     /// - Parameter ignoredInstruments: When starting a global span via this tracer, listed instruments do not inherit that global trace (CX-35955); auto spans for those types use `setNoParent()`.
-    public func getCustomTracer(ignoredInstruments: Set<CoralogixIgnoredInstrument> = []) -> CoralogixCustomTracer {
-        CoralogixCustomTracer(rum: self, ignoredInstruments: ignoredInstruments)
+    public func getCustomTracer(ignoredInstruments: Set<CoralogixIgnoredInstrument> = []) -> CoralogixCustomTracer? {
+        guard CoralogixRum.isInitialized else {
+            Log.w("Coralogix RUM is not initialized — getCustomTracer unavailable")
+            return nil
+        }
+        guard let opts = self.options else {
+            Log.w("traceParentInHeader must be enabled to use custom tracer")
+            return nil
+        }
+        guard let tpDict = opts.traceParentInHeader else {
+            Log.w("traceParentInHeader must be enabled to use custom tracer")
+            return nil
+        }
+        let traceParent = TraceParentInHeader(params: tpDict)
+        guard traceParent.enable else {
+            Log.w("traceParentInHeader must be enabled to use custom tracer")
+            return nil
+        }
+        guard !CoralogixRum.customTracerIssued else {
+            Log.w("Custom tracer already exists")
+            return nil
+        }
+        CoralogixRum.customTracerIssued = true
+        return CoralogixCustomTracer(rum: self, ignoredInstruments: ignoredInstruments)
     }
     
     // MARK: - Spans & Attributes

--- a/Coralogix/Sources/CoralogixRum.swift
+++ b/Coralogix/Sources/CoralogixRum.swift
@@ -43,9 +43,13 @@ public class CoralogixRum {
 
     /// CX-35956: `getCustomTracer()` may succeed only once per SDK lifecycle (`shutdown()` clears).
     private static var customTracerIssued = false
+    /// Serializes check-and-set for `customTracerIssued` so concurrent `getCustomTracer()` calls cannot both succeed.
+    private static let customTracerIssuanceLock = NSLock()
 
     /// Resets CX-35956 singleton state when tests reinitialize the SDK in-process without calling `shutdown()`.
     internal static func resetCustomTracerIssuanceForTesting() {
+        customTracerIssuanceLock.lock()
+        defer { customTracerIssuanceLock.unlock() }
         customTracerIssued = false
     }
     
@@ -320,7 +324,9 @@ public class CoralogixRum {
     
     public func shutdown() {
         CoralogixCustomGlobalSpanRegistry.shared.teardownIfNeeded()
+        Self.customTracerIssuanceLock.lock()
         CoralogixRum.customTracerIssued = false
+        Self.customTracerIssuanceLock.unlock()
         CoralogixRum.isInitialized = false
         self.coralogixExporter?.shutdown(explicitTimeout: nil)
         self.removeNotification()
@@ -384,7 +390,7 @@ public class CoralogixRum {
     /// Returns a tracer for manual custom spans (API naming aligned with the Coralogix Browser SDK: `startCustomSpan`, `endSpan`).
     ///
     /// CX-35956: Returns `nil` when the SDK is not initialized, `traceParentInHeader` is not configured with `enable: true`,
-    /// or a custom tracer was already obtained (singleton until `shutdown()`).
+    /// or a custom tracer was already obtained (singleton until `shutdown()`). The issuance check is locked so concurrent calls cannot both obtain a tracer.
     ///
     /// - Parameter ignoredInstruments: When starting a global span via this tracer, listed instruments do not inherit that global trace (CX-35955); auto spans for those types use `setNoParent()`.
     public func getCustomTracer(ignoredInstruments: Set<CoralogixIgnoredInstrument> = []) -> CoralogixCustomTracer? {
@@ -405,6 +411,8 @@ public class CoralogixRum {
             Log.w("traceParentInHeader must be enabled to use custom tracer")
             return nil
         }
+        Self.customTracerIssuanceLock.lock()
+        defer { Self.customTracerIssuanceLock.unlock() }
         guard !CoralogixRum.customTracerIssued else {
             Log.w("Custom tracer already exists")
             return nil

--- a/Coralogix/Sources/CoralogixRum.swift
+++ b/Coralogix/Sources/CoralogixRum.swift
@@ -374,7 +374,7 @@ public class CoralogixRum {
 
     /// Returns a tracer for manual custom spans (API naming aligned with the Coralogix Browser SDK: `startCustomSpan`, `endSpan`).
     ///
-    /// - Parameter ignoredInstruments: Reserved for future use (filtering auto-instrumentation interaction with custom trace context).
+    /// - Parameter ignoredInstruments: When starting a global span via this tracer, listed instruments do not inherit that global trace (CX-35955); auto spans for those types use `setNoParent()`.
     public func getCustomTracer(ignoredInstruments: Set<CoralogixIgnoredInstrument> = []) -> CoralogixCustomTracer {
         CoralogixCustomTracer(rum: self, ignoredInstruments: ignoredInstruments)
     }
@@ -430,11 +430,23 @@ public class CoralogixRum {
         print(coralogixText)
     }
     
+    /// Maps auto-instrumented `CoralogixEventType` values to `CoralogixIgnoredInstrument` (CX-35955).
+    private static func ignoredInstrument(forAutoSpanEvent event: CoralogixEventType) -> CoralogixIgnoredInstrument? {
+        switch event {
+        case .networkRequest: return .networkRequests
+        case .userInteraction: return .userInteractions
+        case .error: return .errors
+        default: return nil
+        }
+    }
+
     internal func makeSpan(event: CoralogixEventType, source: Keys, severity: CoralogixLogSeverity) -> any Span {
         var builder = tracerProvider().spanBuilder(spanName: Keys.iosSdk.rawValue)
-        // CX-35954: same as URLSessionLogger — parent under registered global when activeSpan is nil (async / different activity).
-        if OpenTelemetry.instance.contextProvider.activeSpan == nil,
-           let global = CoralogogixCustomGlobalSpanRegistry.shared.registeredGlobalForAutoInstrumentationParent() {
+        if let ignored = Self.ignoredInstrument(forAutoSpanEvent: event),
+           CoralogixCustomGlobalSpanRegistry.shared.shouldBreakTraceInheritance(for: ignored) {
+            _ = builder.setNoParent()
+        } else if OpenTelemetry.instance.contextProvider.activeSpan == nil,
+                  let global = CoralogixCustomGlobalSpanRegistry.shared.registeredGlobalForAutoInstrumentationParent() {
             _ = builder.setParent(global)
         }
         var span = builder.startSpan()

--- a/Coralogix/Sources/CoralogixRum.swift
+++ b/Coralogix/Sources/CoralogixRum.swift
@@ -470,7 +470,9 @@ public class CoralogixRum {
         case .networkRequest: return .networkRequests
         case .userInteraction: return .userInteractions
         case .error: return .errors
-        default: return nil
+        default:
+            // Event types without a mapping never use `ignoredInstruments`; they follow the global parent policy in `applyAutoInstrumentationParentPolicy`.
+            return nil
         }
     }
 

--- a/Coralogix/Sources/CoralogixRum.swift
+++ b/Coralogix/Sources/CoralogixRum.swift
@@ -440,15 +440,23 @@ public class CoralogixRum {
         }
     }
 
-    internal func makeSpan(event: CoralogixEventType, source: Keys, severity: CoralogixLogSeverity) -> any Span {
-        var builder = tracerProvider().spanBuilder(spanName: Keys.iosSdk.rawValue)
-        if let ignored = Self.ignoredInstrument(forAutoSpanEvent: event),
+    /// CX-35955: opt out of global trace when this event type is in the active global's `ignoredInstruments`.
+    /// CX-35954: when OTel has no active span but a global is registered, parent explicitly under the global (async / other activity).
+    private static func applyAutoInstrumentationParentPolicy(builder: SpanBuilder, event: CoralogixEventType) {
+        if let ignored = ignoredInstrument(forAutoSpanEvent: event),
            CoralogixCustomGlobalSpanRegistry.shared.shouldBreakTraceInheritance(for: ignored) {
             _ = builder.setNoParent()
-        } else if OpenTelemetry.instance.contextProvider.activeSpan == nil,
-                  let global = CoralogixCustomGlobalSpanRegistry.shared.registeredGlobalForAutoInstrumentationParent() {
+            return
+        }
+        if OpenTelemetry.instance.contextProvider.activeSpan == nil,
+           let global = CoralogixCustomGlobalSpanRegistry.shared.registeredGlobalForAutoInstrumentationParent() {
             _ = builder.setParent(global)
         }
+    }
+
+    internal func makeSpan(event: CoralogixEventType, source: Keys, severity: CoralogixLogSeverity) -> any Span {
+        let builder = tracerProvider().spanBuilder(spanName: Keys.iosSdk.rawValue)
+        Self.applyAutoInstrumentationParentPolicy(builder: builder, event: event)
         var span = builder.startSpan()
         span.setAttribute(key: Keys.eventType.rawValue, value: event.rawValue)
         span.setAttribute(key: Keys.source.rawValue, value: source.rawValue)

--- a/Coralogix/Sources/CoralogixRum.swift
+++ b/Coralogix/Sources/CoralogixRum.swift
@@ -393,7 +393,7 @@ public class CoralogixRum {
             return nil
         }
         guard let opts = self.options else {
-            Log.w("traceParentInHeader must be enabled to use custom tracer")
+            Log.w("getCustomTracer unavailable — exporter options missing (SDK may not be fully initialized)")
             return nil
         }
         guard let tpDict = opts.traceParentInHeader else {

--- a/Coralogix/Sources/Model/CxSpan.swift
+++ b/Coralogix/Sources/Model/CxSpan.swift
@@ -174,13 +174,15 @@ public class CxSpan {
         return mergedDict
     }
     
+    /// Valid severity range (CoralogixLogSeverity: debug=1 through critical=6).
+    private static let validSeverityRange = 1...6
+
     /// Normalizes a severity value supplied by beforeSend into an Int.
     /// Accepts Int directly or a numeric String (matching the OTEL attribute initializer path).
-    /// Returns `fallback` when the value is nil, non-numeric, or an unrecognised type.
+    /// Returns `fallback` when the value is nil, non-numeric, out of valid range (1-6), or an unrecognised type.
     private static func parseSeverity(_ value: Any?, fallback: Int) -> Int {
-        if let intVal = value as? Int { return intVal }
-        if let strVal = value as? String, let parsed = Int(strVal) { return parsed }
-        return fallback
+        let parsed = (value as? Int) ?? (value as? String).flatMap(Int.init)
+        return parsed.flatMap { validSeverityRange.contains($0) ? $0 : nil } ?? fallback
     }
 
     private func updateSnapshotErrorCount(in result: inout [String: Any], sessionManager: SessionManager) {

--- a/Coralogix/Sources/Otel/URLSession/URLSessionInstrumentation.swift
+++ b/Coralogix/Sources/Otel/URLSession/URLSessionInstrumentation.swift
@@ -612,6 +612,10 @@ public class URLSessionInstrumentation {
                                     URLSessionLogger.logResponse(response, dataOrFile: body, instrumentation: self, sessionTaskId: sessionTaskId)
                                 }
                             }
+                            // Clean up requestMap to prevent memory leak
+                            self.queue.sync(flags: .barrier) {
+                                self.requestMap[sessionTaskId] = nil
+                            }
                             // Mark as logged to prevent duplicate in setState: fallback
                             objc_setAssociatedObject(task, &Self.loggedKey, true, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
                             
@@ -692,6 +696,10 @@ public class URLSessionInstrumentation {
                                 #endif
                                 URLSessionLogger.logResponse(response, dataOrFile: body, instrumentation: self, sessionTaskId: sessionTaskId)
                             }
+                        }
+                        // Clean up requestMap to prevent memory leak
+                        self.queue.sync(flags: .barrier) {
+                            self.requestMap[sessionTaskId] = nil
                         }
                         // Mark as logged to prevent duplicate in setState: fallback
                         objc_setAssociatedObject(task, &Self.loggedKey, true, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)

--- a/Coralogix/Sources/Otel/URLSession/URLSessionLogger.swift
+++ b/Coralogix/Sources/Otel/URLSession/URLSessionLogger.swift
@@ -30,6 +30,19 @@ class URLSessionLogger {
         }()
     #endif // os(iOS) && !targetEnvironment(macCatalyst)
 
+    /// CX-35955: when `.networkRequests` is ignored for the active global, start a new trace (`traceparent` matches).
+    /// CX-35954: when OTel has no active span but a global is registered, parent under the global (async URLSession work).
+    private static func applyNetworkAutoInstrumentationParentPolicy(to spanBuilder: SpanBuilder) {
+        if CoralogixCustomGlobalSpanRegistry.shared.shouldBreakTraceInheritance(for: .networkRequests) {
+            _ = spanBuilder.setNoParent()
+            return
+        }
+        if OpenTelemetry.instance.contextProvider.activeSpan == nil,
+           let global = CoralogixCustomGlobalSpanRegistry.shared.registeredGlobalForAutoInstrumentationParent() {
+            _ = spanBuilder.setParent(global)
+        }
+    }
+
     /// This methods creates a Span for a request, and optionally injects tracing headers, returns a  new request if it was needed to create a new one to add the tracing headers
     @discardableResult static func processAndLogRequest(_ request: URLRequest, sessionTaskId: String, instrumentation: URLSessionInstrumentation, shouldInjectHeaders: Bool, preCapturedRequestBody: Data? = nil) -> URLRequest? {
         guard instrumentation.configuration.shouldInstrument?(request) ?? true else {
@@ -74,15 +87,7 @@ class URLSessionLogger {
             spanBuilder.setAttribute(key: $0.key, value: $0.value)
         }
         instrumentation.configuration.spanCustomization?(request, spanBuilder)
-
-        // CX-35955: ignored `.networkRequests` → fresh trace (no global parent), including traceparent.
-        if CoralogixCustomGlobalSpanRegistry.shared.shouldBreakTraceInheritance(for: .networkRequests) {
-            _ = spanBuilder.setNoParent()
-        } else if OpenTelemetry.instance.contextProvider.activeSpan == nil,
-                  let global = CoralogixCustomGlobalSpanRegistry.shared.registeredGlobalForAutoInstrumentationParent() {
-            // CX-35954: OTel active context can be empty on async queues while a global span is still registered.
-            _ = spanBuilder.setParent(global)
-        }
+        Self.applyNetworkAutoInstrumentationParentPolicy(to: spanBuilder)
 
         let span = spanBuilder.startSpan()
         runningSpansQueue.sync {

--- a/Coralogix/Sources/Otel/URLSession/URLSessionLogger.swift
+++ b/Coralogix/Sources/Otel/URLSession/URLSessionLogger.swift
@@ -75,6 +75,12 @@ class URLSessionLogger {
         }
         instrumentation.configuration.spanCustomization?(request, spanBuilder)
 
+        // CX-35954: OTel active context can be empty on async queues while a global span is still registered.
+        if OpenTelemetry.instance.contextProvider.activeSpan == nil,
+           let global = CoralogixCustomGlobalSpanRegistry.shared.registeredGlobalForAutoInstrumentationParent() {
+            _ = spanBuilder.setParent(global)
+        }
+
         let span = spanBuilder.startSpan()
         runningSpansQueue.sync {
             runningSpans[sessionTaskId] = span

--- a/Coralogix/Sources/Otel/URLSession/URLSessionLogger.swift
+++ b/Coralogix/Sources/Otel/URLSession/URLSessionLogger.swift
@@ -75,9 +75,12 @@ class URLSessionLogger {
         }
         instrumentation.configuration.spanCustomization?(request, spanBuilder)
 
-        // CX-35954: OTel active context can be empty on async queues while a global span is still registered.
-        if OpenTelemetry.instance.contextProvider.activeSpan == nil,
-           let global = CoralogixCustomGlobalSpanRegistry.shared.registeredGlobalForAutoInstrumentationParent() {
+        // CX-35955: ignored `.networkRequests` → fresh trace (no global parent), including traceparent.
+        if CoralogixCustomGlobalSpanRegistry.shared.shouldBreakTraceInheritance(for: .networkRequests) {
+            _ = spanBuilder.setNoParent()
+        } else if OpenTelemetry.instance.contextProvider.activeSpan == nil,
+                  let global = CoralogixCustomGlobalSpanRegistry.shared.registeredGlobalForAutoInstrumentationParent() {
+            // CX-35954: OTel active context can be empty on async queues while a global span is still registered.
             _ = spanBuilder.setParent(global)
         }
 

--- a/Coralogix/Sources/Utils/NetworkCaptureRule.swift
+++ b/Coralogix/Sources/Utils/NetworkCaptureRule.swift
@@ -8,6 +8,14 @@
 import Foundation
 import CoralogixInternal
 
+private extension Array where Element: Hashable {
+    /// Returns array with duplicates removed, preserving the order of first occurrences.
+    func uniqued() -> [Element] {
+        var seen = Set<Element>()
+        return filter { seen.insert($0).inserted }
+    }
+}
+
 /// A per-URL rule that controls which headers and payloads the SDK captures for matching network requests.
 ///
 /// Mirrors the browser SDK's `NetworkExtraConfig` interface:
@@ -278,11 +286,11 @@ internal func resolveConfigForUrl(_ requestUrl: String, configs: [NetworkCapture
     guard !matching.isEmpty else { return nil }
     guard matching.count > 1 else { return matching[0] }
 
-    // Merge: union headers, OR booleans
+    // Merge: union headers (preserving insertion order), OR booleans
     let allReqHeaders = matching.compactMap { $0.reqHeaders }.flatMap { $0 }
     let allResHeaders = matching.compactMap { $0.resHeaders }.flatMap { $0 }
-    let mergedReqHeaders: [String]? = allReqHeaders.isEmpty ? nil : Array(Set(allReqHeaders))
-    let mergedResHeaders: [String]? = allResHeaders.isEmpty ? nil : Array(Set(allResHeaders))
+    let mergedReqHeaders: [String]? = allReqHeaders.isEmpty ? nil : allReqHeaders.uniqued()
+    let mergedResHeaders: [String]? = allResHeaders.isEmpty ? nil : allResHeaders.uniqued()
     let collectReq = matching.contains { $0.collectReqPayload }
     let collectRes = matching.contains { $0.collectResPayload }
     return NetworkCaptureRule(url: requestUrl,

--- a/Coralogix/Sources/Utils/SessionManager.swift
+++ b/Coralogix/Sources/Utils/SessionManager.swift
@@ -50,6 +50,7 @@ public class SessionManager {
     private let idleInterval: TimeInterval = 15 * 60  // 15 minutes in seconds
     private var errorCount: Int = 0
     private var clickCount: Int = 0
+    private let countersLock = NSLock()
     public var sessionChangedCallback: ((String) -> Void)?
     public var sessionEndedCallback: (() -> Void)?
     public var hasRecording: Bool = false
@@ -77,16 +78,22 @@ public class SessionManager {
     }
     
     public func incrementErrorCounter() {
+        countersLock.lock()
+        defer { countersLock.unlock() }
         errorCount += 1
     }
 
     public func decrementErrorCounter() {
+        countersLock.lock()
+        defer { countersLock.unlock() }
         if errorCount > 0 {
             errorCount -= 1
         }
     }
     
     public func incrementClickCounter() {
+        countersLock.lock()
+        defer { countersLock.unlock() }
         clickCount += 1
     }
     
@@ -95,10 +102,14 @@ public class SessionManager {
     }
     
     public func getErrorCount() -> Int {
+        countersLock.lock()
+        defer { countersLock.unlock() }
         return errorCount
     }
     
     public func getClickCount() -> Int {
+        countersLock.lock()
+        defer { countersLock.unlock() }
         return clickCount
     }
     
@@ -120,8 +131,10 @@ public class SessionManager {
     }
     
     public func reset() {
+        countersLock.lock()
         self.errorCount = 0
         self.clickCount = 0
+        countersLock.unlock()
         self.hasRecording = false
     }
     

--- a/CoralogixInternal.podspec
+++ b/CoralogixInternal.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "CoralogixInternal"
-  spec.version      = "2.4.1"
+  spec.version      = "2.5.0"
   spec.summary      = "Coralogix Internal Package. This module is not for public use."
 
   spec.description  = <<-DESC

--- a/CoralogixInternal/Sources/Utils.swift
+++ b/CoralogixInternal/Sources/Utils.swift
@@ -16,7 +16,7 @@ public enum ImageFormat {
 }
 
 public enum Global: String {
-    case sdk = "2.4.1"
+    case sdk = "2.5.0"
     case swiftVersion = "5.9"
     case coralogixPath = "/browser/v1beta/logs"
     case sessionReplayPath = "/browser/alpha/sessionrecording"

--- a/Example/DemoAppSwift/CustomSpansViewController.swift
+++ b/Example/DemoAppSwift/CustomSpansViewController.swift
@@ -10,6 +10,9 @@ import Coralogix
 
 final class CustomSpansViewController: UITableViewController {
 
+    /// CX-35956: `getCustomTracer()` succeeds only once per SDK session; reuse for all rows.
+    private var cachedCustomTracer: CoralogixCustomTracer?
+
     private struct DemoItem {
         let title: String
         let subtitle: String
@@ -154,18 +157,31 @@ final class CustomSpansViewController: UITableViewController {
 
     // MARK: - Demos
 
+    /// First successful `getCustomTracer` wins for the session (CX-35956). If another row already obtained a tracer with a different `ignoredInstruments`, that tracer is reused.
+    private func tracerForSession(preferIgnored: Bool) -> CoralogixCustomTracer? {
+        if let c = cachedCustomTracer { return c }
+        let rum = CoralogixRumManager.shared.sdk
+        let t: CoralogixCustomTracer?
+        if preferIgnored {
+            t = rum.getCustomTracer(ignoredInstruments: [.networkRequests, .errors])
+        } else {
+            t = rum.getCustomTracer()
+        }
+        guard let tracer = t else {
+            presentToast("Custom tracer unavailable — set traceParentInHeader with enable: true in SDK options.")
+            return nil
+        }
+        cachedCustomTracer = tracer
+        return tracer
+    }
+
     private func runSimpleFlow(useIgnoredTracer: Bool) {
         let rum = CoralogixRumManager.shared.sdk
         guard rum.isInitialized else {
             presentToast("SDK not initialized")
             return
         }
-        let tracer: CoralogixCustomTracer
-        if useIgnoredTracer {
-            tracer = rum.getCustomTracer(ignoredInstruments: [.networkRequests, .errors])
-        } else {
-            tracer = rum.getCustomTracer()
-        }
+        guard let tracer = tracerForSession(preferIgnored: useIgnoredTracer) else { return }
         guard let global = tracer.startGlobalSpan(
             name: "demo.custom.global",
             labels: ["demo.screen": "CustomSpans"]
@@ -188,7 +204,7 @@ final class CustomSpansViewController: UITableViewController {
             presentToast("SDK not initialized")
             return
         }
-        let tracer = rum.getCustomTracer()
+        guard let tracer = tracerForSession(preferIgnored: false) else { return }
         guard let first = tracer.startGlobalSpan(name: "demo.custom.first_global") else {
             presentToast("Unexpected: first startGlobalSpan failed")
             return
@@ -213,7 +229,8 @@ final class CustomSpansViewController: UITableViewController {
             presentToast("SDK not initialized")
             return
         }
-        guard let global = rum.getCustomTracer().startGlobalSpan(
+        guard let tracer = tracerForSession(preferIgnored: false) else { return }
+        guard let global = tracer.startGlobalSpan(
             name: "demo.custom.with_context",
             labels: ["demo.flow": "network"]
         ) else {

--- a/Example/DemoAppSwift/CustomSpansViewController.swift
+++ b/Example/DemoAppSwift/CustomSpansViewController.swift
@@ -12,6 +12,8 @@ final class CustomSpansViewController: UITableViewController {
 
     /// CX-35956: `getCustomTracer()` succeeds only once per SDK session; reuse for all rows.
     private var cachedCustomTracer: CoralogixCustomTracer?
+    /// Whether the cached tracer was created with `ignoredInstruments: [.networkRequests, .errors]` (`true`) or `[]` (`false`).
+    private var cachedTracerPreferIgnored: Bool?
 
     private struct DemoItem {
         let title: String
@@ -159,7 +161,14 @@ final class CustomSpansViewController: UITableViewController {
 
     /// First successful `getCustomTracer` wins for the session (CX-35956). If another row already obtained a tracer with a different `ignoredInstruments`, that tracer is reused.
     private func tracerForSession(preferIgnored: Bool) -> CoralogixCustomTracer? {
-        if let c = cachedCustomTracer { return c }
+        if let c = cachedCustomTracer {
+            if let cachedPref = cachedTracerPreferIgnored, cachedPref != preferIgnored {
+                presentToast(
+                    "Reusing the tracer from an earlier demo — ignored-instruments setting differs. Relaunch the app to switch tracer configuration."
+                )
+            }
+            return c
+        }
         let rum = CoralogixRumManager.shared.sdk
         let t: CoralogixCustomTracer?
         if preferIgnored {
@@ -172,6 +181,7 @@ final class CustomSpansViewController: UITableViewController {
             return nil
         }
         cachedCustomTracer = tracer
+        cachedTracerPreferIgnored = preferIgnored
         return tracer
     }
 

--- a/Example/DemoAppSwift/CustomSpansViewController.swift
+++ b/Example/DemoAppSwift/CustomSpansViewController.swift
@@ -162,7 +162,7 @@ final class CustomSpansViewController: UITableViewController {
     /// First successful `getCustomTracer` wins for the session (CX-35956). If another row already obtained a tracer with a different `ignoredInstruments`, that tracer is reused.
     private func tracerForSession(preferIgnored: Bool) -> CoralogixCustomTracer? {
         if let c = cachedCustomTracer {
-            if let cachedPref = cachedTracerPreferIgnored, cachedPref != preferIgnored {
+            if (cachedTracerPreferIgnored ?? false) != preferIgnored {
                 presentToast(
                     "Reusing the tracer from an earlier demo — ignored-instruments setting differs. Relaunch the app to switch tracer configuration."
                 )

--- a/Example/DemoAppUITests/DemoAppUITests.swift
+++ b/Example/DemoAppUITests/DemoAppUITests.swift
@@ -35,6 +35,34 @@ final class DemoAppUITests: XCTestCase {
         let timestamp = String(format: "%.2f", Date().timeIntervalSince1970)
         print("🕐 [\(timestamp)] \(message)")
     }
+
+    /// Taps a row on the Network instrumentation table. Scrolls like `NetworkInstrumentationUITests.tapNetworkOption`
+    /// so CI (large titles / long lists / iOS 18) still finds the label.
+    private func tapNetworkInstrumentationRow(titled optionName: String, waitAfterTap: TimeInterval) {
+        let table = app.tables.firstMatch
+        XCTAssertTrue(table.waitForExistence(timeout: elementTimeout), "❌ Network instrumentation table not found")
+
+        let byLabel = app.staticTexts[optionName]
+        var attempts = 0
+        let maxScrollAttempts = 8
+        while !byLabel.waitForExistence(timeout: 1.5) && attempts < maxScrollAttempts {
+            table.swipeUp()
+            Thread.sleep(forTimeInterval: 0.4)
+            attempts += 1
+        }
+
+        if byLabel.exists {
+            byLabel.tap()
+        } else {
+            let cell = table.cells.containing(NSPredicate(format: "label CONTAINS[c] %@", optionName)).firstMatch
+            XCTAssertTrue(
+                cell.waitForExistence(timeout: elementTimeout),
+                "❌ '\(optionName)' row not found (staticText or cell label)"
+            )
+            cell.tap()
+        }
+        Thread.sleep(forTimeInterval: waitAfterTap)
+    }
     
     override func setUpWithError() throws {
         continueAfterFailure = false
@@ -59,18 +87,9 @@ final class DemoAppUITests: XCTestCase {
         XCTAssertTrue(networkButtonExists, "❌ 'Network instrumentation' button not found")
         networkInstrumentationButton.tap()
         Thread.sleep(forTimeInterval: shortDelay)  // Wait for navigation
-        
-        let failingNetworkButton = app.staticTexts["Failing network request"].firstMatch
-        let failingButtonExists = failingNetworkButton.waitForExistence(timeout: elementTimeout)
-        XCTAssertTrue(failingButtonExists, "❌ 'Failing network request' button not found")
-        failingNetworkButton.tap()
-        Thread.sleep(forTimeInterval: networkDelay)  // Wait for network request
-        
-        let successfulNetworkButton = app.staticTexts["Successful network request"].firstMatch
-        let successfulButtonExists = successfulNetworkButton.waitForExistence(timeout: elementTimeout)
-        XCTAssertTrue(successfulButtonExists, "❌ 'Successful network request' button not found")
-        successfulNetworkButton.tap()
-        Thread.sleep(forTimeInterval: networkDelay)  // Wait for network request
+
+        tapNetworkInstrumentationRow(titled: "Failing network request", waitAfterTap: networkDelay)
+        tapNetworkInstrumentationRow(titled: "Successful network request", waitAfterTap: networkDelay)
         
         // Navigate back using navigation bar back button
         let navBar = app.navigationBars.firstMatch
@@ -99,7 +118,7 @@ final class DemoAppUITests: XCTestCase {
         Thread.sleep(forTimeInterval: shortDelay)  // Wait for event processing
         
         let logErrorButton = app.staticTexts["Log Error"].firstMatch
-        let logErrorButtonExists = messageDataErrorButton.waitForExistence(timeout: elementTimeout)
+        let logErrorButtonExists = logErrorButton.waitForExistence(timeout: elementTimeout)
         XCTAssertTrue(logErrorButtonExists, "❌ 'Log Error' button not found")
         logErrorButton.tap()
         Thread.sleep(forTimeInterval: shortDelay)  // Wait for event processing

--- a/Example/Shared/CoralogixRumManager.swift
+++ b/Example/Shared/CoralogixRumManager.swift
@@ -52,6 +52,7 @@ final class CoralogixRumManager {
 //        },
                                                enableSwizzling: true,
                                                proxyUrl: Envs.PROXY_URL.rawValue, // remove if not need to use proxy
+                                               traceParentInHeader: ["enable": true],
                                                mobileVitals:[.cpuDetector: false,
                                                              .warmDetector: false,
                                                              .coldDetector: false,

--- a/SessionReplay.podspec
+++ b/SessionReplay.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "SessionReplay"
-  spec.version      = "2.4.1"
+  spec.version      = "2.5.0"
   spec.summary      = "Coralogix Session-Replay pod for iOS."
 
   spec.description  = <<-DESC
@@ -23,7 +23,7 @@ Pod::Spec.new do |spec|
   spec.static_framework = true
 
   spec.source_files  = 'SessionReplay/Sources/**/*.swift'
-  spec.dependency 'CoralogixInternal', '2.4.1'
+  spec.dependency 'CoralogixInternal', '2.5.0'
   
     spec.test_spec 'Tests' do |test|
         test.source_files = 'Tests/SessionReplayTests/**/*.swift'

--- a/Tests/CoralogixRumTests/CoralogixCustomSpansTests.swift
+++ b/Tests/CoralogixRumTests/CoralogixCustomSpansTests.swift
@@ -263,4 +263,80 @@ final class CoralogixCustomSpansTests: XCTestCase {
         custom.endSpan()
         global.endSpan()
     }
+
+    // MARK: - CX-35954 / CX-35955 (registry + makeSpan parent policy)
+
+    /// Registry exposes ignored flags only while a global span from that tracer is active.
+    func testRegistry_shouldBreakTraceInheritance_matchesIgnoredInstrumentsOnGlobalSpan() {
+        let rum = CoralogixRum(options: options!)
+        let tracer = rum.getCustomTracer(ignoredInstruments: [.errors, .networkRequests])
+        XCTAssertFalse(
+            CoralogixCustomGlobalSpanRegistry.shared.shouldBreakTraceInheritance(for: .errors),
+            "No global yet — nothing ignored for propagation"
+        )
+        guard let global = tracer.startGlobalSpan(name: "g") else {
+            return XCTFail("Expected global span")
+        }
+        defer { global.endSpan() }
+        XCTAssertTrue(CoralogixCustomGlobalSpanRegistry.shared.shouldBreakTraceInheritance(for: .errors))
+        XCTAssertTrue(CoralogixCustomGlobalSpanRegistry.shared.shouldBreakTraceInheritance(for: .networkRequests))
+        XCTAssertFalse(CoralogixCustomGlobalSpanRegistry.shared.shouldBreakTraceInheritance(for: .userInteractions))
+    }
+
+    func testRegistry_shouldBreakTraceInheritance_falseAfterGlobalEnds() {
+        let rum = CoralogixRum(options: options!)
+        let tracer = rum.getCustomTracer(ignoredInstruments: [.userInteractions])
+        guard let global = tracer.startGlobalSpan(name: "g") else {
+            return XCTFail("Expected global span")
+        }
+        XCTAssertTrue(CoralogixCustomGlobalSpanRegistry.shared.shouldBreakTraceInheritance(for: .userInteractions))
+        global.endSpan()
+        XCTAssertFalse(CoralogixCustomGlobalSpanRegistry.shared.shouldBreakTraceInheritance(for: .userInteractions))
+    }
+
+    /// CX-35955: `makeSpan` for an ignored event type uses `setNoParent()` — new trace, no parent.
+    func testMakeSpan_ignoredUserInteraction_breaksGlobalTrace() {
+        let rum = CoralogixRum(options: options!)
+        let tracer = rum.getCustomTracer(ignoredInstruments: [.userInteractions])
+        guard let global = tracer.startGlobalSpan(name: "g") else {
+            return XCTFail("Expected global span")
+        }
+        defer { global.endSpan() }
+        guard let globalReadable = global.span as? any ReadableSpan else {
+            return XCTFail("Expected ReadableSpan")
+        }
+        let globalData = globalReadable.toSpanData()
+
+        var span = rum.makeSpan(event: .userInteraction, source: .console, severity: .info)
+        defer { span.end() }
+        guard let readable = span as? any ReadableSpan else {
+            return XCTFail("Expected ReadableSpan")
+        }
+        let data = readable.toSpanData()
+        XCTAssertNotEqual(data.traceId, globalData.traceId)
+        XCTAssertNil(data.parentSpanId)
+    }
+
+    /// CX-35954: event types not listed in `ignoredInstruments` still parent under the global when it is the active span (default OTel current span).
+    func testMakeSpan_navigationWithGlobalActive_inheritsGlobalTrace() {
+        let rum = CoralogixRum(options: options!)
+        let tracer = rum.getCustomTracer(ignoredInstruments: [.networkRequests])
+        guard let global = tracer.startGlobalSpan(name: "g") else {
+            return XCTFail("Expected global span")
+        }
+        defer { global.endSpan() }
+        guard let globalReadable = global.span as? any ReadableSpan else {
+            return XCTFail("Expected ReadableSpan")
+        }
+        let globalData = globalReadable.toSpanData()
+
+        var span = rum.makeSpan(event: .navigation, source: .console, severity: .info)
+        defer { span.end() }
+        guard let readable = span as? any ReadableSpan else {
+            return XCTFail("Expected ReadableSpan")
+        }
+        let data = readable.toSpanData()
+        XCTAssertEqual(data.traceId, globalData.traceId)
+        XCTAssertEqual(data.parentSpanId, globalData.spanId)
+    }
 }

--- a/Tests/CoralogixRumTests/CoralogixCustomSpansTests.swift
+++ b/Tests/CoralogixRumTests/CoralogixCustomSpansTests.swift
@@ -307,7 +307,7 @@ final class CoralogixCustomSpansTests: XCTestCase {
         }
         let globalData = globalReadable.toSpanData()
 
-        var span = rum.makeSpan(event: .userInteraction, source: .console, severity: .info)
+        let span = rum.makeSpan(event: .userInteraction, source: .console, severity: .info)
         defer { span.end() }
         guard let readable = span as? any ReadableSpan else {
             return XCTFail("Expected ReadableSpan")
@@ -330,7 +330,7 @@ final class CoralogixCustomSpansTests: XCTestCase {
         }
         let globalData = globalReadable.toSpanData()
 
-        var span = rum.makeSpan(event: .navigation, source: .console, severity: .info)
+        let span = rum.makeSpan(event: .navigation, source: .console, severity: .info)
         defer { span.end() }
         guard let readable = span as? any ReadableSpan else {
             return XCTFail("Expected ReadableSpan")

--- a/Tests/CoralogixRumTests/CoralogixCustomSpansTests.swift
+++ b/Tests/CoralogixRumTests/CoralogixCustomSpansTests.swift
@@ -17,6 +17,7 @@ final class CoralogixCustomSpansTests: XCTestCase {
             ignoreErrors: [],
             labels: [:],
             sessionSampleRate: 100,
+            traceParentInHeader: [Keys.enable.rawValue: true],
             debug: true
         )
     }
@@ -25,13 +26,16 @@ final class CoralogixCustomSpansTests: XCTestCase {
         CoralogixCustomGlobalSpanRegistry.shared.teardownIfNeeded()
         options = nil
         CoralogixRum.isInitialized = false
+        CoralogixRum.resetCustomTracerIssuanceForTesting()
         RunLoop.main.run(until: Date().addingTimeInterval(0.05))
     }
 
     func testGetCustomTracerPreservesIgnoredInstruments() {
         let rum = CoralogixRum(options: options!)
         let instruments: Set<CoralogixIgnoredInstrument> = [.networkRequests, .errors]
-        let tracer = rum.getCustomTracer(ignoredInstruments: instruments)
+        guard let tracer = rum.getCustomTracer(ignoredInstruments: instruments) else {
+            return XCTFail("Expected custom tracer")
+        }
         XCTAssertEqual(tracer.ignoredInstruments, instruments)
     }
 
@@ -52,13 +56,14 @@ final class CoralogixCustomSpansTests: XCTestCase {
         )
         let rum = CoralogixRum(options: offOptions)
         XCTAssertFalse(rum.isInitialized)
-        let tracer = rum.getCustomTracer()
-        XCTAssertNil(tracer.startGlobalSpan(name: "root"))
+        XCTAssertNil(rum.getCustomTracer())
     }
 
     func testCustomSpansStampEventTypeSourceSeverityLikeBrowserSdk() {
         let rum = CoralogixRum(options: options!)
-        let tracer = rum.getCustomTracer()
+        guard let tracer = rum.getCustomTracer() else {
+            return XCTFail("Expected custom tracer")
+        }
         guard let global = tracer.startGlobalSpan(name: "g") else {
             return XCTFail("Expected global span")
         }
@@ -85,7 +90,9 @@ final class CoralogixCustomSpansTests: XCTestCase {
     /// Nested custom spans must carry session/user attributes so `SessionContext` succeeds during export (otherwise the child is dropped and only the global appears in RUM).
     func testStartCustomSpanIncludesSessionMetadataLikeGlobal() {
         let rum = CoralogixRum(options: options!)
-        let tracer = rum.getCustomTracer()
+        guard let tracer = rum.getCustomTracer() else {
+            return XCTFail("Expected custom tracer")
+        }
         guard let global = tracer.startGlobalSpan(name: "g") else {
             return XCTFail("Expected global span")
         }
@@ -107,7 +114,9 @@ final class CoralogixCustomSpansTests: XCTestCase {
 
     func testStartGlobalSpanAppliesNameLabelsAndSessionMetadata() {
         let rum = CoralogixRum(options: options!)
-        let tracer = rum.getCustomTracer()
+        guard let tracer = rum.getCustomTracer() else {
+            return XCTFail("Expected custom tracer")
+        }
         guard let global = tracer.startGlobalSpan(name: "checkout", labels: ["flow": "standard"]) else {
             return XCTFail("Expected global span")
         }
@@ -139,10 +148,13 @@ final class CoralogixCustomSpansTests: XCTestCase {
             ignoreErrors: [],
             labels: ["tier": "sdk", "onlySdk": "1"],
             sessionSampleRate: 100,
+            traceParentInHeader: [Keys.enable.rawValue: true],
             debug: true
         )
         let rum = CoralogixRum(options: opts)
-        let tracer = rum.getCustomTracer()
+        guard let tracer = rum.getCustomTracer() else {
+            return XCTFail("Expected custom tracer")
+        }
         guard let global = tracer.startGlobalSpan(name: "g", labels: ["tier": "global", "fromGlobal": "yes"]) else {
             return XCTFail("Expected global span")
         }
@@ -173,7 +185,9 @@ final class CoralogixCustomSpansTests: XCTestCase {
 
     func testStartCustomSpanIsChildOfGlobalSpan() {
         let rum = CoralogixRum(options: options!)
-        let tracer = rum.getCustomTracer()
+        guard let tracer = rum.getCustomTracer() else {
+            return XCTFail("Expected custom tracer")
+        }
         guard let global = tracer.startGlobalSpan(name: "parent") else {
             return XCTFail("Expected global span")
         }
@@ -192,7 +206,9 @@ final class CoralogixCustomSpansTests: XCTestCase {
 
     func testWithContextSetsActiveSpan() {
         let rum = CoralogixRum(options: options!)
-        let tracer = rum.getCustomTracer()
+        guard let tracer = rum.getCustomTracer() else {
+            return XCTFail("Expected custom tracer")
+        }
         guard let global = tracer.startGlobalSpan(name: "ctx") else {
             return XCTFail("Expected global span")
         }
@@ -216,7 +232,9 @@ final class CoralogixCustomSpansTests: XCTestCase {
 
     func testSecondStartGlobalSpanReturnsNilUntilFirstEnds() {
         let rum = CoralogixRum(options: options!)
-        let tracer = rum.getCustomTracer()
+        guard let tracer = rum.getCustomTracer() else {
+            return XCTFail("Expected custom tracer")
+        }
         guard let first = tracer.startGlobalSpan(name: "first") else {
             return XCTFail("Expected first global span")
         }
@@ -237,7 +255,10 @@ final class CoralogixCustomSpansTests: XCTestCase {
         XCTAssertTrue(
             (OpenTelemetry.instance.contextProvider.activeSpan as AnyObject?) === (marker as AnyObject)
         )
-        guard let global = rum.getCustomTracer().startGlobalSpan(name: "global") else {
+        guard let tracerForGlobal = rum.getCustomTracer() else {
+            return XCTFail("Expected custom tracer")
+        }
+        guard let global = tracerForGlobal.startGlobalSpan(name: "global") else {
             return XCTFail("Expected global span")
         }
         XCTAssertTrue(
@@ -253,7 +274,9 @@ final class CoralogixCustomSpansTests: XCTestCase {
 
     func testCustomSpanSetStatusAndEndSpan() {
         let rum = CoralogixRum(options: options!)
-        let tracer = rum.getCustomTracer()
+        guard let tracer = rum.getCustomTracer() else {
+            return XCTFail("Expected custom tracer")
+        }
         guard let global = tracer.startGlobalSpan(name: "g") else {
             return XCTFail("Expected global span")
         }
@@ -264,12 +287,68 @@ final class CoralogixCustomSpansTests: XCTestCase {
         global.endSpan()
     }
 
+    // MARK: - CX-35956 (getCustomTracer guards)
+
+    func testGetCustomTracer_nilWhenTraceParentNotConfigured() {
+        let opts = CoralogixExporterOptions(
+            coralogixDomain: CoralogixDomain.US2,
+            userContext: nil,
+            environment: "PROD",
+            application: "TestApp",
+            version: "1.0",
+            publicKey: "token",
+            ignoreUrls: [],
+            ignoreErrors: [],
+            labels: [:],
+            sessionSampleRate: 100,
+            debug: true
+        )
+        let rum = CoralogixRum(options: opts)
+        XCTAssertNil(rum.getCustomTracer())
+    }
+
+    func testGetCustomTracer_nilWhenTraceParentEnableFalse() {
+        let opts = CoralogixExporterOptions(
+            coralogixDomain: CoralogixDomain.US2,
+            userContext: nil,
+            environment: "PROD",
+            application: "TestApp",
+            version: "1.0",
+            publicKey: "token",
+            ignoreUrls: [],
+            ignoreErrors: [],
+            labels: [:],
+            sessionSampleRate: 100,
+            traceParentInHeader: [Keys.enable.rawValue: false],
+            debug: true
+        )
+        let rum = CoralogixRum(options: opts)
+        XCTAssertNil(rum.getCustomTracer())
+    }
+
+    func testGetCustomTracer_singletonSecondCallReturnsNil() {
+        let rum = CoralogixRum(options: options!)
+        XCTAssertNotNil(rum.getCustomTracer())
+        XCTAssertNil(rum.getCustomTracer())
+    }
+
+    func testGetCustomTracer_availableAgainAfterShutdown() {
+        let rum = CoralogixRum(options: options!)
+        XCTAssertNotNil(rum.getCustomTracer())
+        XCTAssertNil(rum.getCustomTracer())
+        rum.shutdown()
+        let rum2 = CoralogixRum(options: options!)
+        XCTAssertNotNil(rum2.getCustomTracer())
+    }
+
     // MARK: - CX-35954 / CX-35955 (registry + makeSpan parent policy)
 
     /// Registry exposes ignored flags only while a global span from that tracer is active.
     func testRegistry_shouldBreakTraceInheritance_matchesIgnoredInstrumentsOnGlobalSpan() {
         let rum = CoralogixRum(options: options!)
-        let tracer = rum.getCustomTracer(ignoredInstruments: [.errors, .networkRequests])
+        guard let tracer = rum.getCustomTracer(ignoredInstruments: [.errors, .networkRequests]) else {
+            return XCTFail("Expected custom tracer")
+        }
         XCTAssertFalse(
             CoralogixCustomGlobalSpanRegistry.shared.shouldBreakTraceInheritance(for: .errors),
             "No global yet — nothing ignored for propagation"
@@ -285,7 +364,9 @@ final class CoralogixCustomSpansTests: XCTestCase {
 
     func testRegistry_shouldBreakTraceInheritance_falseAfterGlobalEnds() {
         let rum = CoralogixRum(options: options!)
-        let tracer = rum.getCustomTracer(ignoredInstruments: [.userInteractions])
+        guard let tracer = rum.getCustomTracer(ignoredInstruments: [.userInteractions]) else {
+            return XCTFail("Expected custom tracer")
+        }
         guard let global = tracer.startGlobalSpan(name: "g") else {
             return XCTFail("Expected global span")
         }
@@ -297,7 +378,9 @@ final class CoralogixCustomSpansTests: XCTestCase {
     /// CX-35955: `makeSpan` for an ignored event type uses `setNoParent()` — new trace, no parent.
     func testMakeSpan_ignoredUserInteraction_breaksGlobalTrace() {
         let rum = CoralogixRum(options: options!)
-        let tracer = rum.getCustomTracer(ignoredInstruments: [.userInteractions])
+        guard let tracer = rum.getCustomTracer(ignoredInstruments: [.userInteractions]) else {
+            return XCTFail("Expected custom tracer")
+        }
         guard let global = tracer.startGlobalSpan(name: "g") else {
             return XCTFail("Expected global span")
         }
@@ -320,7 +403,9 @@ final class CoralogixCustomSpansTests: XCTestCase {
     /// CX-35954: event types not listed in `ignoredInstruments` still parent under the global when it is the active span (default OTel current span).
     func testMakeSpan_navigationWithGlobalActive_inheritsGlobalTrace() {
         let rum = CoralogixRum(options: options!)
-        let tracer = rum.getCustomTracer(ignoredInstruments: [.networkRequests])
+        guard let tracer = rum.getCustomTracer(ignoredInstruments: [.networkRequests]) else {
+            return XCTFail("Expected custom tracer")
+        }
         guard let global = tracer.startGlobalSpan(name: "g") else {
             return XCTFail("Expected global span")
         }

--- a/Tests/CoralogixRumTests/CoralogixCustomSpansTests.swift
+++ b/Tests/CoralogixRumTests/CoralogixCustomSpansTests.swift
@@ -230,6 +230,63 @@ final class CoralogixCustomSpansTests: XCTestCase {
         global.endSpan()
     }
 
+    /// CX-35957: When another span is active, `withContext` restores global as active so nested `startCustomSpan` inherits global trace/parent.
+    func testWithContextChildSpanInheritsGlobalTraceWhenGlobalWasNotActive() {
+        let rum = CoralogixRum(options: options!)
+        let tracer = rum.tracerProvider()
+        guard let customTracer = rum.getCustomTracer() else {
+            return XCTFail("Expected custom tracer")
+        }
+        guard let global = customTracer.startGlobalSpan(name: "g") else {
+            return XCTFail("Expected global span")
+        }
+        guard let globalData = (global.span as? any ReadableSpan)?.toSpanData() else {
+            return XCTFail("Expected ReadableSpan")
+        }
+        let markerBuilder = tracer.spanBuilder(spanName: "marker")
+        _ = markerBuilder.setActive(true)
+        let marker = markerBuilder.startSpan()
+        XCTAssertFalse(
+            (OpenTelemetry.instance.contextProvider.activeSpan as AnyObject?) === (global.span as AnyObject),
+            "Precondition: marker span must replace global as OTel active span"
+        )
+        global.withContext {
+            let child = global.startCustomSpan(name: "inside_ctx")
+            defer { child.endSpan() }
+            guard let childData = (child.span as? any ReadableSpan)?.toSpanData() else {
+                XCTFail("Expected ReadableSpan")
+                return
+            }
+            XCTAssertEqual(childData.traceId, globalData.traceId)
+            XCTAssertEqual(childData.parentSpanId, globalData.spanId)
+        }
+        marker.end()
+        global.endSpan()
+    }
+
+    /// CX-35957: After `endSpan()` on a global, the next `startGlobalSpan` is a new root with a new trace id.
+    func testNewGlobalSpanAfterEndGetsFreshTraceId() {
+        let rum = CoralogixRum(options: options!)
+        guard let customTracer = rum.getCustomTracer() else {
+            return XCTFail("Expected custom tracer")
+        }
+        guard let first = customTracer.startGlobalSpan(name: "first") else {
+            return XCTFail("Expected first global")
+        }
+        guard let firstData = (first.span as? any ReadableSpan)?.toSpanData() else {
+            return XCTFail("Expected ReadableSpan")
+        }
+        first.endSpan()
+        guard let second = customTracer.startGlobalSpan(name: "second") else {
+            return XCTFail("Expected second global after first ended")
+        }
+        defer { second.endSpan() }
+        guard let secondData = (second.span as? any ReadableSpan)?.toSpanData() else {
+            return XCTFail("Expected ReadableSpan")
+        }
+        XCTAssertNotEqual(firstData.traceId, secondData.traceId, "New global span must not reuse ended global's trace id")
+    }
+
     func testSecondStartGlobalSpanReturnsNilUntilFirstEnds() {
         let rum = CoralogixRum(options: options!)
         guard let tracer = rum.getCustomTracer() else {

--- a/Tests/CoralogixRumTests/GlobalSpanPropagationIntegrationTests.swift
+++ b/Tests/CoralogixRumTests/GlobalSpanPropagationIntegrationTests.swift
@@ -1,0 +1,205 @@
+//
+//  GlobalSpanPropagationIntegrationTests.swift
+//  CoralogixRumTests
+//
+//  CX-35954: Auto-instrumented spans (network, user interaction via makeSpan) must share
+//  traceId with an active global span and use parentSpanId = global span id — including
+//  when OTel active context is empty on async queues (registry fallback).
+//
+
+import XCTest
+import CoralogixInternal
+@testable import Coralogix
+
+// MARK: - URLProtocol stub (same pattern as NetworkCaptureIntegrationTests)
+
+private final class PropagationTestURLProtocol: URLProtocol {
+    static var stub: (status: Int, headers: [String: String], body: Data)?
+    static let scheme = "proptest"
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        request.url?.scheme == scheme
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let stub = Self.stub else {
+            client?.urlProtocol(self, didFailWithError: NSError(domain: "PropagationTest", code: -1, userInfo: nil))
+            return
+        }
+        let url = request.url ?? URL(string: "proptest://localhost/")!
+        let response = HTTPURLResponse(url: url, statusCode: stub.status, httpVersion: nil, headerFields: stub.headers)!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: stub.body)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+// MARK: - Tests
+
+final class GlobalSpanPropagationIntegrationTests: XCTestCase {
+
+    static let baseURL = "proptest://cx35954"
+    var rum: CoralogixRum?
+    var capturedSpans: [SpanData] = []
+    let captureLock = NSLock()
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        capturedSpans = []
+        URLProtocol.registerClass(PropagationTestURLProtocol.self)
+        CoralogixExporter.testExportCallback = { [weak self] spans in
+            self?.captureLock.lock()
+            self?.capturedSpans.append(contentsOf: spans)
+            self?.captureLock.unlock()
+        }
+    }
+
+    override func tearDownWithError() throws {
+        CoralogixCustomGlobalSpanRegistry.shared.teardownIfNeeded()
+        rum = nil
+        CoralogixRum.isInitialized = false
+        CoralogixExporter.testExportCallback = nil
+        capturedSpans = []
+        URLProtocol.unregisterClass(PropagationTestURLProtocol.self)
+        try super.tearDownWithError()
+    }
+
+    func makeOptions() -> CoralogixExporterOptions {
+        CoralogixExporterOptions(
+            coralogixDomain: .EU2,
+            userContext: nil,
+            environment: "test",
+            application: "CX35954Propagation",
+            version: "1.0",
+            publicKey: "test-key",
+            ignoreUrls: [],
+            ignoreErrors: [],
+            labels: [:],
+            sessionSampleRate: 100,
+            debug: true,
+            instrumentations: [.network: true],
+            networkExtraConfig: [NetworkCaptureRule(url: Self.baseURL)]
+        )
+    }
+
+    func startRUM() {
+        rum = CoralogixRum(options: makeOptions())
+        XCTAssertTrue(CoralogixRum.isInitialized)
+    }
+
+    func forceFlush() {
+        (OpenTelemetry.instance.tracerProvider as? TracerProviderSdk)?.forceFlush(timeout: 3)
+        Thread.sleep(forTimeInterval: 0.6)
+    }
+
+    func waitForNetworkSpan(urlContains: String, timeout: TimeInterval = 8) -> SpanData? {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            forceFlush()
+            captureLock.lock()
+            let match = capturedSpans.first { span in
+                let type = span.attributes[Keys.eventType.rawValue]?.description ?? ""
+                guard type.contains(CoralogixEventType.networkRequest.rawValue) else { return false }
+                guard let url = span.attributes[SemanticAttributes.httpUrl.rawValue]?.description else { return false }
+                return url.contains(urlContains)
+            }
+            captureLock.unlock()
+            if let match {
+                return match
+            }
+            Thread.sleep(forTimeInterval: 0.15)
+        }
+        return nil
+    }
+
+    // MARK: - CX-35954
+
+    func testGlobalSpan_networkRequest_sameThread_sharesTraceAndParent() throws {
+        PropagationTestURLProtocol.stub = (200, ["Content-Type": "application/json"], Data("{}".utf8))
+        startRUM()
+        let tracer = try XCTUnwrap(rum).getCustomTracer()
+        guard let global = tracer.startGlobalSpan(name: "flow.root") else {
+            return XCTFail("Expected global span")
+        }
+        defer { global.endSpan() }
+
+        guard let globalReadable = global.span as? ReadableSpan else {
+            return XCTFail("Expected ReadableSpan")
+        }
+        let globalData = globalReadable.toSpanData()
+
+        let url = try XCTUnwrap(URL(string: "\(Self.baseURL)/sync"))
+        let exp = expectation(description: "request")
+        URLSession.shared.dataTask(with: url) { _, _, _ in exp.fulfill() }.resume()
+        wait(for: [exp], timeout: 5)
+
+        let net = try XCTUnwrap(waitForNetworkSpan(urlContains: "cx35954"), "Exported network span must appear")
+        XCTAssertEqual(net.traceId, globalData.traceId, "Network span must use global trace id")
+        XCTAssertEqual(net.parentSpanId, globalData.spanId, "Network span parent must be global span id")
+    }
+
+    func testGlobalSpan_networkRequest_fromBackgroundQueue_sharesTraceAndParent() throws {
+        PropagationTestURLProtocol.stub = (200, [:], Data())
+        startRUM()
+        let tracer = try XCTUnwrap(rum).getCustomTracer()
+        guard let global = tracer.startGlobalSpan(name: "flow.async") else {
+            return XCTFail("Expected global span")
+        }
+        defer { global.endSpan() }
+
+        guard let globalReadable = global.span as? ReadableSpan else {
+            return XCTFail("Expected ReadableSpan")
+        }
+        let globalData = globalReadable.toSpanData()
+
+        let exp = expectation(description: "bg request")
+        DispatchQueue.global(qos: .userInitiated).async {
+            guard let url = URL(string: "\(Self.baseURL)/async") else {
+                XCTFail("Invalid URL")
+                exp.fulfill()
+                return
+            }
+            URLSession.shared.dataTask(with: url) { _, _, _ in exp.fulfill() }.resume()
+        }
+        wait(for: [exp], timeout: 8)
+
+        let net = try XCTUnwrap(waitForNetworkSpan(urlContains: "async"), "Network span must inherit global trace when URLSession runs off main (CX-35954)")
+        XCTAssertEqual(net.traceId, globalData.traceId)
+        XCTAssertEqual(net.parentSpanId, globalData.spanId)
+    }
+
+    func testGlobalSpan_makeSpanOnBackgroundQueue_userInteraction_parentsUnderGlobal() throws {
+        startRUM()
+        let r = try XCTUnwrap(rum)
+        let tracer = r.getCustomTracer()
+        guard let global = tracer.startGlobalSpan(name: "ui.flow") else {
+            return XCTFail("Expected global span")
+        }
+        defer { global.endSpan() }
+
+        guard let globalReadable = global.span as? ReadableSpan else {
+            return XCTFail("Expected ReadableSpan")
+        }
+        let globalData = globalReadable.toSpanData()
+
+        let exp = expectation(description: "bg makeSpan")
+        DispatchQueue.global(qos: .userInitiated).async {
+            var span = r.makeSpan(event: .userInteraction, source: .console, severity: .info)
+            defer { span.end() }
+            guard let readable = span as? ReadableSpan else {
+                XCTFail("Expected ReadableSpan")
+                exp.fulfill()
+                return
+            }
+            let data = readable.toSpanData()
+            XCTAssertEqual(data.traceId, globalData.traceId, "User interaction span must use global trace id")
+            XCTAssertEqual(data.parentSpanId, globalData.spanId, "User interaction span must parent under global when active context is nil on worker queue")
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 3)
+    }
+}

--- a/Tests/CoralogixRumTests/GlobalSpanPropagationIntegrationTests.swift
+++ b/Tests/CoralogixRumTests/GlobalSpanPropagationIntegrationTests.swift
@@ -83,9 +83,9 @@ final class GlobalSpanPropagationIntegrationTests: XCTestCase {
             ignoreErrors: [],
             labels: [:],
             sessionSampleRate: 100,
-            debug: true,
             instrumentations: [.network: true],
-            networkExtraConfig: [NetworkCaptureRule(url: Self.baseURL)]
+            networkExtraConfig: [NetworkCaptureRule(url: Self.baseURL)],
+            debug: true
         )
     }
 
@@ -104,7 +104,9 @@ final class GlobalSpanPropagationIntegrationTests: XCTestCase {
         while Date() < deadline {
             forceFlush()
             captureLock.lock()
-            let match = capturedSpans.first { span in
+            // URLSession instrumentation may emit more than one client span per request (factory + resume paths).
+            // Assert against the last matching export for this URL so we validate the span built with final parent policy.
+            let match = capturedSpans.last { span in
                 let type = span.attributes[Keys.eventType.rawValue]?.description ?? ""
                 guard type.contains(CoralogixEventType.networkRequest.rawValue) else { return false }
                 guard let url = span.attributes[SemanticAttributes.httpUrl.rawValue]?.description else { return false }

--- a/Tests/CoralogixRumTests/GlobalSpanPropagationIntegrationTests.swift
+++ b/Tests/CoralogixRumTests/GlobalSpanPropagationIntegrationTests.swift
@@ -202,4 +202,104 @@ final class GlobalSpanPropagationIntegrationTests: XCTestCase {
         }
         wait(for: [exp], timeout: 3)
     }
+
+    // MARK: - CX-35955 ignoredInstruments (break trace inheritance)
+
+    func testIgnoredInstruments_networkRequests_networkSpanUsesSeparateTrace() throws {
+        PropagationTestURLProtocol.stub = (200, [:], Data())
+        startRUM()
+        let r = try XCTUnwrap(rum)
+        let tracer = r.getCustomTracer(ignoredInstruments: [.networkRequests])
+        guard let global = tracer.startGlobalSpan(name: "ignored.net") else {
+            return XCTFail("Expected global span")
+        }
+        defer { global.endSpan() }
+
+        guard let globalReadable = global.span as? ReadableSpan else {
+            return XCTFail("Expected ReadableSpan")
+        }
+        let globalData = globalReadable.toSpanData()
+
+        let url = try XCTUnwrap(URL(string: "\(Self.baseURL)/ignored-net"))
+        let exp = expectation(description: "request")
+        URLSession.shared.dataTask(with: url) { _, _, _ in exp.fulfill() }.resume()
+        wait(for: [exp], timeout: 5)
+
+        let net = try XCTUnwrap(waitForNetworkSpan(urlContains: "ignored-net"))
+        XCTAssertNotEqual(net.traceId, globalData.traceId, "Ignored network must not share global trace id (CX-35955)")
+        XCTAssertNil(net.parentSpanId, "Ignored network span must be a root span")
+    }
+
+    func testIgnoredInstruments_userInteractions_makeSpanUsesSeparateTrace() throws {
+        startRUM()
+        let r = try XCTUnwrap(rum)
+        let tracer = r.getCustomTracer(ignoredInstruments: [.userInteractions])
+        guard let global = tracer.startGlobalSpan(name: "ignored.ui") else {
+            return XCTFail("Expected global span")
+        }
+        defer { global.endSpan() }
+
+        guard let globalReadable = global.span as? ReadableSpan else {
+            return XCTFail("Expected ReadableSpan")
+        }
+        let globalData = globalReadable.toSpanData()
+
+        var span = r.makeSpan(event: .userInteraction, source: .console, severity: .info)
+        defer { span.end() }
+        guard let readable = span as? ReadableSpan else {
+            return XCTFail("Expected ReadableSpan")
+        }
+        let data = readable.toSpanData()
+        XCTAssertNotEqual(data.traceId, globalData.traceId)
+        XCTAssertNil(data.parentSpanId)
+    }
+
+    func testIgnoredInstruments_errors_makeSpanUsesSeparateTrace() throws {
+        startRUM()
+        let r = try XCTUnwrap(rum)
+        let tracer = r.getCustomTracer(ignoredInstruments: [.errors])
+        guard let global = tracer.startGlobalSpan(name: "ignored.err") else {
+            return XCTFail("Expected global span")
+        }
+        defer { global.endSpan() }
+
+        guard let globalReadable = global.span as? ReadableSpan else {
+            return XCTFail("Expected ReadableSpan")
+        }
+        let globalData = globalReadable.toSpanData()
+
+        var span = r.makeSpan(event: .error, source: .console, severity: .error)
+        defer { span.end() }
+        guard let readable = span as? ReadableSpan else {
+            return XCTFail("Expected ReadableSpan")
+        }
+        let data = readable.toSpanData()
+        XCTAssertNotEqual(data.traceId, globalData.traceId)
+        XCTAssertNil(data.parentSpanId)
+    }
+
+    /// When only network is ignored, user-interaction auto spans must still inherit the global trace.
+    func testIgnoredInstruments_networkOnly_userInteractionStillInheritsGlobal() throws {
+        startRUM()
+        let r = try XCTUnwrap(rum)
+        let tracer = r.getCustomTracer(ignoredInstruments: [.networkRequests])
+        guard let global = tracer.startGlobalSpan(name: "partial") else {
+            return XCTFail("Expected global span")
+        }
+        defer { global.endSpan() }
+
+        guard let globalReadable = global.span as? ReadableSpan else {
+            return XCTFail("Expected ReadableSpan")
+        }
+        let globalData = globalReadable.toSpanData()
+
+        var span = r.makeSpan(event: .userInteraction, source: .console, severity: .info)
+        defer { span.end() }
+        guard let readable = span as? ReadableSpan else {
+            return XCTFail("Expected ReadableSpan")
+        }
+        let data = readable.toSpanData()
+        XCTAssertEqual(data.traceId, globalData.traceId)
+        XCTAssertEqual(data.parentSpanId, globalData.spanId)
+    }
 }

--- a/Tests/CoralogixRumTests/GlobalSpanPropagationIntegrationTests.swift
+++ b/Tests/CoralogixRumTests/GlobalSpanPropagationIntegrationTests.swift
@@ -2,9 +2,12 @@
 //  GlobalSpanPropagationIntegrationTests.swift
 //  CoralogixRumTests
 //
-//  CX-35954: Auto-instrumented spans (network, user interaction via makeSpan) must share
-//  traceId with an active global span and use parentSpanId = global span id — including
-//  when OTel active context is empty on async queues (registry fallback).
+//  Integration coverage for custom global span + auto-instrumentation:
+//  - CX-35954: `registeredGlobalForAutoInstrumentationParent()` + `URLSessionLogger.applyNetworkAutoInstrumentationParentPolicy`
+//    / `CoralogixRum.applyAutoInstrumentationParentPolicy` — same trace when global is active or when active OTel
+//    context is empty on async work (explicit `setParent(global)`).
+//  - CX-35955: `ignoredInstruments` on the tracer passed to `startGlobalSpan` — matching instruments use `setNoParent()`
+//    (fresh trace for network / makeSpan userInteraction / error).
 //
 
 import XCTest
@@ -116,7 +119,31 @@ final class GlobalSpanPropagationIntegrationTests: XCTestCase {
         return nil
     }
 
-    // MARK: - CX-35954
+    // MARK: - CX-35954 (inherit global trace)
+
+    func testGlobalSpan_makeSpan_sameThread_userInteraction_inheritsGlobal() throws {
+        startRUM()
+        let r = try XCTUnwrap(rum)
+        let tracer = r.getCustomTracer()
+        guard let global = tracer.startGlobalSpan(name: "ui.main") else {
+            return XCTFail("Expected global span")
+        }
+        defer { global.endSpan() }
+
+        guard let globalReadable = global.span as? ReadableSpan else {
+            return XCTFail("Expected ReadableSpan")
+        }
+        let globalData = globalReadable.toSpanData()
+
+        var span = r.makeSpan(event: .userInteraction, source: .console, severity: .info)
+        defer { span.end() }
+        guard let readable = span as? ReadableSpan else {
+            return XCTFail("Expected ReadableSpan")
+        }
+        let data = readable.toSpanData()
+        XCTAssertEqual(data.traceId, globalData.traceId, "Same-thread UI span should parent via active OTel context (CX-35954)")
+        XCTAssertEqual(data.parentSpanId, globalData.spanId)
+    }
 
     func testGlobalSpan_networkRequest_sameThread_sharesTraceAndParent() throws {
         PropagationTestURLProtocol.stub = (200, ["Content-Type": "application/json"], Data("{}".utf8))
@@ -203,7 +230,59 @@ final class GlobalSpanPropagationIntegrationTests: XCTestCase {
         wait(for: [exp], timeout: 3)
     }
 
-    // MARK: - CX-35955 ignoredInstruments (break trace inheritance)
+    // MARK: - CX-35955 (ignoredInstruments → setNoParent for matching auto spans)
+
+    /// Only `.userInteractions` is ignored — URLSession network spans must still join the global trace.
+    func testIgnoredInstruments_userInteractionsOnly_networkStillInheritsGlobal() throws {
+        PropagationTestURLProtocol.stub = (200, [:], Data())
+        startRUM()
+        let r = try XCTUnwrap(rum)
+        let tracer = r.getCustomTracer(ignoredInstruments: [.userInteractions])
+        guard let global = tracer.startGlobalSpan(name: "partial-net") else {
+            return XCTFail("Expected global span")
+        }
+        defer { global.endSpan() }
+
+        guard let globalReadable = global.span as? ReadableSpan else {
+            return XCTFail("Expected ReadableSpan")
+        }
+        let globalData = globalReadable.toSpanData()
+
+        let url = try XCTUnwrap(URL(string: "\(Self.baseURL)/ui-ignored-net"))
+        let exp = expectation(description: "request")
+        URLSession.shared.dataTask(with: url) { _, _, _ in exp.fulfill() }.resume()
+        wait(for: [exp], timeout: 5)
+
+        let net = try XCTUnwrap(waitForNetworkSpan(urlContains: "ui-ignored-net"))
+        XCTAssertEqual(net.traceId, globalData.traceId, "Network must still inherit global when only userInteractions is ignored (CX-35955)")
+        XCTAssertEqual(net.parentSpanId, globalData.spanId)
+    }
+
+    /// Only `.errors` is ignored — network must still inherit global.
+    func testIgnoredInstruments_errorsOnly_networkStillInheritsGlobal() throws {
+        PropagationTestURLProtocol.stub = (200, [:], Data())
+        startRUM()
+        let r = try XCTUnwrap(rum)
+        let tracer = r.getCustomTracer(ignoredInstruments: [.errors])
+        guard let global = tracer.startGlobalSpan(name: "partial-err") else {
+            return XCTFail("Expected global span")
+        }
+        defer { global.endSpan() }
+
+        guard let globalReadable = global.span as? ReadableSpan else {
+            return XCTFail("Expected ReadableSpan")
+        }
+        let globalData = globalReadable.toSpanData()
+
+        let url = try XCTUnwrap(URL(string: "\(Self.baseURL)/err-ignored-net"))
+        let exp = expectation(description: "request")
+        URLSession.shared.dataTask(with: url) { _, _, _ in exp.fulfill() }.resume()
+        wait(for: [exp], timeout: 5)
+
+        let net = try XCTUnwrap(waitForNetworkSpan(urlContains: "err-ignored-net"))
+        XCTAssertEqual(net.traceId, globalData.traceId)
+        XCTAssertEqual(net.parentSpanId, globalData.spanId)
+    }
 
     func testIgnoredInstruments_networkRequests_networkSpanUsesSeparateTrace() throws {
         PropagationTestURLProtocol.stub = (200, [:], Data())

--- a/Tests/CoralogixRumTests/GlobalSpanPropagationIntegrationTests.swift
+++ b/Tests/CoralogixRumTests/GlobalSpanPropagationIntegrationTests.swift
@@ -65,6 +65,7 @@ final class GlobalSpanPropagationIntegrationTests: XCTestCase {
         CoralogixCustomGlobalSpanRegistry.shared.teardownIfNeeded()
         rum = nil
         CoralogixRum.isInitialized = false
+        CoralogixRum.resetCustomTracerIssuanceForTesting()
         CoralogixExporter.testExportCallback = nil
         capturedSpans = []
         URLProtocol.unregisterClass(PropagationTestURLProtocol.self)
@@ -84,6 +85,7 @@ final class GlobalSpanPropagationIntegrationTests: XCTestCase {
             labels: [:],
             sessionSampleRate: 100,
             instrumentations: [.network: true],
+            traceParentInHeader: [Keys.enable.rawValue: true],
             networkExtraConfig: [NetworkCaptureRule(url: Self.baseURL)],
             debug: true
         )
@@ -126,7 +128,9 @@ final class GlobalSpanPropagationIntegrationTests: XCTestCase {
     func testGlobalSpan_makeSpan_sameThread_userInteraction_inheritsGlobal() throws {
         startRUM()
         let r = try XCTUnwrap(rum)
-        let tracer = r.getCustomTracer()
+        guard let tracer = r.getCustomTracer() else {
+            return XCTFail("Expected custom tracer")
+        }
         guard let global = tracer.startGlobalSpan(name: "ui.main") else {
             return XCTFail("Expected global span")
         }
@@ -150,7 +154,10 @@ final class GlobalSpanPropagationIntegrationTests: XCTestCase {
     func testGlobalSpan_networkRequest_sameThread_sharesTraceAndParent() throws {
         PropagationTestURLProtocol.stub = (200, ["Content-Type": "application/json"], Data("{}".utf8))
         startRUM()
-        let tracer = try XCTUnwrap(rum).getCustomTracer()
+        let sdk = try XCTUnwrap(rum)
+        guard let tracer = sdk.getCustomTracer() else {
+            return XCTFail("Expected custom tracer")
+        }
         guard let global = tracer.startGlobalSpan(name: "flow.root") else {
             return XCTFail("Expected global span")
         }
@@ -174,7 +181,10 @@ final class GlobalSpanPropagationIntegrationTests: XCTestCase {
     func testGlobalSpan_networkRequest_fromBackgroundQueue_sharesTraceAndParent() throws {
         PropagationTestURLProtocol.stub = (200, [:], Data())
         startRUM()
-        let tracer = try XCTUnwrap(rum).getCustomTracer()
+        let sdk = try XCTUnwrap(rum)
+        guard let tracer = sdk.getCustomTracer() else {
+            return XCTFail("Expected custom tracer")
+        }
         guard let global = tracer.startGlobalSpan(name: "flow.async") else {
             return XCTFail("Expected global span")
         }
@@ -204,7 +214,9 @@ final class GlobalSpanPropagationIntegrationTests: XCTestCase {
     func testGlobalSpan_makeSpanOnBackgroundQueue_userInteraction_parentsUnderGlobal() throws {
         startRUM()
         let r = try XCTUnwrap(rum)
-        let tracer = r.getCustomTracer()
+        guard let tracer = r.getCustomTracer() else {
+            return XCTFail("Expected custom tracer")
+        }
         guard let global = tracer.startGlobalSpan(name: "ui.flow") else {
             return XCTFail("Expected global span")
         }
@@ -239,7 +251,9 @@ final class GlobalSpanPropagationIntegrationTests: XCTestCase {
         PropagationTestURLProtocol.stub = (200, [:], Data())
         startRUM()
         let r = try XCTUnwrap(rum)
-        let tracer = r.getCustomTracer(ignoredInstruments: [.userInteractions])
+        guard let tracer = r.getCustomTracer(ignoredInstruments: [.userInteractions]) else {
+            return XCTFail("Expected custom tracer")
+        }
         guard let global = tracer.startGlobalSpan(name: "partial-net") else {
             return XCTFail("Expected global span")
         }
@@ -265,7 +279,9 @@ final class GlobalSpanPropagationIntegrationTests: XCTestCase {
         PropagationTestURLProtocol.stub = (200, [:], Data())
         startRUM()
         let r = try XCTUnwrap(rum)
-        let tracer = r.getCustomTracer(ignoredInstruments: [.errors])
+        guard let tracer = r.getCustomTracer(ignoredInstruments: [.errors]) else {
+            return XCTFail("Expected custom tracer")
+        }
         guard let global = tracer.startGlobalSpan(name: "partial-err") else {
             return XCTFail("Expected global span")
         }
@@ -290,7 +306,9 @@ final class GlobalSpanPropagationIntegrationTests: XCTestCase {
         PropagationTestURLProtocol.stub = (200, [:], Data())
         startRUM()
         let r = try XCTUnwrap(rum)
-        let tracer = r.getCustomTracer(ignoredInstruments: [.networkRequests])
+        guard let tracer = r.getCustomTracer(ignoredInstruments: [.networkRequests]) else {
+            return XCTFail("Expected custom tracer")
+        }
         guard let global = tracer.startGlobalSpan(name: "ignored.net") else {
             return XCTFail("Expected global span")
         }
@@ -314,7 +332,9 @@ final class GlobalSpanPropagationIntegrationTests: XCTestCase {
     func testIgnoredInstruments_userInteractions_makeSpanUsesSeparateTrace() throws {
         startRUM()
         let r = try XCTUnwrap(rum)
-        let tracer = r.getCustomTracer(ignoredInstruments: [.userInteractions])
+        guard let tracer = r.getCustomTracer(ignoredInstruments: [.userInteractions]) else {
+            return XCTFail("Expected custom tracer")
+        }
         guard let global = tracer.startGlobalSpan(name: "ignored.ui") else {
             return XCTFail("Expected global span")
         }
@@ -338,7 +358,9 @@ final class GlobalSpanPropagationIntegrationTests: XCTestCase {
     func testIgnoredInstruments_errors_makeSpanUsesSeparateTrace() throws {
         startRUM()
         let r = try XCTUnwrap(rum)
-        let tracer = r.getCustomTracer(ignoredInstruments: [.errors])
+        guard let tracer = r.getCustomTracer(ignoredInstruments: [.errors]) else {
+            return XCTFail("Expected custom tracer")
+        }
         guard let global = tracer.startGlobalSpan(name: "ignored.err") else {
             return XCTFail("Expected global span")
         }
@@ -363,7 +385,9 @@ final class GlobalSpanPropagationIntegrationTests: XCTestCase {
     func testIgnoredInstruments_networkOnly_userInteractionStillInheritsGlobal() throws {
         startRUM()
         let r = try XCTUnwrap(rum)
-        let tracer = r.getCustomTracer(ignoredInstruments: [.networkRequests])
+        guard let tracer = r.getCustomTracer(ignoredInstruments: [.networkRequests]) else {
+            return XCTFail("Expected custom tracer")
+        }
         guard let global = tracer.startGlobalSpan(name: "partial") else {
             return XCTFail("Expected global span")
         }

--- a/Tests/CoralogixRumTests/GlobalSpanPropagationIntegrationTests.swift
+++ b/Tests/CoralogixRumTests/GlobalSpanPropagationIntegrationTests.swift
@@ -132,14 +132,14 @@ final class GlobalSpanPropagationIntegrationTests: XCTestCase {
         }
         defer { global.endSpan() }
 
-        guard let globalReadable = global.span as? ReadableSpan else {
+        guard let globalReadable = global.span as? any ReadableSpan else {
             return XCTFail("Expected ReadableSpan")
         }
         let globalData = globalReadable.toSpanData()
 
         var span = r.makeSpan(event: .userInteraction, source: .console, severity: .info)
         defer { span.end() }
-        guard let readable = span as? ReadableSpan else {
+        guard let readable = span as? any ReadableSpan else {
             return XCTFail("Expected ReadableSpan")
         }
         let data = readable.toSpanData()
@@ -156,7 +156,7 @@ final class GlobalSpanPropagationIntegrationTests: XCTestCase {
         }
         defer { global.endSpan() }
 
-        guard let globalReadable = global.span as? ReadableSpan else {
+        guard let globalReadable = global.span as? any ReadableSpan else {
             return XCTFail("Expected ReadableSpan")
         }
         let globalData = globalReadable.toSpanData()
@@ -180,7 +180,7 @@ final class GlobalSpanPropagationIntegrationTests: XCTestCase {
         }
         defer { global.endSpan() }
 
-        guard let globalReadable = global.span as? ReadableSpan else {
+        guard let globalReadable = global.span as? any ReadableSpan else {
             return XCTFail("Expected ReadableSpan")
         }
         let globalData = globalReadable.toSpanData()
@@ -210,7 +210,7 @@ final class GlobalSpanPropagationIntegrationTests: XCTestCase {
         }
         defer { global.endSpan() }
 
-        guard let globalReadable = global.span as? ReadableSpan else {
+        guard let globalReadable = global.span as? any ReadableSpan else {
             return XCTFail("Expected ReadableSpan")
         }
         let globalData = globalReadable.toSpanData()
@@ -219,7 +219,7 @@ final class GlobalSpanPropagationIntegrationTests: XCTestCase {
         DispatchQueue.global(qos: .userInitiated).async {
             var span = r.makeSpan(event: .userInteraction, source: .console, severity: .info)
             defer { span.end() }
-            guard let readable = span as? ReadableSpan else {
+            guard let readable = span as? any ReadableSpan else {
                 XCTFail("Expected ReadableSpan")
                 exp.fulfill()
                 return
@@ -245,7 +245,7 @@ final class GlobalSpanPropagationIntegrationTests: XCTestCase {
         }
         defer { global.endSpan() }
 
-        guard let globalReadable = global.span as? ReadableSpan else {
+        guard let globalReadable = global.span as? any ReadableSpan else {
             return XCTFail("Expected ReadableSpan")
         }
         let globalData = globalReadable.toSpanData()
@@ -271,7 +271,7 @@ final class GlobalSpanPropagationIntegrationTests: XCTestCase {
         }
         defer { global.endSpan() }
 
-        guard let globalReadable = global.span as? ReadableSpan else {
+        guard let globalReadable = global.span as? any ReadableSpan else {
             return XCTFail("Expected ReadableSpan")
         }
         let globalData = globalReadable.toSpanData()
@@ -296,7 +296,7 @@ final class GlobalSpanPropagationIntegrationTests: XCTestCase {
         }
         defer { global.endSpan() }
 
-        guard let globalReadable = global.span as? ReadableSpan else {
+        guard let globalReadable = global.span as? any ReadableSpan else {
             return XCTFail("Expected ReadableSpan")
         }
         let globalData = globalReadable.toSpanData()
@@ -320,14 +320,14 @@ final class GlobalSpanPropagationIntegrationTests: XCTestCase {
         }
         defer { global.endSpan() }
 
-        guard let globalReadable = global.span as? ReadableSpan else {
+        guard let globalReadable = global.span as? any ReadableSpan else {
             return XCTFail("Expected ReadableSpan")
         }
         let globalData = globalReadable.toSpanData()
 
         var span = r.makeSpan(event: .userInteraction, source: .console, severity: .info)
         defer { span.end() }
-        guard let readable = span as? ReadableSpan else {
+        guard let readable = span as? any ReadableSpan else {
             return XCTFail("Expected ReadableSpan")
         }
         let data = readable.toSpanData()
@@ -344,14 +344,14 @@ final class GlobalSpanPropagationIntegrationTests: XCTestCase {
         }
         defer { global.endSpan() }
 
-        guard let globalReadable = global.span as? ReadableSpan else {
+        guard let globalReadable = global.span as? any ReadableSpan else {
             return XCTFail("Expected ReadableSpan")
         }
         let globalData = globalReadable.toSpanData()
 
         var span = r.makeSpan(event: .error, source: .console, severity: .error)
         defer { span.end() }
-        guard let readable = span as? ReadableSpan else {
+        guard let readable = span as? any ReadableSpan else {
             return XCTFail("Expected ReadableSpan")
         }
         let data = readable.toSpanData()
@@ -369,14 +369,14 @@ final class GlobalSpanPropagationIntegrationTests: XCTestCase {
         }
         defer { global.endSpan() }
 
-        guard let globalReadable = global.span as? ReadableSpan else {
+        guard let globalReadable = global.span as? any ReadableSpan else {
             return XCTFail("Expected ReadableSpan")
         }
         let globalData = globalReadable.toSpanData()
 
         var span = r.makeSpan(event: .userInteraction, source: .console, severity: .info)
         defer { span.end() }
-        guard let readable = span as? ReadableSpan else {
+        guard let readable = span as? any ReadableSpan else {
             return XCTFail("Expected ReadableSpan")
         }
         let data = readable.toSpanData()

--- a/Tests/CoralogixRumTests/GlobalSpanPropagationIntegrationTests.swift
+++ b/Tests/CoralogixRumTests/GlobalSpanPropagationIntegrationTests.swift
@@ -8,6 +8,8 @@
 //    context is empty on async work (explicit `setParent(global)`).
 //  - CX-35955: `ignoredInstruments` on the tracer passed to `startGlobalSpan` — matching instruments use `setNoParent()`
 //    (fresh trace for network / makeSpan userInteraction / error).
+//  - CX-35957: Outgoing `traceparent` on instrumented URLSession requests matches the global trace id when a global
+//    custom span is active (and trace propagation is enabled).
 //
 
 import XCTest
@@ -18,7 +20,18 @@ import CoralogixInternal
 
 private final class PropagationTestURLProtocol: URLProtocol {
     static var stub: (status: Int, headers: [String: String], body: Data)?
+    /// Last outgoing request seen by the stub (for CX-35957 `traceparent` assertions).
+    static var lastRequest: URLRequest?
+    static var lastTraceparentHeader: String?
     static let scheme = "proptest"
+
+    private static func traceparent(from request: URLRequest) -> String? {
+        guard let fields = request.allHTTPHeaderFields else { return nil }
+        for (key, value) in fields where key.lowercased() == "traceparent" {
+            return value
+        }
+        return nil
+    }
 
     override class func canInit(with request: URLRequest) -> Bool {
         request.url?.scheme == scheme
@@ -27,6 +40,8 @@ private final class PropagationTestURLProtocol: URLProtocol {
     override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
 
     override func startLoading() {
+        Self.lastRequest = request
+        Self.lastTraceparentHeader = Self.traceparent(from: request)
         guard let stub = Self.stub else {
             client?.urlProtocol(self, didFailWithError: NSError(domain: "PropagationTest", code: -1, userInfo: nil))
             return
@@ -53,6 +68,8 @@ final class GlobalSpanPropagationIntegrationTests: XCTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
         capturedSpans = []
+        PropagationTestURLProtocol.lastRequest = nil
+        PropagationTestURLProtocol.lastTraceparentHeader = nil
         URLProtocol.registerClass(PropagationTestURLProtocol.self)
         CoralogixExporter.testExportCallback = { [weak self] spans in
             self?.captureLock.lock()
@@ -67,7 +84,12 @@ final class GlobalSpanPropagationIntegrationTests: XCTestCase {
         CoralogixRum.isInitialized = false
         CoralogixRum.resetCustomTracerIssuanceForTesting()
         CoralogixExporter.testExportCallback = nil
-        capturedSpans = []
+        captureLock.lock()
+        capturedSpans.removeAll(keepingCapacity: false)
+        captureLock.unlock()
+        PropagationTestURLProtocol.stub = nil
+        PropagationTestURLProtocol.lastRequest = nil
+        PropagationTestURLProtocol.lastTraceparentHeader = nil
         URLProtocol.unregisterClass(PropagationTestURLProtocol.self)
         try super.tearDownWithError()
     }
@@ -176,6 +198,42 @@ final class GlobalSpanPropagationIntegrationTests: XCTestCase {
         let net = try XCTUnwrap(waitForNetworkSpan(urlContains: "cx35954"), "Exported network span must appear")
         XCTAssertEqual(net.traceId, globalData.traceId, "Network span must use global trace id")
         XCTAssertEqual(net.parentSpanId, globalData.spanId, "Network span parent must be global span id")
+    }
+
+    /// W3C `traceparent`: `version-traceid-spanid-flags` — trace id is 32 lowercase hex chars (CX-35957).
+    private func traceIdHexFromTraceparentHeader(_ header: String?) -> String? {
+        guard let header else { return nil }
+        let parts = header.split(separator: "-", omittingEmptySubsequences: false)
+        guard parts.count >= 2, parts[1].count == 32 else { return nil }
+        return String(parts[1])
+    }
+
+    func testGlobalSpan_networkRequest_traceparentHeaderMatchesGlobalTraceId() throws {
+        PropagationTestURLProtocol.stub = (200, ["Content-Type": "application/json"], Data("{}".utf8))
+        startRUM()
+        let sdk = try XCTUnwrap(rum)
+        guard let tracer = sdk.getCustomTracer() else {
+            return XCTFail("Expected custom tracer")
+        }
+        guard let global = tracer.startGlobalSpan(name: "traceparent.flow") else {
+            return XCTFail("Expected global span")
+        }
+        defer { global.endSpan() }
+
+        guard let globalReadable = global.span as? any ReadableSpan else {
+            return XCTFail("Expected ReadableSpan")
+        }
+        let globalTraceHex = globalReadable.toSpanData().traceId.hexString
+
+        let url = try XCTUnwrap(URL(string: "\(Self.baseURL)/traceparent"))
+        let exp = expectation(description: "request")
+        URLSession.shared.dataTask(with: url) { _, _, _ in exp.fulfill() }.resume()
+        wait(for: [exp], timeout: 5)
+
+        let header = PropagationTestURLProtocol.lastTraceparentHeader
+        XCTAssertNotNil(header, "Instrumented request should include traceparent when propagation is enabled (CX-35957)")
+        let headerTraceHex = traceIdHexFromTraceparentHeader(header)
+        XCTAssertEqual(headerTraceHex, globalTraceHex, "traceparent trace id must match the active global span's trace id")
     }
 
     func testGlobalSpan_networkRequest_fromBackgroundQueue_sharesTraceAndParent() throws {

--- a/Tests/CoralogixRumTests/NetworkCaptureIntegrationTests.swift
+++ b/Tests/CoralogixRumTests/NetworkCaptureIntegrationTests.swift
@@ -60,7 +60,10 @@ final class NetworkCaptureIntegrationTests: XCTestCase {
         rum = nil
         CoralogixRum.isInitialized = false
         CoralogixExporter.testExportCallback = nil
-        capturedSpans = []
+        captureLock.lock()
+        capturedSpans.removeAll(keepingCapacity: false)
+        captureLock.unlock()
+        CaptureTestURLProtocol.stub = nil
         URLProtocol.unregisterClass(CaptureTestURLProtocol.self)
         try super.tearDownWithError()
     }
@@ -201,7 +204,12 @@ final class NetworkCaptureIntegrationTests: XCTestCase {
         CaptureTestURLProtocol.stub = (200, [:], Data())
         startSDK(rules: [NetworkCaptureRule(url: "capturetest://integration", collectReqPayload: true)])
         performRequest(url: url, method: "POST", body: largeBody.data(using: .utf8), headers: ["Content-Type": "text/plain"])
-        let span = try XCTUnwrap(waitForNetworkSpan(urlContains: "capturetest"))
+        // Match the specific path — `urlContains: "capturetest"` is too broad: a late export from another
+        // integration URL (e.g. previous test) can be the *last* matching span and make this flaky on CI.
+        let span = try XCTUnwrap(
+            waitForNetworkSpan(urlContains: "/api/large", timeout: 15),
+            "Network span for POST /api/large must be exported"
+        )
         let payload = span.attributes[Keys.requestPayload.rawValue]?.description
         XCTAssertNil(payload, "Request body over 1024 chars must be absent")
     }
@@ -224,7 +232,7 @@ final class NetworkCaptureIntegrationTests: XCTestCase {
         CaptureTestURLProtocol.stub = (200, ["Content-Type": "image/png"], Data([0x89, 0x50, 0x4E, 0x47]))
         startSDK(rules: [NetworkCaptureRule(url: "capturetest://integration", collectResPayload: true)])
         performRequest(url: url)
-        let span = try XCTUnwrap(waitForNetworkSpan(urlContains: "capturetest"))
+        let span = try XCTUnwrap(waitForNetworkSpan(urlContains: "/image.png"), "Network span for image request must be exported")
         let payload = span.attributes[Keys.responsePayload.rawValue]?.description
         XCTAssertNil(payload, "Binary (image/png) must not be stringified")
     }
@@ -237,7 +245,7 @@ final class NetworkCaptureIntegrationTests: XCTestCase {
         CaptureTestURLProtocol.stub = (200, ["Content-Type": "application/json", "X-Secret": "no"], "{}".data(using: .utf8)!)
         startSDK(rules: [NetworkCaptureRule(url: "capturetest://integration", reqHeaders: ["Accept"], resHeaders: ["Content-Type"])])
         performRequest(url: url, headers: ["Accept": "application/json", "Authorization": "Bearer x"])
-        let span = try XCTUnwrap(waitForNetworkSpan(urlContains: "capturetest"), "Network span must be exported")
+        let span = try XCTUnwrap(waitForNetworkSpan(urlContains: "/sec"), "Network span must be exported")
         let reqJson = span.attributes[Keys.requestHeaders.rawValue]?.description ?? ""
         let resJson = span.attributes[Keys.responseHeaders.rawValue]?.description ?? ""
         if !reqJson.isEmpty {

--- a/Tests/CoralogixRumTests/NetworkCaptureIntegrationTests.swift
+++ b/Tests/CoralogixRumTests/NetworkCaptureIntegrationTests.swift
@@ -118,10 +118,12 @@ final class NetworkCaptureIntegrationTests: XCTestCase {
 
     /// Finds a network span matching the URL. When `requiringRequestPayload` is true, only returns a span that has
     /// request_payload set — avoids picking a span from another swizzle layer that lacks capture (flaky in CI).
+    /// Prefers the **last** match: URLSession instrumentation may emit more than one client span per request (factory + resume);
+    /// the later export usually reflects the span after response handling (e.g. `response_payload`).
     func findNetworkSpan(urlContains: String, requiringRequestPayload: Bool) -> SpanData? {
         captureLock.lock()
         defer { captureLock.unlock() }
-        return capturedSpans.first { span in
+        return capturedSpans.last { span in
             let type = span.attributes[Keys.eventType.rawValue]?.description ?? ""
             guard type.contains(CoralogixEventType.networkRequest.rawValue) else { return false }
             guard let url = span.attributes[SemanticAttributes.httpUrl.rawValue]?.description else { return false }
@@ -157,7 +159,7 @@ final class NetworkCaptureIntegrationTests: XCTestCase {
             NetworkCaptureRule(urlPattern: pattern, collectResPayload: true)
         ])
         performRequest(url: url)
-        let span = try XCTUnwrap(waitForNetworkSpan(urlContains: "capturetest"), "Network span for regex-matched URL must be exported")
+        let span = try XCTUnwrap(waitForNetworkSpan(urlContains: "/v2/orders/1"), "Network span for regex-matched URL must be exported")
         let payload = span.attributes[Keys.responsePayload.rawValue]?.description
         if let p = payload {
             XCTAssertEqual(p, json, "When response payload is captured it must match stub body")


### PR DESCRIPTION
## Summary

- **CX-35954:** When OpenTelemetry has no active span but a custom global span is still registered (e.g. URLSession or work off the main queue), auto-instrumented spans parent under that global so `traceId` / `parentSpanId` stay aligned with the global trace.
- **CX-35955:** `ignoredInstruments` on the tracer used to start the global span causes matching auto spans (network, user interaction, error) to call `setNoParent()` so they do not inherit the global trace.

## Code review (this branch only)

### CoralogixCustomSpans.swift
- **Issue:** None.
- **Suggestion:** `ignoredInstruments` is cleared when the global ends or on `teardownIfNeeded()`, which keeps tests and shutdown behavior consistent.

### CoralogixRum.swift
- **Issue:** None.
- **Suggestion:** `applyAutoInstrumentationParentPolicy` applies CX-35955 (`setNoParent`) before the CX-35954 fallback (`setParent(global)` when `activeSpan == nil`), so ignored instruments never accidentally inherit via the registry path.

### URLSessionLogger.swift
- **Issue:** None.
- **Nit (optional):** `applyNetworkAutoInstrumentationParentPolicy` runs after `spanCustomization`; propagation policy therefore wins if customization touched the builder.

### Tests (`CoralogixCustomSpansTests`, `GlobalSpanPropagationIntegrationTests`)
- **Issue:** None.
- **Nit (optional):** Some `makeSpan` scenarios are covered in both unit and integration tests; that overlap is acceptable for fast vs end-to-end coverage.

**Overall:** The new code looks good.

## Tickets
- CX-35954
- CX-35955


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Option to exclude specific auto-instrumented event types from inheriting a global span so those events start independent traces.
  * Global span propagation now applies to async work and URLSession network requests when no active span exists.

* **Behavior Changes**
  * Obtaining a custom tracer can return nil if prerequisites aren’t met; issuing a tracer is one-shot until shutdown resets it.
  * Example app now caches the first successful tracer for the session.

* **Tests**
  * Added unit and integration tests covering global-span propagation, ignore rules, and async/network behavior.

* **Documentation**
  * Updated docs and examples to reflect optional tracer returns and ignored-instrument configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->