### PR TITLE
fix: iOS SDK custom spans API hardening + network span 422 fix (CX-39134)

### DIFF
--- a/.github/workflows/podspec-lint.yml
+++ b/.github/workflows/podspec-lint.yml
@@ -3,21 +3,21 @@ name: Podspec Lint
 permissions:
   contents: read
 
+concurrency:
+  group: podspec-lint-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Run on every push and PR so CocoaPods validation catches SDK / podspec drift
+# without waiting for a release or a podspec-only change on master.
 on:
   pull_request:
-    paths:
-      - '**/*.podspec'
-      - '.github/workflows/podspec-lint.yml'
   push:
-    branches: [ master ]
-    paths:
-      - '**/*.podspec'
-      - '.github/workflows/podspec-lint.yml'
+  workflow_dispatch:
 
 jobs:
   lint:
     runs-on: macos-14
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     steps:
       - name: Checkout code
@@ -55,7 +55,6 @@ jobs:
             --platforms=iOS \
             --use-static-frameworks \
             --allow-warnings \
-            --skip-tests \
             --fail-fast \
             --no-clean \
             --verbose 2>&1 | tee lint_internal.log
@@ -78,7 +77,6 @@ jobs:
             --platforms=iOS \
             --use-static-frameworks \
             --allow-warnings \
-            --skip-tests \
             --fail-fast \
             --no-clean \
             --verbose 2>&1 | tee lint_session_replay.log
@@ -101,7 +99,6 @@ jobs:
             --platforms=iOS \
             --use-static-frameworks \
             --allow-warnings \
-            --skip-tests \
             --fail-fast \
             --no-clean \
             --verbose 2>&1 | tee lint_main.log

--- a/Coralogix.podspec
+++ b/Coralogix.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "Coralogix"
-  spec.version      = "2.5.1"
+  spec.version      = "2.6.0"
   spec.summary      = "Coralogix OpenTelemetry pod for iOS."
 
   spec.description  = <<-DESC
@@ -29,7 +29,7 @@ Pod::Spec.new do |spec|
 
   spec.static_framework = true
   spec.dependency 'PLCrashReporter', '~> 1.12'
-  spec.dependency 'CoralogixInternal', '2.5.1'
+  spec.dependency 'CoralogixInternal', '2.6.0'
 
   spec.test_spec 'Tests' do |test|
     test.source_files = 'Tests/CoralogixRumTests/**/*.swift'

--- a/Coralogix/Sources/CoralogixCustomSpans.swift
+++ b/Coralogix/Sources/CoralogixCustomSpans.swift
@@ -184,7 +184,9 @@ public final class CoralogixCustomTracer {
 /// - Important: If this object is deallocated without calling `endSpan()`, the span will be
 ///   automatically ended and the OTel context restored as a safety net. Always prefer explicit `endSpan()`.
 public final class CoralogixGlobalSpan {
-    public let span: any Span
+    internal let span: any Span
+    public var traceId: String { span.context.traceId.hexString }
+    public var spanId: String { span.context.spanId.hexString }
     private let tracer: Tracer
     private weak var rum: CoralogixRum?
     /// Snapshot of SDK ∪ global labels at `startGlobalSpan` time; child spans merge child keys on top (CX-35953).

--- a/Coralogix/Sources/CoralogixCustomSpans.swift
+++ b/Coralogix/Sources/CoralogixCustomSpans.swift
@@ -294,10 +294,6 @@ public final class CoralogixCustomSpan {
         span.setAttribute(key: key, value: value)
     }
 
-    public func setAttribute(key: String, value: AttributeValue?) {
-        span.setAttribute(key: key, value: value)
-    }
-
     public func addEvent(name: String) {
         span.addEvent(name: name)
     }

--- a/Coralogix/Sources/CoralogixCustomSpans.swift
+++ b/Coralogix/Sources/CoralogixCustomSpans.swift
@@ -174,7 +174,12 @@ public final class CoralogixCustomTracer {
         stampCoralogixCustomSpanRUM(on: &otelSpan)
         rum.addRumCorrelationMetadata(to: &otelSpan)
         setMergedCustomLabelsJSON(merged: mergedSdkAndGlobal, on: &otelSpan)
-        CoralogixCustomGlobalSpanRegistry.shared.registerGlobalSpan(otelSpan, ignoredInstruments: ignoredInstruments)
+        guard CoralogixCustomGlobalSpanRegistry.shared.registerGlobalSpan(otelSpan, ignoredInstruments: ignoredInstruments) else {
+            // Another thread registered a span between the pre-check and here (TOCTOU).
+            Log.w("Global span already exists")
+            otelSpan.end()
+            return nil
+        }
         return CoralogixGlobalSpan(
             span: otelSpan,
             tracer: tracer,

--- a/Coralogix/Sources/CoralogixCustomSpans.swift
+++ b/Coralogix/Sources/CoralogixCustomSpans.swift
@@ -164,7 +164,7 @@ public final class CoralogixCustomTracer {
             return nil
         }
         guard !CoralogixCustomGlobalSpanRegistry.shared.isGlobalSpanActive else {
-            Log.w("Global span already exists")
+            Log.w("[CoralogixCustomTracer] startGlobalSpan ignored — a global span is already active")
             return nil
         }
         let tracer = rum.tracerProvider()
@@ -176,7 +176,7 @@ public final class CoralogixCustomTracer {
         setMergedCustomLabelsJSON(merged: mergedSdkAndGlobal, on: &otelSpan)
         guard CoralogixCustomGlobalSpanRegistry.shared.registerGlobalSpan(otelSpan, ignoredInstruments: ignoredInstruments) else {
             // Another thread registered a span between the pre-check and here (TOCTOU).
-            Log.w("Global span already exists")
+            Log.w("[CoralogixCustomTracer] startGlobalSpan race — span created but discarded, another thread registered first")
             otelSpan.end()
             return nil
         }

--- a/Coralogix/Sources/CoralogixCustomSpans.swift
+++ b/Coralogix/Sources/CoralogixCustomSpans.swift
@@ -35,6 +35,7 @@ final class CoralogixCustomGlobalSpanRegistry {
     }
 
     /// Returns `false` if a global custom span is already registered (second `startGlobalSpan` is ignored, like the Browser SDK).
+    @discardableResult
     func registerGlobalSpan(_ span: any Span, ignoredInstruments: Set<CoralogixIgnoredInstrument>) -> Bool {
         lock.lock()
         defer { lock.unlock() }
@@ -173,11 +174,7 @@ public final class CoralogixCustomTracer {
         stampCoralogixCustomSpanRUM(on: &otelSpan)
         rum.addRumCorrelationMetadata(to: &otelSpan)
         setMergedCustomLabelsJSON(merged: mergedSdkAndGlobal, on: &otelSpan)
-        guard CoralogixCustomGlobalSpanRegistry.shared.registerGlobalSpan(otelSpan, ignoredInstruments: ignoredInstruments) else {
-            // Rare race: another thread registered between the pre-check and here.
-            otelSpan.end()
-            return nil
-        }
+        CoralogixCustomGlobalSpanRegistry.shared.registerGlobalSpan(otelSpan, ignoredInstruments: ignoredInstruments)
         return CoralogixGlobalSpan(
             span: otelSpan,
             tracer: tracer,

--- a/Coralogix/Sources/CoralogixCustomSpans.swift
+++ b/Coralogix/Sources/CoralogixCustomSpans.swift
@@ -131,7 +131,7 @@ private func mergingCustomLabelLayer(into base: [String: Any], _ layer: [String:
 /// Writes Browser-parity `custom_labels` JSON on the span for RUM (`Helper.getLabels` / Explorer).
 private func setMergedCustomLabelsJSON(merged: [String: Any], on span: inout any Span) {
     guard !merged.isEmpty else { return }
-    let json = Helper.convertDictionayToJsonString(dict: merged)
+    let json = Helper.convertDictionaryToJsonString(dict: merged)
     guard !json.isEmpty else {
         Log.w("Custom span labels could not be JSON-encoded — custom_labels attribute omitted")
         return

--- a/Coralogix/Sources/CoralogixCustomSpans.swift
+++ b/Coralogix/Sources/CoralogixCustomSpans.swift
@@ -110,8 +110,8 @@ private func stampCoralogixCustomSpanRUM(on span: inout any Span) {
 
 // MARK: - Custom span labels (CX-35953, Browser `getCustomMergedLabels` / `setCustomLabelsForSpan`)
 
-/// Merge order: `base` (SDK-level `[String: Any]`) then `layer` (`[String: String]` wins on key collision).
-private func mergingCustomLabelLayer(into base: [String: Any], _ layer: [String: String]?) -> [String: Any] {
+/// Merge order: `base` (SDK-level `[String: Any]`) then `layer` (`[String: Any]` wins on key collision).
+private func mergingCustomLabelLayer(into base: [String: Any], _ layer: [String: Any]?) -> [String: Any] {
     guard let layer, !layer.isEmpty else { return base }
     var out = base
     for (key, value) in layer {
@@ -151,7 +151,7 @@ public final class CoralogixCustomTracer {
     }
 
     /// Starts a new root span (new trace). Returns `nil` if the SDK is not initialized or the `CoralogixRum` instance was deallocated.
-    public func startGlobalSpan(name: String, labels: [String: String]? = nil) -> CoralogixGlobalSpan? {
+    public func startGlobalSpan(name: String, labels: [String: Any]? = nil) -> CoralogixGlobalSpan? {
         guard let rum = rum, rum.isInitialized else {
             return nil
         }
@@ -237,7 +237,7 @@ public final class CoralogixGlobalSpan {
     }
 
     /// Starts a child span while the global span is the OTel active span (same trace/parent as Browser `context.with(global, …)`).
-    public func startCustomSpan(name: String, labels: [String: String]? = nil) -> CoralogixCustomSpan {
+    public func startCustomSpan(name: String, labels: [String: Any]? = nil) -> CoralogixCustomSpan {
         let baseBuilder: any SpanBuilder
         if isRegisteredGlobalActiveInOTel() {
             baseBuilder = tracer.spanBuilder(spanName: name)

--- a/Coralogix/Sources/CoralogixCustomSpans.swift
+++ b/Coralogix/Sources/CoralogixCustomSpans.swift
@@ -72,6 +72,13 @@ final class CoralogixCustomGlobalSpanRegistry {
         return true
     }
 
+    /// Returns `true` if a global custom span is currently registered (fast pre-check before span creation).
+    internal var isGlobalSpanActive: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return registeredGlobal != nil
+    }
+
     /// When `OpenTelemetry.instance.contextProvider.activeSpan` is `nil` (e.g. URLSession callback or `DispatchQueue` work on another activity) but a global custom span is still registered, auto-instrumented spans should parent under that span so traceId / parentSpanId match the global trace (CX-35954).
     internal func registeredGlobalForAutoInstrumentationParent() -> (any Span)? {
         lock.lock()
@@ -155,6 +162,10 @@ public final class CoralogixCustomTracer {
         guard let rum = rum, rum.isInitialized else {
             return nil
         }
+        guard !CoralogixCustomGlobalSpanRegistry.shared.isGlobalSpanActive else {
+            Log.w("Global span already exists")
+            return nil
+        }
         let tracer = rum.tracerProvider()
         let sdkLabels = rum.labels ?? [:]
         let mergedSdkAndGlobal = mergingCustomLabelLayer(into: sdkLabels, labels)
@@ -163,7 +174,7 @@ public final class CoralogixCustomTracer {
         rum.addRumCorrelationMetadata(to: &otelSpan)
         setMergedCustomLabelsJSON(merged: mergedSdkAndGlobal, on: &otelSpan)
         guard CoralogixCustomGlobalSpanRegistry.shared.registerGlobalSpan(otelSpan, ignoredInstruments: ignoredInstruments) else {
-            Log.w("Global span already exists")
+            // Rare race: another thread registered between the pre-check and here.
             otelSpan.end()
             return nil
         }

--- a/Coralogix/Sources/Exporter/CoralogixExporter.swift
+++ b/Coralogix/Sources/Exporter/CoralogixExporter.swift
@@ -102,8 +102,9 @@ public class CoralogixExporter: SpanExporter {
         
         // ignore Urls
         var filterSpans = spans.filter { self.shouldRemoveSpan(span: $0) }
+        Log.d("[CoralogixExporter] export: \(spans.count) spans in, \(filterSpans.count) after URL filter")
         if filterSpans.isEmpty { return .failure }
-        
+
         // ignore Error
         filterSpans = filterSpans.filter { self.shouldFilterIgnoreError(span: $0) }
         
@@ -127,6 +128,7 @@ public class CoralogixExporter: SpanExporter {
             let cxSpansDictionary = autoreleasepool {
                 encodeSpans(spans: uniqueSpans)
             }
+            Log.d("[CoralogixExporter] encodeSpans: \(uniqueSpans.count) in, \(cxSpansDictionary.count) encoded")
             if cxSpansDictionary.isEmpty {
                 return .success
             }

--- a/Coralogix/Sources/Exporter/CoralogixExporter.swift
+++ b/Coralogix/Sources/Exporter/CoralogixExporter.swift
@@ -122,7 +122,11 @@ public class CoralogixExporter: SpanExporter {
             // handle their own errors within the callback.
             if let tracesExporter = tracesExporterCallback {
                 let exporterData = CoralogixTraceExporterData(spans: uniqueSpans)
-                tracesExporter(exporterData)
+                do {
+                    try tracesExporter(exporterData)
+                } catch {
+                    Log.e("[CoralogixExporter] tracesExporter callback threw: \(error)")
+                }
             }
             
             let cxSpansDictionary = autoreleasepool {

--- a/Coralogix/Sources/Exporter/CoralogixTraceExporterData.swift
+++ b/Coralogix/Sources/Exporter/CoralogixTraceExporterData.swift
@@ -63,4 +63,4 @@ public struct CoralogixTraceExporterData {
 /// - Important: This callback is invoked on a background thread (BatchSpanProcessor's processing queue).
 ///   Implementations must not block for extended periods. If you need to perform I/O operations,
 ///   dispatch them to another queue.
-public typealias TracesExporterCallback = (CoralogixTraceExporterData) -> Void
+public typealias TracesExporterCallback = (CoralogixTraceExporterData) throws -> Void

--- a/Coralogix/Sources/Exporter/SpanDataToOtlpConverter.swift
+++ b/Coralogix/Sources/Exporter/SpanDataToOtlpConverter.swift
@@ -127,16 +127,20 @@ struct SpanDataToOtlpConverter {
             timeUnixNano: dateToUnixNanoString(event.timestamp),
             name: event.name,
             attributes: convertAttributes(event.attributes),
+            // SpanData.Event has no totalAttributeCount; the OTel Swift SDK does not track
+            // dropped event attributes. Span-level dropped attrs use max(0, totalAttributeCount - attributes.count).
             droppedAttributesCount: 0
         )
     }
-    
+
     private static func convertLink(_ link: SpanData.Link) -> OtlpSpanLink {
         return OtlpSpanLink(
             traceId: encodeTraceIdToBase64(link.context.traceId),
             spanId: encodeSpanIdToBase64(link.context.spanId),
             traceState: link.context.traceState.entries.isEmpty ? nil : traceStateToString(link.context.traceState),
             attributes: convertAttributes(link.attributes),
+            // SpanData.Link has no totalAttributeCount; the OTel Swift SDK does not track
+            // dropped link attributes. Span-level dropped attrs use max(0, totalAttributeCount - attributes.count).
             droppedAttributesCount: 0
         )
     }

--- a/Coralogix/Sources/Exporter/SpanUploader.swift
+++ b/Coralogix/Sources/Exporter/SpanUploader.swift
@@ -62,7 +62,8 @@ final class SpanUploader: SpanUploading {
 
             let httpStatus = (response as? HTTPURLResponse)?.statusCode ?? 0
             if httpStatus < 200 || httpStatus >= 300 {
-                let body = data.flatMap { String(data: $0, encoding: .utf8) } ?? "<no body>"
+                let rawBody = data.flatMap { String(data: $0, encoding: .utf8) } ?? "<no body>"
+                let body = rawBody.count > 512 ? String(rawBody.prefix(512)) + "…" : rawBody
                 Log.e("[SpanUploader] Backend rejected upload with HTTP \(httpStatus): \(body)")
                 status = .failure
                 return

--- a/Coralogix/Sources/Exporter/SpanUploader.swift
+++ b/Coralogix/Sources/Exporter/SpanUploader.swift
@@ -51,16 +51,25 @@ final class SpanUploader: SpanUploading {
         var status: SpanExporterResultCode = .failure
         let semaphore = DispatchSemaphore(value: 0)
         let jsonDataCopy = requestJsonData
-        let task = URLSession.shared.dataTask(with: request) { [weak self] _, _, error in
+        let task = URLSession.shared.dataTask(with: request) { [weak self] data, response, error in
             defer { semaphore.signal() }
-            
-            if error != nil {
+
+            if let error = error {
+                Log.e("[SpanUploader] Network error: \(error.localizedDescription)")
                 status = .failure
                 return
             }
-            
+
+            let httpStatus = (response as? HTTPURLResponse)?.statusCode ?? 0
+            if httpStatus < 200 || httpStatus >= 300 {
+                let body = data.flatMap { String(data: $0, encoding: .utf8) } ?? "<no body>"
+                Log.e("[SpanUploader] Backend rejected upload with HTTP \(httpStatus): \(body)")
+                status = .failure
+                return
+            }
+
             status = .success
-            
+
             if let data = jsonDataCopy {
                 self?.logJSON(from: data, prettyPrint: true)
             }

--- a/Coralogix/Sources/Instrumentation/ErrorInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/ErrorInstrumentation.swift
@@ -126,11 +126,11 @@ extension CoralogixRum {
         span.setAttribute(key: Keys.message.rawValue, value: message)
         
         if let labels = labels {
-            span.setAttribute(key: Keys.customLabels.rawValue, value: Helper.convertDictionayToJsonString(dict: labels))
+            span.setAttribute(key: Keys.customLabels.rawValue, value: Helper.convertDictionaryToJsonString(dict: labels))
         }
         
         if let data = data {
-            span.setAttribute(key: Keys.data.rawValue, value: Helper.convertDictionayToJsonString(dict: data))
+            span.setAttribute(key: Keys.data.rawValue, value: Helper.convertDictionaryToJsonString(dict: data))
         }
                 
         if severity == .error { self.recordScreenshotForSpan(to: &span) }
@@ -179,7 +179,7 @@ extension CoralogixRum {
         if let errorType { span.setAttribute(key: Keys.errorType.rawValue, value: errorType) }
         if let stackTraceJson { span.setAttribute(key: Keys.stackTrace.rawValue, value: stackTraceJson) }
         if let userInfo, !userInfo.isEmpty {
-            span.setAttribute(key: Keys.userInfo.rawValue, value: Helper.convertDictionayToJsonString(dict: userInfo))
+            span.setAttribute(key: Keys.userInfo.rawValue, value: Helper.convertDictionaryToJsonString(dict: userInfo))
         }
         if let arch, !arch.isEmpty { span.setAttribute(key: Keys.arch.rawValue, value: arch) }
         if let buildId, !buildId.isEmpty { span.setAttribute(key: Keys.buildId.rawValue, value: buildId) }

--- a/Coralogix/Sources/Instrumentation/MobileVitalsInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/MobileVitalsInstrumentation.swift
@@ -16,7 +16,7 @@ extension CoralogixRum {
     
     func sendMobileVitals(_ mobileVitals: [String: Any]) {
         let span = makeSpan(event: .mobileVitals, source: .code, severity: .info)
-        span.setAttribute(key: Keys.mobileVitalsType.rawValue, value: Helper.convertDictionayToJsonString(dict: mobileVitals))
+        span.setAttribute(key: Keys.mobileVitalsType.rawValue, value: Helper.convertDictionaryToJsonString(dict: mobileVitals))
         span.end()
     }
 }

--- a/Coralogix/Sources/Instrumentation/NetworkInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/NetworkInstrumentation.swift
@@ -217,7 +217,7 @@ extension CoralogixRum {
             let filtered = NetworkCaptureRule.filterHeaders(allReq, allowlist: reqHeaders)
             if !filtered.isEmpty {
                 let dictAny = Dictionary(uniqueKeysWithValues: filtered.map { ($0.key, $0.value as Any) })
-                let json = Helper.convertDictionayToJsonString(dict: dictAny)
+                let json = Helper.convertDictionaryToJsonString(dict: dictAny)
                 span.setAttribute(key: Keys.requestHeaders.rawValue, value: AttributeValue.string(json))
             }
         }
@@ -227,7 +227,7 @@ extension CoralogixRum {
             let filtered = NetworkCaptureRule.filterHeaders(allRes, allowlist: resHeaders)
             if !filtered.isEmpty {
                 let dictAny = Dictionary(uniqueKeysWithValues: filtered.map { ($0.key, $0.value as Any) })
-                let json = Helper.convertDictionayToJsonString(dict: dictAny)
+                let json = Helper.convertDictionaryToJsonString(dict: dictAny)
                 span.setAttribute(key: Keys.responseHeaders.rawValue, value: AttributeValue.string(json))
             }
         }
@@ -296,7 +296,7 @@ extension CoralogixRum {
             }
             if !filtered.isEmpty {
                 let dictAny = Dictionary(uniqueKeysWithValues: filtered.map { ($0.key, $0.value as Any) })
-                let json = Helper.convertDictionayToJsonString(dict: dictAny)
+                let json = Helper.convertDictionaryToJsonString(dict: dictAny)
                 span.setAttribute(key: Keys.requestHeaders.rawValue, value: AttributeValue.string(json))
             }
         } else if let reqHeaders = dictionary[Keys.requestHeaders.rawValue] as? String, !reqHeaders.isEmpty {
@@ -314,7 +314,7 @@ extension CoralogixRum {
             }
             if !filtered.isEmpty {
                 let dictAny = Dictionary(uniqueKeysWithValues: filtered.map { ($0.key, $0.value as Any) })
-                let json = Helper.convertDictionayToJsonString(dict: dictAny)
+                let json = Helper.convertDictionaryToJsonString(dict: dictAny)
                 span.setAttribute(key: Keys.responseHeaders.rawValue, value: AttributeValue.string(json))
             }
         } else if let resHeaders = dictionary[Keys.responseHeaders.rawValue] as? String, !resHeaders.isEmpty {

--- a/Coralogix/Sources/Instrumentation/NetworkInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/NetworkInstrumentation.swift
@@ -181,7 +181,7 @@ extension CoralogixRum {
             spanBuilder.setAttribute(key: Keys.sessionId.rawValue, value: sessionMetadata.sessionId)
             spanBuilder.setAttribute(key: Keys.sessionCreationDate.rawValue, value: String(Int(sessionMetadata.sessionCreationDate)))
         } else {
-            Log.w("[Coralogix] ⚠️ Network span missing session attributes — CoralogixRum instance or sessionMetadata is nil. Span will be dropped.")
+            Log.w("[Coralogix] ⚠️ Network span missing session attributes — CoralogixRum instance or sessionMetadata is nil. Session attributes will be skipped; span will still be exported.")
         }
     }
     

--- a/Coralogix/Sources/Instrumentation/NetworkInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/NetworkInstrumentation.swift
@@ -180,6 +180,8 @@ extension CoralogixRum {
         if let sessionMetadata = getCurrentInstance()?.sessionManager?.sessionMetadata {
             spanBuilder.setAttribute(key: Keys.sessionId.rawValue, value: sessionMetadata.sessionId)
             spanBuilder.setAttribute(key: Keys.sessionCreationDate.rawValue, value: String(Int(sessionMetadata.sessionCreationDate)))
+        } else {
+            Log.w("[Coralogix] ⚠️ Network span missing session attributes — CoralogixRum instance or sessionMetadata is nil. Span will be dropped.")
         }
     }
     

--- a/Coralogix/Sources/Instrumentation/UserActionsInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/UserActionsInstrumentation.swift
@@ -93,7 +93,7 @@ extension CoralogixRum {
 
         span.setAttribute(
             key: Keys.tapObject.rawValue,
-            value: Helper.convertDictionayToJsonString(dict: properties)
+            value: Helper.convertDictionaryToJsonString(dict: properties)
         )
         span.end()
     }

--- a/Coralogix/Sources/Model/InstrumentationData.swift
+++ b/Coralogix/Sources/Model/InstrumentationData.swift
@@ -192,7 +192,14 @@ struct OtelSpan {
         let raw = statusDict[Keys.code.rawValue]
         let code: Int = {
             if let i = raw as? Int { return i }
-            if let s = raw as? String, let i = Int(s) { return i }
+            if let s = raw as? String {
+                switch s {
+                case "STATUS_CODE_OK":    return 1
+                case "STATUS_CODE_ERROR": return 2
+                default: break
+                }
+                if let i = Int(s) { return i }
+            }
             return 0
         }()
         let otlpCode: Int

--- a/Coralogix/Sources/Model/InstrumentationData.swift
+++ b/Coralogix/Sources/Model/InstrumentationData.swift
@@ -214,7 +214,7 @@ struct OtelSpan {
         result[Keys.startTime.rawValue] = self.startTime
         result[Keys.endTime.rawValue] = self.endTime
         result[Keys.status.rawValue] = Self.otlpStatusCode(from: self.status)
-        result[Keys.kind.rawValue] = Self.otlpSpanKindString(from: self.kind)
+        result[Keys.kind.rawValue] = Self.otlpSpanKind(from: self.kind)
         result[Keys.duration.rawValue] = self.duration
         if let sessionId = self.sessionId { result[Keys.keySessionId.rawValue] = sessionId }
         return result
@@ -223,7 +223,7 @@ struct OtelSpan {
     /// Maps OTel SDK SpanKind to OTLP proto SpanKind integer (backend expects i32).
     /// OTel SDK: 0=INTERNAL,1=SERVER,2=CLIENT,3=PRODUCER,4=CONSUMER
     /// OTLP proto: 0=UNSPECIFIED,1=INTERNAL,2=SERVER,3=CLIENT,4=PRODUCER,5=CONSUMER
-    private static func otlpSpanKindString(from kind: Int) -> Int {
+    private static func otlpSpanKind(from kind: Int) -> Int {
         switch kind {
         case 0: return 1  // INTERNAL
         case 1: return 2  // SERVER

--- a/Coralogix/Sources/Model/InstrumentationData.swift
+++ b/Coralogix/Sources/Model/InstrumentationData.swift
@@ -186,7 +186,8 @@ struct OtelSpan {
         return attrs
     }
 
-    /// Browser `mapStatusCodeToOtlp` (traces-exporter.utils.ts).
+    /// Maps CxSpan status to OTLP status code integer (proto enum: UNSET=0, OK=1, ERROR=2).
+    /// Backend expects i32, not the string name — protobuf JSON uses numeric enum values.
     private static func otlpStatusCode(from statusDict: [String: Any]) -> [String: Any] {
         let raw = statusDict[Keys.code.rawValue]
         let code: Int = {
@@ -194,13 +195,13 @@ struct OtelSpan {
             if let s = raw as? String, let i = Int(s) { return i }
             return 0
         }()
-        let name: String
+        let otlpCode: Int
         switch code {
-        case 1: name = Keys.otlpStatusCodeOk.rawValue
-        case 2: name = Keys.otlpStatusCodeError.rawValue
-        default: name = Keys.otlpStatusCodeUnset.rawValue
+        case 1: otlpCode = 1  // STATUS_CODE_OK
+        case 2: otlpCode = 2  // STATUS_CODE_ERROR
+        default: otlpCode = 0 // STATUS_CODE_UNSET
         }
-        return [Keys.code.rawValue: name]
+        return [Keys.code.rawValue: otlpCode]
     }
 
     func getDictionary() -> [String: Any] {
@@ -212,25 +213,24 @@ struct OtelSpan {
         result[Keys.attributes.rawValue] = self.attributes
         result[Keys.startTime.rawValue] = self.startTime
         result[Keys.endTime.rawValue] = self.endTime
-        // OTLP-formatted status: {code: "STATUS_CODE_*"} matching Browser mapCxSpanToOtlpSpan.
         result[Keys.status.rawValue] = Self.otlpStatusCode(from: self.status)
-        // OTLP-formatted kind: "SPAN_KIND_*" string matching Browser mapCxSpanToOtlpSpan.
         result[Keys.kind.rawValue] = Self.otlpSpanKindString(from: self.kind)
         result[Keys.duration.rawValue] = self.duration
         if let sessionId = self.sessionId { result[Keys.keySessionId.rawValue] = sessionId }
         return result
     }
 
-    /// Maps OpenTelemetry SpanKind integer to OTLP kind string.
-    /// SpanKind values: 0=INTERNAL, 1=SERVER, 2=CLIENT, 3=PRODUCER, 4=CONSUMER
-    private static func otlpSpanKindString(from kind: Int) -> String {
+    /// Maps OTel SDK SpanKind to OTLP proto SpanKind integer (backend expects i32).
+    /// OTel SDK: 0=INTERNAL,1=SERVER,2=CLIENT,3=PRODUCER,4=CONSUMER
+    /// OTLP proto: 0=UNSPECIFIED,1=INTERNAL,2=SERVER,3=CLIENT,4=PRODUCER,5=CONSUMER
+    private static func otlpSpanKindString(from kind: Int) -> Int {
         switch kind {
-        case 0: return Keys.otlpSpanKindInternal.rawValue
-        case 1: return Keys.otlpSpanKindServer.rawValue
-        case 2: return Keys.otlpSpanKindClient.rawValue
-        case 3: return Keys.otlpSpanKindProducer.rawValue
-        case 4: return Keys.otlpSpanKindConsumer.rawValue
-        default: return Keys.otlpSpanKindUnspecified.rawValue
+        case 0: return 1  // INTERNAL
+        case 1: return 2  // SERVER
+        case 2: return 3  // CLIENT
+        case 3: return 4  // PRODUCER
+        case 4: return 5  // CONSUMER
+        default: return 0 // UNSPECIFIED
         }
     }
 }

--- a/Coralogix/Sources/Model/InstrumentationData.swift
+++ b/Coralogix/Sources/Model/InstrumentationData.swift
@@ -25,6 +25,15 @@ struct InstrumentationData {
     }
 }
 
+/// RUM `instrumentation_data.otelSpan` payload (see `getDictionary()`).
+///
+/// **Ingestion contract:** coordinate changes with the backend/RUM pipeline owners. Mixed SDK versions
+/// in the field may require the server to accept more than one shape during rollout.
+/// - Top-level span identity and timing use **camelCase** (`traceId`, `spanId`, `startTime`, …).
+///   Legacy OTLP **snake_case duplicate mirror keys** that nested the same information again under
+///   `otelSpan` were removed on purpose; tracing extractors must not depend on those mirrors.
+/// - `status.code` is an OTLP **integer** enum (`0` unset, `1` ok, `2` error), not `STATUS_CODE_*` strings.
+/// - `kind` is emitted as an OTLP SpanKind **integer** (i32), not a string name.
 struct OtelSpan {
     let spanId: String
     let traceId: String
@@ -186,21 +195,20 @@ struct OtelSpan {
         return attrs
     }
 
-    /// Maps CxSpan status to OTLP status code integer (proto enum: UNSET=0, OK=1, ERROR=2).
-    /// Backend expects i32, not the string name — protobuf JSON uses numeric enum values.
+    /// Maps span status to OTLP status code integer (proto enum: UNSET=0, OK=1, ERROR=2).
+    /// Production `SpanData.getStatusCode()` always supplies `code` as `Int`; string branches are for
+    /// numeric strings and legacy OTLP status names from tests or external `SpanDataProtocol` stubs.
     private static func otlpStatusCode(from statusDict: [String: Any]) -> [String: Any] {
         let raw = statusDict[Keys.code.rawValue]
         let code: Int = {
             if let i = raw as? Int { return i }
-            if let s = raw as? String {
-                switch s {
-                case "STATUS_CODE_OK":    return 1
-                case "STATUS_CODE_ERROR": return 2
-                default: break
-                }
-                if let i = Int(s) { return i }
+            guard let s = raw as? String else { return 0 }
+            switch s {
+            case "STATUS_CODE_OK": return 1
+            case "STATUS_CODE_ERROR": return 2
+            default: break
             }
-            return 0
+            return Int(s) ?? 0
         }()
         let otlpCode: Int
         switch code {

--- a/Coralogix/Sources/Model/InstrumentationData.swift
+++ b/Coralogix/Sources/Model/InstrumentationData.swift
@@ -186,14 +186,6 @@ struct OtelSpan {
         return attrs
     }
 
-    /// Matches Browser `timestampToNanosString` (concat of epoch seconds + 9-digit nanos) for Tracing extractors.
-    private static func otlpUnixNanoString(hrTime: [UInt64]) -> String {
-        guard hrTime.count >= 2 else { return "0" }
-        let sec = hrTime[0]
-        let nanos = hrTime[1]
-        return "\(sec)" + String(format: "%09llu", nanos)
-    }
-
     /// Browser `mapStatusCodeToOtlp` (traces-exporter.utils.ts).
     private static func otlpStatusCode(from statusDict: [String: Any]) -> [String: Any] {
         let raw = statusDict[Keys.code.rawValue]
@@ -226,16 +218,6 @@ struct OtelSpan {
         result[Keys.kind.rawValue] = Self.otlpSpanKindString(from: self.kind)
         result[Keys.duration.rawValue] = self.duration
         if let sessionId = self.sessionId { result[Keys.keySessionId.rawValue] = sessionId }
-
-        // OTLP-shaped extra fields (Browser mapCxSpanToOtlpSpan) — Tracing extractors read these from RUM logs.
-        result[Keys.otlpTraceId.rawValue] = self.traceId
-        result[Keys.otlpSpanId.rawValue] = self.spanId
-        if let parentSpanId = self.parentSpanId {
-            result[Keys.otlpParentSpanId.rawValue] = parentSpanId
-        }
-        result[Keys.otlpStartTimeUnixNano.rawValue] = Self.otlpUnixNanoString(hrTime: self.startTime)
-        result[Keys.otlpEndTimeUnixNano.rawValue] = Self.otlpUnixNanoString(hrTime: self.endTime)
-
         return result
     }
 

--- a/Coralogix/Sources/Otel/URLSession/URLSessionInstrumentation.swift
+++ b/Coralogix/Sources/Otel/URLSession/URLSessionInstrumentation.swift
@@ -805,18 +805,21 @@ public class URLSessionInstrumentation {
             let originalIMP = method_getImplementation(method)
             
             let block: @convention(block) (AnyObject) -> Void = { [weak self] task in
-                guard let self = self else { return }
-                
+                let original: ResumeIMPType = unsafeBitCast(originalIMP, to: ResumeIMPType.self)
+                guard let self = self else {
+                    original(task, selector)
+                    return
+                }
+
                 // Call hook
                 if let urlSessionTask = task as? URLSessionTask {
                     self.urlSessionTaskWillResume(urlSessionTask)
                 }
-                
+
                 objc_setAssociatedObject(task, &Self.resumeSwizzleKey, true, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
                 // Call original implementation
-                let original: ResumeIMPType = unsafeBitCast(originalIMP, to: ResumeIMPType.self)
                 original(task, selector)
-                
+
                 objc_setAssociatedObject(task, &Self.resumeSwizzleKey, nil, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
             }
             

--- a/Coralogix/Sources/Utils/Helper.swift
+++ b/Coralogix/Sources/Utils/Helper.swift
@@ -72,15 +72,121 @@ class Helper {
     }
     
     internal static func convertDictionayToJsonString(dict: [String: Any]) -> String {
-        do {
-            let jsonData = try JSONSerialization.data(withJSONObject: dict, options: [])
-            if let jsonString = String(data: jsonData, encoding: .utf8) {
-                return jsonString
+        func encode(_ d: [String: Any]) -> String? {
+            do {
+                let jsonData = try JSONSerialization.data(withJSONObject: d, options: [])
+                return String(data: jsonData, encoding: .utf8)
+            } catch {
+                return nil
             }
-        } catch {
-            Log.e("Error: \(error)")
         }
+        if let json = encode(dict) {
+            return json
+        }
+        let sanitized = jsonSerializationSafeDictionary(dict, keyPath: "")
+        if let json = encode(sanitized) {
+            return json
+        }
+        Log.e("convertDictionayToJsonString: serialization failed after sanitization (key count \(dict.count))")
         return ""
+    }
+
+    /// Builds a dictionary `JSONSerialization` accepts: unwraps nested `Optional`s, converts `Date`/`URL`/etc.,
+    /// and replaces unknown types with `String(describing:)` so one bad value does not drop the whole payload.
+    private static func jsonSerializationSafeDictionary(_ dict: [String: Any], keyPath: String) -> [String: Any] {
+        var out: [String: Any] = [:]
+        out.reserveCapacity(dict.count)
+        for (key, value) in dict {
+            let path = keyPath.isEmpty ? key : "\(keyPath).\(key)"
+            out[key] = jsonSerializationSafeValue(value, keyPath: path)
+        }
+        return out
+    }
+
+    private static func jsonSerializationSafeValue(_ value: Any, keyPath: String) -> Any {
+        if let inner = unwrapAnyOptional(value) {
+            return jsonSerializationSafeValue(inner, keyPath: keyPath)
+        }
+        switch value {
+        case is NSNull:
+            return value
+        case let v as String:
+            return v
+        case let v as Bool:
+            return v
+        case let v as Int:
+            return v
+        case let v as Int8:
+            return Int(v)
+        case let v as Int16:
+            return Int(v)
+        case let v as Int32:
+            return Int(v)
+        case let v as Int64:
+            return Int(v)
+        case let v as UInt:
+            return v
+        case let v as UInt8:
+            return UInt(v)
+        case let v as UInt16:
+            return UInt(v)
+        case let v as UInt32:
+            return UInt(v)
+        case let v as UInt64:
+            return v
+        case let v as Double:
+            return v
+        case let v as Float:
+            return Double(v)
+        case let v as NSNumber:
+            return v
+        #if canImport(CoreGraphics)
+        case let v as CGFloat:
+            return Double(v)
+        #endif
+        case let v as Decimal:
+            return NSDecimalNumber(decimal: v).doubleValue
+        case let v as Date:
+            return iso8601String(from: v)
+        case let v as URL:
+            return v.absoluteString
+        case let v as UUID:
+            return v.uuidString
+        case let v as Data:
+            return v.base64EncodedString()
+        case let v as [String: Any]:
+            return jsonSerializationSafeDictionary(v, keyPath: keyPath)
+        case let v as [Any]:
+            return v.map { jsonSerializationSafeValue($0, keyPath: "\(keyPath)[]") }
+        case let v as NSDictionary:
+            var mapped: [String: Any] = [:]
+            for (k, item) in v {
+                guard let ks = k as? String else { continue }
+                mapped[ks] = jsonSerializationSafeValue(item, keyPath: "\(keyPath).\(ks)")
+            }
+            return mapped
+        case let v as NSArray:
+            return v.map { jsonSerializationSafeValue($0, keyPath: "\(keyPath)[]") }
+        default:
+            Log.w("convertDictionayToJsonString: non-JSON-serializable type \(Swift.type(of: value)) at \(keyPath) — coercing with String(describing:)")
+            return String(describing: value)
+        }
+    }
+
+    /// Returns `nil` when `value` is not an `Optional`, `.some(inner)`, or when unwrapping is not needed.
+    private static func unwrapAnyOptional(_ value: Any) -> Any? {
+        let mirror = Mirror(reflecting: value)
+        guard mirror.displayStyle == .optional else { return nil }
+        guard let child = mirror.children.first else {
+            return NSNull()
+        }
+        return child.value
+    }
+
+    private static func iso8601String(from date: Date) -> String {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f.string(from: date)
     }
     
     internal static func convertJsonStringToDict(jsonString: String) -> [String: Any]? {

--- a/Coralogix/Sources/Utils/Helper.swift
+++ b/Coralogix/Sources/Utils/Helper.swift
@@ -71,7 +71,7 @@ class Helper {
         return ""
     }
     
-    internal static func convertDictionayToJsonString(dict: [String: Any]) -> String {
+    internal static func convertDictionaryToJsonString(dict: [String: Any]) -> String {
         func encode(_ d: [String: Any]) -> String? {
             // `isValidJSONObject` rejects `Date` and other non-JSON types without raising an Obj‑C
             // `NSInvalidArgumentException` (which Swift `catch` does not handle).
@@ -90,7 +90,7 @@ class Helper {
         if let json = encode(sanitized) {
             return json
         }
-        Log.e("convertDictionayToJsonString: serialization failed after sanitization (key count \(dict.count))")
+        Log.e("convertDictionaryToJsonString: serialization failed after sanitization (key count \(dict.count))")
         return ""
     }
 
@@ -170,7 +170,7 @@ class Helper {
                 } else {
                     ks = String(describing: k)
                     guard !ks.isEmpty else {
-                        Log.w("convertDictionayToJsonString: skipped non-representable NSDictionary key \(Swift.type(of: k)) at \(keyPath)")
+                        Log.w("convertDictionaryToJsonString: skipped non-representable NSDictionary key \(Swift.type(of: k)) at \(keyPath)")
                         continue
                     }
                 }
@@ -180,7 +180,7 @@ class Helper {
         case let v as NSArray:
             return v.map { jsonSerializationSafeValue($0, keyPath: "\(keyPath)[]") }
         default:
-            Log.w("convertDictionayToJsonString: non-JSON-serializable type \(Swift.type(of: value)) at \(keyPath) — coercing with String(describing:)")
+            Log.w("convertDictionaryToJsonString: non-JSON-serializable type \(Swift.type(of: value)) at \(keyPath) — coercing with String(describing:)")
             return String(describing: value)
         }
     }

--- a/Coralogix/Sources/Utils/Helper.swift
+++ b/Coralogix/Sources/Utils/Helper.swift
@@ -164,7 +164,16 @@ class Helper {
         case let v as NSDictionary:
             var mapped: [String: Any] = [:]
             for (k, item) in v {
-                guard let ks = k as? String else { continue }
+                let ks: String
+                if let stringKey = k as? String {
+                    ks = stringKey
+                } else {
+                    ks = String(describing: k)
+                    guard !ks.isEmpty else {
+                        Log.w("convertDictionayToJsonString: skipped non-representable NSDictionary key \(Swift.type(of: k)) at \(keyPath)")
+                        continue
+                    }
+                }
                 mapped[ks] = jsonSerializationSafeValue(item, keyPath: "\(keyPath).\(ks)")
             }
             return mapped

--- a/Coralogix/Sources/Utils/Helper.swift
+++ b/Coralogix/Sources/Utils/Helper.swift
@@ -73,6 +73,9 @@ class Helper {
     
     internal static func convertDictionayToJsonString(dict: [String: Any]) -> String {
         func encode(_ d: [String: Any]) -> String? {
+            // `isValidJSONObject` rejects `Date` and other non-JSON types without raising an Obj‑C
+            // `NSInvalidArgumentException` (which Swift `catch` does not handle).
+            guard JSONSerialization.isValidJSONObject(d) else { return nil }
             do {
                 let jsonData = try JSONSerialization.data(withJSONObject: d, options: [])
                 return String(data: jsonData, encoding: .utf8)

--- a/CoralogixInternal.podspec
+++ b/CoralogixInternal.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "CoralogixInternal"
-  spec.version      = "2.5.1"
+  spec.version      = "2.6.0"
   spec.summary      = "Coralogix Internal Package. This module is not for public use."
 
   spec.description  = <<-DESC

--- a/CoralogixInternal/Sources/Keys.swift
+++ b/CoralogixInternal/Sources/Keys.swift
@@ -141,21 +141,6 @@ public enum Keys: String {
     case endTime
     case status
     case kind
-    /// OTLP-shaped mirror keys on `instrumentation_data.otelSpan` (Browser `mapCxSpanToOtlpSpan` / Tracing extractors).
-    case otlpTraceId = "trace_id"
-    case otlpSpanId = "span_id"
-    case otlpParentSpanId = "parent_span_id"
-    case otlpStartTimeUnixNano = "start_time_unix_nano"
-    case otlpEndTimeUnixNano = "end_time_unix_nano"
-    case otlpSpanKindUnspecified = "SPAN_KIND_UNSPECIFIED"
-    case otlpSpanKindInternal = "SPAN_KIND_INTERNAL"
-    case otlpSpanKindServer = "SPAN_KIND_SERVER"
-    case otlpSpanKindClient = "SPAN_KIND_CLIENT"
-    case otlpSpanKindProducer = "SPAN_KIND_PRODUCER"
-    case otlpSpanKindConsumer = "SPAN_KIND_CONSUMER"
-    case otlpStatusCodeUnset = "STATUS_CODE_UNSET"
-    case otlpStatusCodeOk = "STATUS_CODE_OK"
-    case otlpStatusCodeError = "STATUS_CODE_ERROR"
     case tapName
     case tapCount
     case tapAttributes

--- a/CoralogixInternal/Sources/Utils.swift
+++ b/CoralogixInternal/Sources/Utils.swift
@@ -16,7 +16,7 @@ public enum ImageFormat {
 }
 
 public enum Global: String {
-    case sdk = "2.5.1"
+    case sdk = "2.6.0"
     case swiftVersion = "5.9"
     case coralogixPath = "/browser/v1beta/logs"
     case sessionReplayPath = "/browser/alpha/sessionrecording"

--- a/Example/DemoAppUITests/UserInteractionUITests.swift
+++ b/Example/DemoAppUITests/UserInteractionUITests.swift
@@ -573,8 +573,7 @@ final class UserInteractionUITests: XCTestCase {
         Thread.sleep(forTimeInterval: sdkFlushDelay)
         navigateBackToMainMenu()
         navigateToSchemaValidation()
-        triggerValidation()
-        verifySchemaValidationPassed()
+        validateSchemaWithRetry()
     }
 
     private func triggerValidation() {
@@ -588,17 +587,45 @@ final class UserInteractionUITests: XCTestCase {
         print("🟪 ✅ Validation request sent")
     }
 
-    private func verifySchemaValidationPassed(file: StaticString = #file, line: UInt = #line) {
+    private func validateSchemaWithRetry(file: StaticString = #file, line: UInt = #line) {
+        let maxAttempts = isCI ? 3 : 2
+        for attempt in 1...maxAttempts {
+            print("🟪 🔁 Schema validation attempt \(attempt)/\(maxAttempts)")
+            triggerValidation()
+            if verifySchemaValidationPassed() {
+                return
+            }
+
+            let visibleLabels = app.staticTexts.allElementsBoundByIndex.map { $0.label }
+            let combined = visibleLabels.joined(separator: " | ")
+            let isRetryable = combined.contains("Network error:")
+                || combined.contains("Internet connection appears to be offline")
+                || combined.contains("timed out")
+                || combined.contains("could not connect")
+
+            if attempt < maxAttempts && isRetryable {
+                print("🟨 Schema validation hit transient network issue, retrying…")
+                Thread.sleep(forTimeInterval: networkDelay)
+                continue
+            }
+
+            XCTFail(
+                "Schema validation failed after \(attempt) attempt(s). Visible labels: [\(visibleLabels.joined(separator: ", "))]",
+                file: file,
+                line: line
+            )
+            return
+        }
+    }
+
+    private func verifySchemaValidationPassed() -> Bool {
         print("🟪 🔍 Checking schema validation result…")
         let successLabel = app.staticTexts["All logs are valid! ✅"]
-        if !successLabel.waitForExistence(timeout: networkDelay) {
-            let visibleLabels = app.staticTexts.allElementsBoundByIndex
-                .map { $0.label }
-                .joined(separator: ", ")
-            XCTFail("Schema validation failed. Visible labels: [\(visibleLabels)]", file: file, line: line)
-        } else {
+        if successLabel.waitForExistence(timeout: networkDelay) {
             print("🟪 ✅ Schema validation passed!")
+            return true
         }
+        return false
     }
 
     // MARK: - Temp-file I/O

--- a/Example/Shared/CoralogixRumManager.swift
+++ b/Example/Shared/CoralogixRumManager.swift
@@ -51,7 +51,7 @@ final class CoralogixRumManager {
 //            return editableCxRum
 //        },
                                                enableSwizzling: true,
-       //                                        proxyUrl: Envs.PROXY_URL.rawValue, // remove if not need to use proxy
+                                               proxyUrl: Envs.PROXY_URL.rawValue, // remove if not need to use proxy
                                                traceParentInHeader: ["enable": true],
                                                mobileVitals:[.cpuDetector: false,
                                                              .warmDetector: false,

--- a/Example/Shared/CoralogixRumManager.swift
+++ b/Example/Shared/CoralogixRumManager.swift
@@ -51,7 +51,7 @@ final class CoralogixRumManager {
 //            return editableCxRum
 //        },
                                                enableSwizzling: true,
-                                               proxyUrl: Envs.PROXY_URL.rawValue, // remove if not need to use proxy
+       //                                        proxyUrl: Envs.PROXY_URL.rawValue, // remove if not need to use proxy
                                                traceParentInHeader: ["enable": true],
                                                mobileVitals:[.cpuDetector: false,
                                                              .warmDetector: false,

--- a/SessionReplay.podspec
+++ b/SessionReplay.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "SessionReplay"
-  spec.version      = "2.5.1"
+  spec.version      = "2.6.0"
   spec.summary      = "Coralogix Session-Replay pod for iOS."
 
   spec.description  = <<-DESC
@@ -23,7 +23,7 @@ Pod::Spec.new do |spec|
   spec.static_framework = true
 
   spec.source_files  = 'SessionReplay/Sources/**/*.swift'
-  spec.dependency 'CoralogixInternal', '2.5.1'
+  spec.dependency 'CoralogixInternal', '2.6.0'
   
     spec.test_spec 'Tests' do |test|
         test.source_files = 'Tests/SessionReplayTests/**/*.swift'

--- a/Tests/CoralogixRumTests/CoralogixCustomSpansTests.swift
+++ b/Tests/CoralogixRumTests/CoralogixCustomSpansTests.swift
@@ -481,4 +481,148 @@ final class CoralogixCustomSpansTests: XCTestCase {
         XCTAssertEqual(data.traceId, globalData.traceId)
         XCTAssertEqual(data.parentSpanId, globalData.spanId)
     }
+
+    // MARK: - [String: Any] label merge tests
+
+    /// Mixed-type values (Int, Bool, String) survive merge and JSON serialization to custom_labels.
+    func testGlobalSpanLabels_mixedTypes_surviveJsonSerialization() {
+        let rum = CoralogixRum(options: options!)
+        guard let tracer = rum.getCustomTracer() else {
+            return XCTFail("Expected custom tracer")
+        }
+        let labels: [String: Any] = ["name": "checkout", "retryCount": 3, "isGuest": true]
+        guard let global = tracer.startGlobalSpan(name: "g", labels: labels) else {
+            return XCTFail("Expected global span")
+        }
+        defer { global.endSpan() }
+        guard let readable = global.span as? any ReadableSpan,
+              case let .string(json)? = readable.toSpanData().attributes[Keys.customLabels.rawValue],
+              let dict = Helper.convertJsonStringToDict(jsonString: json) else {
+            return XCTFail("Expected custom_labels JSON on global span")
+        }
+        XCTAssertEqual(dict["name"] as? String, "checkout")
+        XCTAssertEqual(dict["retryCount"] as? Int, 3)
+        XCTAssertEqual(dict["isGuest"] as? Bool, true)
+    }
+
+    /// Child span labels with mixed types survive three-level merge and JSON serialization.
+    func testChildSpanLabels_mixedTypes_surviveJsonSerialization() {
+        let rum = CoralogixRum(options: options!)
+        guard let tracer = rum.getCustomTracer() else {
+            return XCTFail("Expected custom tracer")
+        }
+        guard let global = tracer.startGlobalSpan(name: "g", labels: ["count": 10]) else {
+            return XCTFail("Expected global span")
+        }
+        defer { global.endSpan() }
+        let child = global.startCustomSpan(name: "c", labels: ["ratio": 0.75, "active": false])
+        defer { child.endSpan() }
+        guard let readable = child.span as? any ReadableSpan,
+              case let .string(json)? = readable.toSpanData().attributes[Keys.customLabels.rawValue],
+              let dict = Helper.convertJsonStringToDict(jsonString: json) else {
+            return XCTFail("Expected custom_labels JSON on child span")
+        }
+        XCTAssertEqual(dict["count"] as? Int, 10)
+        XCTAssertEqual(dict["ratio"] as? Double, 0.75)
+        XCTAssertEqual(dict["active"] as? Bool, false)
+    }
+
+    /// Layer overrides base on key collision (layer wins), even with mixed types.
+    func testLabelMerge_layerOverridesBase_mixedTypes() {
+        let rum = CoralogixRum(options: options!)
+        guard let tracer = rum.getCustomTracer() else {
+            return XCTFail("Expected custom tracer")
+        }
+        guard let global = tracer.startGlobalSpan(name: "g", labels: ["tier": "global", "count": 5]) else {
+            return XCTFail("Expected global span")
+        }
+        defer { global.endSpan() }
+        let child = global.startCustomSpan(name: "c", labels: ["tier": "child", "count": 99])
+        defer { child.endSpan() }
+        guard let readable = child.span as? any ReadableSpan,
+              case let .string(json)? = readable.toSpanData().attributes[Keys.customLabels.rawValue],
+              let dict = Helper.convertJsonStringToDict(jsonString: json) else {
+            return XCTFail("Expected custom_labels JSON")
+        }
+        XCTAssertEqual(dict["tier"] as? String, "child")
+        XCTAssertEqual(dict["count"] as? Int, 99)
+    }
+
+    /// nil layer returns base unchanged (no crash, no empty labels).
+    func testLabelMerge_nilLayer_returnsBaseUnchanged() {
+        let rum = CoralogixRum(options: options!)
+        guard let tracer = rum.getCustomTracer() else {
+            return XCTFail("Expected custom tracer")
+        }
+        guard let global = tracer.startGlobalSpan(name: "g", labels: ["env": "prod"]) else {
+            return XCTFail("Expected global span")
+        }
+        defer { global.endSpan() }
+        let child = global.startCustomSpan(name: "c", labels: nil)
+        defer { child.endSpan() }
+        guard let readable = child.span as? any ReadableSpan,
+              case let .string(json)? = readable.toSpanData().attributes[Keys.customLabels.rawValue],
+              let dict = Helper.convertJsonStringToDict(jsonString: json) else {
+            return XCTFail("Expected custom_labels JSON")
+        }
+        XCTAssertEqual(dict["env"] as? String, "prod")
+    }
+
+    /// Empty layer returns base unchanged.
+    func testLabelMerge_emptyLayer_returnsBaseUnchanged() {
+        let rum = CoralogixRum(options: options!)
+        guard let tracer = rum.getCustomTracer() else {
+            return XCTFail("Expected custom tracer")
+        }
+        guard let global = tracer.startGlobalSpan(name: "g", labels: ["env": "staging"]) else {
+            return XCTFail("Expected global span")
+        }
+        defer { global.endSpan() }
+        let child = global.startCustomSpan(name: "c", labels: [:])
+        defer { child.endSpan() }
+        guard let readable = child.span as? any ReadableSpan,
+              case let .string(json)? = readable.toSpanData().attributes[Keys.customLabels.rawValue],
+              let dict = Helper.convertJsonStringToDict(jsonString: json) else {
+            return XCTFail("Expected custom_labels JSON")
+        }
+        XCTAssertEqual(dict["env"] as? String, "staging")
+    }
+
+    /// Three-level merge: SDK labels → global labels → child labels, each level wins on collision.
+    func testLabelMerge_threeLevels_mixedTypes_eachLevelWinsOnCollision() {
+        let opts = CoralogixExporterOptions(
+            coralogixDomain: CoralogixDomain.US2,
+            userContext: nil,
+            environment: "PROD",
+            application: "TestApp-CustomSpans",
+            version: "1.0",
+            publicKey: "token",
+            ignoreUrls: [],
+            ignoreErrors: [],
+            labels: ["tier": "sdk", "sdkOnly": 42, "flag": false],
+            sessionSampleRate: 100,
+            traceParentInHeader: [Keys.enable.rawValue: true],
+            debug: true
+        )
+        let rum = CoralogixRum(options: opts)
+        guard let tracer = rum.getCustomTracer() else {
+            return XCTFail("Expected custom tracer")
+        }
+        guard let global = tracer.startGlobalSpan(name: "g", labels: ["tier": "global", "globalOnly": 99]) else {
+            return XCTFail("Expected global span")
+        }
+        defer { global.endSpan() }
+        let child = global.startCustomSpan(name: "c", labels: ["tier": "child", "childOnly": true])
+        defer { child.endSpan() }
+        guard let readable = child.span as? any ReadableSpan,
+              case let .string(json)? = readable.toSpanData().attributes[Keys.customLabels.rawValue],
+              let dict = Helper.convertJsonStringToDict(jsonString: json) else {
+            return XCTFail("Expected custom_labels JSON on child")
+        }
+        XCTAssertEqual(dict["tier"] as? String, "child")
+        XCTAssertEqual(dict["sdkOnly"] as? Int, 42)
+        XCTAssertEqual(dict["flag"] as? Bool, false)
+        XCTAssertEqual(dict["globalOnly"] as? Int, 99)
+        XCTAssertEqual(dict["childOnly"] as? Bool, true)
+    }
 }

--- a/Tests/CoralogixRumTests/CxRumTests.swift
+++ b/Tests/CoralogixRumTests/CxRumTests.swift
@@ -26,7 +26,7 @@ final class CxRumTests: XCTestCase {
                                        actionCount: 0,
                                        hasRecording: false)
         let dict = Helper.convertDictionary(snapshot.getDictionary())
-        let snapshotString = Helper.convertDictionayToJsonString(dict: dict)
+        let snapshotString = Helper.convertDictionaryToJsonString(dict: dict)
         mockSpanData = MockSpanData(attributes: [Keys.severity.rawValue: AttributeValue("3"),
                                                  Keys.eventType.rawValue: AttributeValue("log"),
                                                  Keys.source.rawValue: AttributeValue("console"),

--- a/Tests/CoralogixRumTests/HelperTests.swift
+++ b/Tests/CoralogixRumTests/HelperTests.swift
@@ -88,5 +88,21 @@ final class HelperTests: XCTestCase {
             XCTAssertEqual(result.traceId, "trace123")
             XCTAssertEqual(result.spanId, "span123")
         }
+
+    /// Non-JSON-serializable values (e.g. `Date`) must not cause `convertDictionayToJsonString` to return empty for the whole map.
+    func testConvertDictionaryToJsonStringSanitizesDateAndKeepsOtherKeys() throws {
+        let date = Date(timeIntervalSince1970: 1_700_000_000)
+        let json = Helper.convertDictionayToJsonString(dict: [
+            "userId": "abc",
+            "loggedAt": date,
+            "count": 3
+        ])
+        XCTAssertFalse(json.isEmpty, "expected sanitized JSON, not empty string")
+        let data = try XCTUnwrap(json.data(using: .utf8))
+        let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        XCTAssertEqual(obj?["userId"] as? String, "abc")
+        XCTAssertEqual(obj?["count"] as? Int, 3)
+        XCTAssertNotNil(obj?["loggedAt"] as? String)
+    }
 }
     

--- a/Tests/CoralogixRumTests/HelperTests.swift
+++ b/Tests/CoralogixRumTests/HelperTests.swift
@@ -104,5 +104,25 @@ final class HelperTests: XCTestCase {
         XCTAssertEqual(obj?["count"] as? Int, 3)
         XCTAssertNotNil(obj?["loggedAt"] as? String)
     }
+
+    func testConvertDictionaryToJsonStringPreservesNonStringNestedNSDictionaryKeys() throws {
+        let nested: NSDictionary = [
+            NSNumber(value: 42): "answer",
+            NSNumber(value: 7): URL(string: "https://example.com/path")!,
+            "plain": "text"
+        ]
+        let json = Helper.convertDictionayToJsonString(dict: [
+            "labels": nested
+        ])
+        XCTAssertFalse(json.isEmpty, "expected sanitized JSON, not empty string")
+
+        let data = try XCTUnwrap(json.data(using: .utf8))
+        let obj = try XCTUnwrap(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let labels = try XCTUnwrap(obj["labels"] as? [String: Any])
+
+        XCTAssertEqual(labels["42"] as? String, "answer")
+        XCTAssertEqual(labels["7"] as? String, "https://example.com/path")
+        XCTAssertEqual(labels["plain"] as? String, "text")
+    }
 }
     

--- a/Tests/CoralogixRumTests/HelperTests.swift
+++ b/Tests/CoralogixRumTests/HelperTests.swift
@@ -89,10 +89,10 @@ final class HelperTests: XCTestCase {
             XCTAssertEqual(result.spanId, "span123")
         }
 
-    /// Non-JSON-serializable values (e.g. `Date`) must not cause `convertDictionayToJsonString` to return empty for the whole map.
+    /// Non-JSON-serializable values (e.g. `Date`) must not cause `convertDictionaryToJsonString` to return empty for the whole map.
     func testConvertDictionaryToJsonStringSanitizesDateAndKeepsOtherKeys() throws {
         let date = Date(timeIntervalSince1970: 1_700_000_000)
-        let json = Helper.convertDictionayToJsonString(dict: [
+        let json = Helper.convertDictionaryToJsonString(dict: [
             "userId": "abc",
             "loggedAt": date,
             "count": 3
@@ -111,7 +111,7 @@ final class HelperTests: XCTestCase {
             NSNumber(value: 7): URL(string: "https://example.com/path")!,
             "plain": "text"
         ]
-        let json = Helper.convertDictionayToJsonString(dict: [
+        let json = Helper.convertDictionaryToJsonString(dict: [
             "labels": nested
         ])
         XCTAssertFalse(json.isEmpty, "expected sanitized JSON, not empty string")

--- a/Tests/CoralogixRumTests/InstrumentationDataTests.swift
+++ b/Tests/CoralogixRumTests/InstrumentationDataTests.swift
@@ -102,14 +102,14 @@ final class InstrumentationDataTests: XCTestCase {
         XCTAssertEqual(dict[Keys.spanId.rawValue] as? String, "span123")
         XCTAssertEqual(dict[Keys.traceId.rawValue] as? String, "trace123")
         XCTAssertEqual(dict[Keys.name.rawValue] as? String, "testSpan")
-        // kind is now OTLP-formatted string (matching Browser mapCxSpanToOtlpSpan).
-        XCTAssertEqual(dict[Keys.kind.rawValue] as? String, Keys.otlpSpanKindClient.rawValue)
+        // kind is OTLP proto integer: OTel SDK CLIENT(2) → OTLP CLIENT(3)
+        XCTAssertEqual(dict[Keys.kind.rawValue] as? Int, 3)
         XCTAssertNotNil(dict[Keys.startTime.rawValue])
         XCTAssertNotNil(dict[Keys.endTime.rawValue])
-        // status is now OTLP-formatted: {code: "STATUS_CODE_*"}.
+        // status.code is OTLP proto integer: UNSET=0, OK=1, ERROR=2
         XCTAssertEqual(
-            (dict[Keys.status.rawValue] as? [String: Any])?[Keys.code.rawValue] as? String,
-            Keys.otlpStatusCodeUnset.rawValue
+            (dict[Keys.status.rawValue] as? [String: Any])?[Keys.code.rawValue] as? Int,
+            0
         )
         XCTAssertNotNil(dict[Keys.duration.rawValue])
         XCTAssertEqual(dict[Keys.keySessionId.rawValue] as? String, "session_001")

--- a/Tests/CoralogixRumTests/InstrumentationDataTests.swift
+++ b/Tests/CoralogixRumTests/InstrumentationDataTests.swift
@@ -115,10 +115,10 @@ final class InstrumentationDataTests: XCTestCase {
         XCTAssertEqual(dict[Keys.keySessionId.rawValue] as? String, "session_001")
         XCTAssertNil(dict[Keys.parentSpanId.rawValue], "parentSpanId should be absent for root spans")
 
-        XCTAssertEqual(dict[Keys.otlpTraceId.rawValue] as? String, "trace123")
-        XCTAssertEqual(dict[Keys.otlpSpanId.rawValue] as? String, "span123")
-        XCTAssertNotNil(dict[Keys.otlpStartTimeUnixNano.rawValue] as? String)
-        XCTAssertNotNil(dict[Keys.otlpEndTimeUnixNano.rawValue] as? String)
+        XCTAssertNil(dict[Keys.otlpTraceId.rawValue], "snake_case trace_id must not appear in log output")
+        XCTAssertNil(dict[Keys.otlpSpanId.rawValue], "snake_case span_id must not appear in log output")
+        XCTAssertNil(dict[Keys.otlpStartTimeUnixNano.rawValue], "snake_case start_time_unix_nano must not appear in log output")
+        XCTAssertNil(dict[Keys.otlpEndTimeUnixNano.rawValue], "snake_case end_time_unix_nano must not appear in log output")
     }
 
     func testInitializationWithAttributes() throws {

--- a/Tests/CoralogixRumTests/InstrumentationDataTests.swift
+++ b/Tests/CoralogixRumTests/InstrumentationDataTests.swift
@@ -115,10 +115,10 @@ final class InstrumentationDataTests: XCTestCase {
         XCTAssertEqual(dict[Keys.keySessionId.rawValue] as? String, "session_001")
         XCTAssertNil(dict[Keys.parentSpanId.rawValue], "parentSpanId should be absent for root spans")
 
-        XCTAssertNil(dict[Keys.otlpTraceId.rawValue], "snake_case trace_id must not appear in log output")
-        XCTAssertNil(dict[Keys.otlpSpanId.rawValue], "snake_case span_id must not appear in log output")
-        XCTAssertNil(dict[Keys.otlpStartTimeUnixNano.rawValue], "snake_case start_time_unix_nano must not appear in log output")
-        XCTAssertNil(dict[Keys.otlpEndTimeUnixNano.rawValue], "snake_case end_time_unix_nano must not appear in log output")
+        XCTAssertNil(dict["trace_id"], "snake_case trace_id must not appear in log output")
+        XCTAssertNil(dict["span_id"], "snake_case span_id must not appear in log output")
+        XCTAssertNil(dict["start_time_unix_nano"], "snake_case start_time_unix_nano must not appear in log output")
+        XCTAssertNil(dict["end_time_unix_nano"], "snake_case end_time_unix_nano must not appear in log output")
     }
 
     func testInitializationWithAttributes() throws {

--- a/Tests/CoralogixRumTests/InstrumentationDataTests.swift
+++ b/Tests/CoralogixRumTests/InstrumentationDataTests.swift
@@ -290,6 +290,70 @@ final class InstrumentationDataTests: XCTestCase {
         XCTAssertNil(attrs["cx_rum.error_context.error_message"])
     }
 
+    // MARK: - OTLP serialization regression tests (fix: network spans 422)
+    // Backend requires i32 for status.code and kind — string enum names cause HTTP 422.
+
+    func testOtlpStatusCode_isInt_notString() {
+        // Regression: status.code was "STATUS_CODE_UNSET" (String) → backend rejected with HTTP 422.
+        // Must be an Int (0=UNSET, 1=OK, 2=ERROR) per OTLP proto spec.
+        let cxRum = makeCxRum()
+        let span = MockSpanData(attributes: [:], kind: 2, statusCode: [:])
+        let dict = OtelSpan(otel: span, cxRum: cxRum, viewManager: nil).getDictionary()
+        let statusCode = (dict[Keys.status.rawValue] as? [String: Any])?[Keys.code.rawValue]
+        XCTAssertNil(statusCode as? String, "status.code must not be a String — backend expects i32")
+        XCTAssertNotNil(statusCode as? Int, "status.code must be an Int")
+    }
+
+    func testOtlpStatusCode_unset_isZero() {
+        let cxRum = makeCxRum()
+        let span = MockSpanData(attributes: [:], kind: 2, statusCode: [Keys.code.rawValue: 0])
+        let code = (OtelSpan(otel: span, cxRum: cxRum, viewManager: nil).getDictionary()[Keys.status.rawValue] as? [String: Any])?[Keys.code.rawValue] as? Int
+        XCTAssertEqual(code, 0)
+    }
+
+    func testOtlpStatusCode_ok_isOne() {
+        let cxRum = makeCxRum()
+        let span = MockSpanData(attributes: [:], kind: 2, statusCode: [Keys.code.rawValue: 1])
+        let code = (OtelSpan(otel: span, cxRum: cxRum, viewManager: nil).getDictionary()[Keys.status.rawValue] as? [String: Any])?[Keys.code.rawValue] as? Int
+        XCTAssertEqual(code, 1)
+    }
+
+    func testOtlpStatusCode_error_isTwo() {
+        let cxRum = makeCxRum()
+        let span = MockSpanData(attributes: [:], kind: 2, statusCode: [Keys.code.rawValue: 2])
+        let code = (OtelSpan(otel: span, cxRum: cxRum, viewManager: nil).getDictionary()[Keys.status.rawValue] as? [String: Any])?[Keys.code.rawValue] as? Int
+        XCTAssertEqual(code, 2)
+    }
+
+    func testOtlpKind_isInt_notString() {
+        // Regression: kind was "SPAN_KIND_CLIENT" (String) → backend would reject with HTTP 422.
+        // Must be an Int per OTLP proto spec.
+        let cxRum = makeCxRum()
+        let span = MockSpanData(attributes: [:], kind: 2)
+        let dict = OtelSpan(otel: span, cxRum: cxRum, viewManager: nil).getDictionary()
+        XCTAssertNil(dict[Keys.kind.rawValue] as? String, "kind must not be a String — backend expects i32")
+        XCTAssertNotNil(dict[Keys.kind.rawValue] as? Int, "kind must be an Int")
+    }
+
+    func testOtlpKind_sdkClientMapsToOtlpClient() {
+        // OTel SDK CLIENT=2 must map to OTLP proto CLIENT=3 (off-by-one: OTLP has UNSPECIFIED=0 at index 0).
+        let cxRum = makeCxRum()
+        let span = MockSpanData(attributes: [:], kind: 2)
+        let kind = OtelSpan(otel: span, cxRum: cxRum, viewManager: nil).getDictionary()[Keys.kind.rawValue] as? Int
+        XCTAssertEqual(kind, 3, "OTel SDK CLIENT(2) must serialize as OTLP proto CLIENT(3)")
+    }
+
+    func testOtlpKind_allSdkValues_mapCorrectly() {
+        // Exhaustive mapping: OTel SDK 0…4 → OTLP proto 1…5; unknown → 0
+        let cxRum = makeCxRum()
+        let expectedOtlpKind: [Int: Int] = [0: 1, 1: 2, 2: 3, 3: 4, 4: 5, 99: 0]
+        for (sdkKind, expectedKind) in expectedOtlpKind {
+            let span = MockSpanData(attributes: [:], kind: sdkKind)
+            let kind = OtelSpan(otel: span, cxRum: cxRum, viewManager: nil).getDictionary()[Keys.kind.rawValue] as? Int
+            XCTAssertEqual(kind, expectedKind, "OTel SDK kind \(sdkKind) should map to OTLP kind \(expectedKind)")
+        }
+    }
+
     // MARK: - Helpers
 
     private func makeCxRum(

--- a/Tests/CoralogixRumTests/InteractionContextTests.swift
+++ b/Tests/CoralogixRumTests/InteractionContextTests.swift
@@ -31,7 +31,7 @@ final class InteractionContextTests: XCTestCase {
                 Keys.eventType.rawValue:   AttributeValue("user-interaction"),
                 Keys.source.rawValue:      AttributeValue("console"),
                 Keys.environment.rawValue: AttributeValue("prod"),
-                Keys.tapObject.rawValue:   AttributeValue(Helper.convertDictionayToJsonString(dict: tapObject))
+                Keys.tapObject.rawValue:   AttributeValue(Helper.convertDictionaryToJsonString(dict: tapObject))
             ],
             startTime: now,
             endTime: now,

--- a/version_bump.sh
+++ b/version_bump.sh
@@ -75,12 +75,21 @@ update_internal_dependency_version() {
 }
 
 # Main script logic
-if [ $# -ne 1 ]; then
-  echo "Usage: $0 {major|minor|patch}"
-  exit 1
+if [ $# -eq 1 ]; then
+  part=$1
+else
+  echo "Select version bump type:"
+  echo "  1) patch"
+  echo "  2) minor"
+  echo "  3) major"
+  read -rp "Choice [1/2/3]: " choice
+  case $choice in
+    1) part="patch" ;;
+    2) part="minor" ;;
+    3) part="major" ;;
+    *) echo "Invalid choice: $choice"; exit 1 ;;
+  esac
 fi
-
-part=$1
 
 # Get the absolute path of the script directory
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)

--- a/version_bump.sh
+++ b/version_bump.sh
@@ -77,18 +77,27 @@ update_internal_dependency_version() {
 # Main script logic
 if [ $# -eq 1 ]; then
   part=$1
+elif [ $# -gt 1 ]; then
+  echo "Error: too many arguments (expected at most 1, got $#)"
+  echo "Usage: $0 {major|minor|patch}"
+  exit 1
 else
-  echo "Select version bump type:"
-  echo "  1) patch"
-  echo "  2) minor"
-  echo "  3) major"
-  read -rp "Choice [1/2/3]: " choice
-  case $choice in
-    1) part="patch" ;;
-    2) part="minor" ;;
-    3) part="major" ;;
-    *) echo "Invalid choice: $choice"; exit 1 ;;
-  esac
+  if [ -t 0 ]; then
+    echo "Select version bump type:"
+    echo "  1) patch"
+    echo "  2) minor"
+    echo "  3) major"
+    read -rp "Choice [1/2/3]: " choice
+    case $choice in
+      1) part="patch" ;;
+      2) part="minor" ;;
+      3) part="major" ;;
+      *) echo "Invalid choice: $choice"; exit 1 ;;
+    esac
+  else
+    echo "Error: no argument provided and stdin is not a TTY (non-interactive). Usage: $0 {major|minor|patch}"
+    exit 1
+  fi
 fi
 
 # Get the absolute path of the script directory


### PR DESCRIPTION
# User description
## Summary
- Fix network spans HTTP 422 — OTLP `status.code` and `kind` must be `i32`, not string enum names
- Fix orphaned span leak in `startGlobalSpan` — pre-check registry before creating span
- Fix resume swizzle silent drop when `URLSessionInstrumentation` is deallocated
- Harden custom spans public API (see breaking changes below)

## Breaking changes (minor version bump)
- `CoralogixGlobalSpan.span` is now `internal`; use new `traceId` and `spanId` string properties instead
- `startGlobalSpan` / `startCustomSpan` labels now accept `[String: Any]` (was `[String: String]`)
- `CoralogixCustomSpan.setAttribute(key:value:AttributeValue?)` removed
- `TracesExporterCallback` is now `throws`; wrap your callback body in `do/catch` if needed

## Test plan
- [ ] All existing `CoralogixCustomSpansTests` pass
- [ ] New OTLP i32 regression tests pass (`testOtlpStatusCode_*`, `testOtlpKind_*`)
- [ ] New label merge tests pass (`testGlobalSpanLabels_mixedTypes_*`, `testLabelMerge_*`)
- [ ] Network spans reach backend without HTTP 422

Jira: [CX-39134](https://coralogix.atlassian.net/browse/CX-39134)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CX-39134]: https://coralogix.atlassian.net/browse/CX-39134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global spans now expose traceId/spanId and accept richer (mixed-type) labels.

* **Bug Fixes**
  * Prevents starting a new global span when one is already active.
  * Improved HTTP upload error handling and safer network resume behavior.

* **Improvements**
  * More diagnostic logging around trace export and exporter callbacks.
  * Warn when session metadata is missing.
  * OTLP serialization now emits numeric status/kind and omits extra OTLP fields.

* **Tests**
  * Expanded tests for mixed-type label merging and OTLP mappings.

* **Breaking Changes**
  * Removed a public span-attribute overload; label parameters now use mixed-type values.

* **Chores**
  * Version bumped to 2.6.0 across packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Rework the custom span entry points and helper serialization so mixed-type labels survive JSON conversion, global span registration races are avoided, and callers now expose safe <code>traceId</code>/<code>spanId</code> accessors instead of leaking the raw <code>Span</code>. Harden the OTLP export path (span model, exporter callbacks, uploader, URLSession instrumentation, and backend-visible metadata) to emit integer <code>status.code</code>/<code>kind</code>, log failures, and banish legacy snake_case mirrors while keeping release/test tooling aligned with the new 2.6.0 packages.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/188?tool=ast&topic=Other>Other</a>
        </td><td>Other files<details><summary>Modified files (2)</summary><ul><li>Tests/CoralogixRumTests/CxRumTests.swift</li>
<li>Tests/CoralogixRumTests/InteractionContextTests.swift</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/188?tool=ast&topic=Release+%26+QA+Automation>Release & QA Automation</a>
        </td><td>Advance release and QA plumbing by bumping the podspec versions (Coralogix, SessionReplay, CoralogixInternal) and runtime <code>Global.sdk</code> value to 2.6.0, expanding <code>.github/workflows/podspec-lint.yml</code> to cover all pushes/PRs with concurrency limits, making <code>version_bump.sh</code> interactive when invoked without arguments, and stabilizing the DemoApp schema validation UITest with retry logic for transient network errors.<details><summary>Modified files (8)</summary><ul><li>.github/workflows/podspec-lint.yml</li>
<li>Coralogix.podspec</li>
<li>CoralogixInternal.podspec</li>
<li>CoralogixInternal/Sources/Keys.swift</li>
<li>CoralogixInternal/Sources/Utils.swift</li>
<li>Example/DemoAppUITests/UserInteractionUITests.swift</li>
<li>SessionReplay.podspec</li>
<li>version_bump.sh</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/188?tool=ast&topic=Custom+Span+Surface>Custom Span Surface</a>
        </td><td>Guard the custom span API surface by adding <code>isGlobalSpanActive</code> pre-checks, richer label merging that tolerates <code>[String: Any]</code>, safer JSON encoding helpers, and new regression tests that prove mixed-type labels survive across SDK/global/child merges and non-string values don’t collapse the JSON payload; callers now see <code>traceId</code>/<code>spanId</code> strings while the raw span becomes internal.<details><summary>Modified files (4)</summary><ul><li>Coralogix/Sources/CoralogixCustomSpans.swift</li>
<li>Coralogix/Sources/Utils/Helper.swift</li>
<li>Tests/CoralogixRumTests/CoralogixCustomSpansTests.swift</li>
<li>Tests/CoralogixRumTests/HelperTests.swift</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/188?tool=ast&topic=OTLP+Export+Flow>OTLP Export Flow</a>
        </td><td>Ensure OTLP tracing exports stabilize by reissuing camelCase-only instrumentation data (integer <code>status.code</code> and proto <code>kind</code>), trimming obsolete OTLP mirrors, extending instrumentation helpers (network, error, mobile vitals, user actions) to use the new JSON encoder, expanding instrumentation data tests, and strengthening exporter resilience (logged callbacks, HTTP failure diagnostics, uploader logging) plus URLSession resume swizzling so telemetry still ships even when instrumentation objects deallocate.<details><summary>Modified files (11)</summary><ul><li>Coralogix/Sources/Exporter/CoralogixExporter.swift</li>
<li>Coralogix/Sources/Exporter/CoralogixTraceExporterData.swift</li>
<li>Coralogix/Sources/Exporter/SpanDataToOtlpConverter.swift</li>
<li>Coralogix/Sources/Exporter/SpanUploader.swift</li>
<li>Coralogix/Sources/Instrumentation/ErrorInstrumentation.swift</li>
<li>Coralogix/Sources/Instrumentation/MobileVitalsInstrumentation.swift</li>
<li>Coralogix/Sources/Instrumentation/NetworkInstrumentation.swift</li>
<li>Coralogix/Sources/Instrumentation/UserActionsInstrumentation.swift</li>
<li>Coralogix/Sources/Model/InstrumentationData.swift</li>
<li>Coralogix/Sources/Otel/URLSession/URLSessionInstrumentation.swift</li>
<li>Tests/CoralogixRumTests/InstrumentationDataTests.swift</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/coralogix/cx-ios-sdk/188?tool=ast>(Baz)</a>.