### PR TITLE
fix: prevent scroll freeze in Flutter — use afterScreenUpdates: false (v2.6.2)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -90,4 +90,4 @@ Events carry context structs from `Coralogix/Sources/Model/Contexts/` (e.g., `De
 
 ## Distribution
 
-Three podspecs must be published in order (`CoralogixInternal` → `SessionReplay` + `Coralogix`) with CDN propagation waits between steps. The `lint_and_push_cocoapods.sh` script handles this interactively. Version numbers must be kept in sync across `Package.swift`, all three `.podspec` files, and the `CoralogixRum` source constant.
+Three podspecs must be published in order (`CoralogixInternal` → `SessionReplay` + `Coralogix`) with CDN propagation waits between steps. The `lint_and_push_cocoapods.sh` script handles this interactively. Version numbers must be kept in sync across all three `.podspec` files and the `CoralogixRum` source constant (`Global.sdk` in `CoralogixInternal/Sources/Utils.swift`). `Package.swift` has no version string — SPM versioning is driven by git tags.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,93 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What This Is
+
+Coralogix RUM SDK for iOS — an OpenTelemetry-based Real User Monitoring SDK that auto-instruments iOS apps (network, errors, user actions, crashes, ANR, mobile vitals, session replay). Distributed via SPM and CocoaPods. Min iOS 13.0, Swift 5.9.
+
+## Build & Test Commands
+
+```bash
+# Build
+swift build
+
+# Run all tests
+swift test
+
+# Run tests via Xcode (matches CI)
+xcodebuild test -scheme Coralogix-Package -destination "platform=iOS Simulator,name=iPhone 16,OS=18.0"
+
+# Lint CocoaPods specs (order matters)
+pod lib lint CoralogixInternal.podspec
+pod lib lint SessionReplay.podspec --include-podspecs=CoralogixInternal.podspec
+pod lib lint Coralogix.podspec --include-podspecs=CoralogixInternal.podspec
+
+# Build xcframeworks for distribution
+./build.sh
+
+# Interactive CocoaPods publish (lint + trunk push)
+./lint_and_push_cocoapods.sh
+```
+
+CI runs on macOS 14 with Xcode 16.x. Three test targets: `CoralogixRumTests`, `CoralogixInternalTests`, `SessionReplayTests`.
+
+## Architecture
+
+### Three Targets
+
+| Target | Role |
+|--------|------|
+| `Coralogix/Sources/` | Main public SDK — all instrumentation, export, and public API |
+| `CoralogixInternal/Sources/` | Shared base library — `SdkManager` singleton, `Keys`, `Log`, utilities |
+| `SessionReplay/Sources/` | Optional screen recording module with privacy scanning pipeline |
+
+`CoralogixInternal` is a dependency of both `Coralogix` and `SessionReplay`. Both products register themselves with `SdkManager` on init so they can coordinate.
+
+### Core Flow
+
+1. **`CoralogixRum.init()`** — validates sample rate (exits early if not sampled), creates `CoralogixExporter`, `TracerProvider`, `BatchSpanProcessor`, then calls each `initialize*Instrumentation()` function based on the options passed.
+2. **Instrumentation modules** — each is an `extension` on `CoralogixRum` (files in `Instrumentation/`). They swizzle system methods or register observers to produce OTel spans.
+3. **`CoralogixExporter`** — implements OTel `SpanExporter`. Batches spans (50 spans / 2s), converts via `SpanDataToOtlpConverter`, applies the `beforeSend` callback, then PODs JSON to the Coralogix endpoint via `SpanUploader`.
+4. **`tracesExporter` callback** — optional secondary export hook; called with raw `Data` so consumers can forward spans to Jaeger/Zipkin/etc.
+
+### Key Classes
+
+- **`CoralogixRum`** — orchestrator; owns all instrumentation references and the `CoralogixExporter`
+- **`CoralogixExporterOptions`** — all SDK configuration; passed at init and stored on the exporter
+- **`SessionManager`** — session lifecycle, idle detection, session ID rotation
+- **`ViewManager`** — current view/screen name, used as RUM context on every span
+- **`NetworkManager`** — network reachability state (not HTTP requests)
+- **`MetricsManager`** — aggregates mobile vitals (FPS via `CADisplayLink`, CPU, memory)
+- **`CoralogixCustomGlobalSpanRegistry`** — global span context for custom spans (mirrors browser SDK's `window.__globalSpan__`)
+- **`SdkManager`** (singleton in `CoralogixInternal`) — registry shared by both products
+
+### Instrumentation Pattern
+
+Each instrumentation file is an `extension CoralogixRum` with a single `initialize*Instrumentation()` method. Network and user-action instrumentations store `currentInstance` and relevant options as **static properties** — this is intentional because swizzling happens once globally but the SDK can be re-initialized; statics ensure the live closures always reach the current options.
+
+### Span Attribute Keys
+
+All span attribute key strings live in `CoralogixInternal/Sources/Keys.swift`. When adding new attributes, define the key there.
+
+### Context Model
+
+Events carry context structs from `Coralogix/Sources/Model/Contexts/` (e.g., `DeviceContext`, `SessionContext`, `ErrorContext`, `InteractionContext`, `ViewContext`). Each context struct is encoded into span attributes by a corresponding builder in `Coralogix/Sources/Model/`.
+
+## Rules
+
+- **Never use `assert`, `precondition`, or `fatalError` in SDK code.** An SDK must never crash the host app. Use early returns or `Log.e(...)` instead. (Commit `7d59641` was entirely dedicated to removing these.)
+
+- **Swizzling tests must restore original implementations in `tearDown`.** Swizzled state leaks between tests if not cleaned up — this caused a full test-isolation fix in `7d59641`.
+
+- **Do not "fix" static properties on instrumentation classes.** `currentInstance`, `currentNetworkOptions`, etc. on `NetworkInstrumentation` and `UserActionsInstrumentation` are intentionally `static` — swizzling is global and these statics ensure SDK re-initialization reaches the current options.
+
+- **iOS 13.0 minimum — guard any newer APIs with `#available`.** Code compiles fine but crashes at runtime on iOS 13 without availability checks.
+
+- **All span attribute key strings belong in `CoralogixInternal/Sources/Keys.swift`.** No inline string literals for attribute keys anywhere else.
+
+- **Protect all shared mutable state with `NSLock` or a serial `DispatchQueue`.** Follow the existing pattern — don't introduce unguarded shared state.
+
+## Distribution
+
+Three podspecs must be published in order (`CoralogixInternal` → `SessionReplay` + `Coralogix`) with CDN propagation waits between steps. The `lint_and_push_cocoapods.sh` script handles this interactively. Version numbers must be kept in sync across `Package.swift`, all three `.podspec` files, and the `CoralogixRum` source constant.

--- a/.claude/commands/bump-version.md
+++ b/.claude/commands/bump-version.md
@@ -1,0 +1,7 @@
+Bump the SDK version using the existing script.
+
+1. Run: `./version_bump.sh $ARGUMENTS`
+   - Valid arguments: `patch`, `minor`, `major`
+   - If no argument was given, ask the user which one before running.
+2. Show the resulting `git diff` so the user can verify all files were updated.
+3. Do NOT commit. Wait for the user to confirm before doing anything else.

--- a/.claude/commands/fix-issues.md
+++ b/.claude/commands/fix-issues.md
@@ -1,0 +1,12 @@
+Fix the issues from the last PR review one at a time.
+
+For each issue:
+1. Show the current code and explain the fix.
+2. Apply the fix.
+3. Run the linter/analyzer to confirm it's clean.
+4. Stop and wait for the user to review before moving on or committing.
+
+Do NOT commit until the user explicitly says "commit" or "commit and next".
+Do NOT move to the next issue until the user approves the current fix.
+
+Start with the first unresolved **Issue**-level finding. Skip Suggestions and Nits unless the user asks for them.

--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -1,0 +1,30 @@
+You are an expert software engineer performing a code review on a feature branch.
+
+**Scope rules (very important):**
+- Review only the new or modified code introduced in this branch.
+- Do NOT comment on pre-existing code, even if it has issues, unless it was directly changed in this branch.
+- Ignore formatting or style issues in untouched code.
+- Assume the base branch code is correct and out of scope.
+
+**Your tasks:**
+1. Identify potential bugs, edge cases, or logical errors in the new code.
+2. Review readability, maintainability, and clarity of the new code.
+3. Flag security, performance, or concurrency concerns introduced by the changes.
+4. Suggest improvements only where the new code itself can be improved.
+
+**Guidelines:**
+- Be precise and reference specific lines or diff sections when possible.
+- If an issue exists in old code but is merely exposed (not modified) by this branch, do not comment on it.
+- If no issues are found, explicitly state that the new code looks good.
+- Do not suggest refactors that require changing old, untouched code.
+
+**Output format:**
+Use bullet points grouped by file. Clearly distinguish between **Issue**, **Suggestion**, and **Nit (optional)**.
+
+---
+
+Run the review now against the current branch diff:
+
+```bash
+git diff master...HEAD
+```

--- a/Coralogix.podspec
+++ b/Coralogix.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "Coralogix"
-  spec.version      = "2.6.1"
+  spec.version      = "2.6.2"
   spec.summary      = "Coralogix OpenTelemetry pod for iOS."
 
   spec.description  = <<-DESC
@@ -29,7 +29,7 @@ Pod::Spec.new do |spec|
 
   spec.static_framework = true
   spec.dependency 'PLCrashReporter', '~> 1.12'
-  spec.dependency 'CoralogixInternal', '2.6.1'
+  spec.dependency 'CoralogixInternal', '2.6.2'
 
   spec.test_spec 'Tests' do |test|
     test.source_files = 'Tests/CoralogixRumTests/**/*.swift'

--- a/CoralogixInternal.podspec
+++ b/CoralogixInternal.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "CoralogixInternal"
-  spec.version      = "2.6.1"
+  spec.version      = "2.6.2"
   spec.summary      = "Coralogix Internal Package. This module is not for public use."
 
   spec.description  = <<-DESC

--- a/CoralogixInternal/Sources/Extention/UIViewExt.swift
+++ b/CoralogixInternal/Sources/Extention/UIViewExt.swift
@@ -48,7 +48,7 @@ public extension UIView {
             for win in windows {
                 ctx.cgContext.saveGState()
                 ctx.cgContext.translateBy(x: win.frame.origin.x, y: win.frame.origin.y)
-                if !win.drawHierarchy(in: win.bounds, afterScreenUpdates: true) {
+                if !win.drawHierarchy(in: win.bounds, afterScreenUpdates: false) {
                     win.layer.render(in: ctx.cgContext)
                 }
                 ctx.cgContext.restoreGState()

--- a/CoralogixInternal/Sources/Utils.swift
+++ b/CoralogixInternal/Sources/Utils.swift
@@ -16,7 +16,7 @@ public enum ImageFormat {
 }
 
 public enum Global: String {
-    case sdk = "2.6.1"
+    case sdk = "2.6.2"
     case swiftVersion = "5.9"
     case coralogixPath = "/browser/v1beta/logs"
     case sessionReplayPath = "/browser/alpha/sessionrecording"

--- a/SessionReplay.podspec
+++ b/SessionReplay.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "SessionReplay"
-  spec.version      = "2.6.1"
+  spec.version      = "2.6.2"
   spec.summary      = "Coralogix Session-Replay pod for iOS."
 
   spec.description  = <<-DESC
@@ -23,7 +23,7 @@ Pod::Spec.new do |spec|
   spec.static_framework = true
 
   spec.source_files  = 'SessionReplay/Sources/**/*.swift'
-  spec.dependency 'CoralogixInternal', '2.6.1'
+  spec.dependency 'CoralogixInternal', '2.6.2'
   
     spec.test_spec 'Tests' do |test|
         test.source_files = 'Tests/SessionReplayTests/**/*.swift'


### PR DESCRIPTION
# User description
## Summary

- Fixes iOS scroll freeze reported by Flutter hybrid-mode customers during session recording
- `drawHierarchy(in:afterScreenUpdates:true)` was blocking the main thread 16–33 ms per capture, causing visible frame drops on scroll gesture events
- Switching to `afterScreenUpdates: false` captures the current framebuffer immediately with no stall; the screenshot may be one render cycle behind the interaction moment, which is imperceptible in recordings
- Bumps version to **2.6.2** across all three podspecs and the `Global.sdk` source constant
- Also adds `.claude/CLAUDE.md` and project-level custom commands for the team

## Root cause

Two code paths both fired a blocking `captureScreenshot` on the main thread for the same physical scroll gesture in Flutter mode:
1. Dart path via `setUserInteraction` → `captureSessionReplay` → `prepareScreenshotIfNeeded`
2. Native swizzle path via `cx_sendEvent` → `processInteractionEvent` → `captureSessionReplayEventIfNeeded`

Both ultimately called `drawHierarchy(in:afterScreenUpdates:true)`, which waits for UIKit to flush all pending render commands before returning.

## Test plan

- [ ] Build and run session recording in a Flutter hybrid app — scroll should be smooth with no frame drops
- [ ] Verify session replay screenshots still capture the correct screen state (one frame behind is acceptable)
- [ ] Run `xcodebuild test -scheme Coralogix-Package -destination "platform=iOS Simulator,name=iPhone 16,OS=18.0"`
- [ ] Pod lint: `pod lib lint CoralogixInternal.podspec`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Improve Flutter scroll smoothness by updating <code>UIViewExt</code> so <code>drawHierarchy(in:afterScreenUpdates:false)</code> captures frames without waiting on pending renders. Synchronize <code>Coralogix</code>, <code>SessionReplay</code>, and <code>CoralogixInternal</code> podspec versions with <code>Global.sdk</code> at <code>2.6.2</code> while documenting repo guidance and helper commands in <code>CLAUDE.md</code>.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/190?tool=ast&topic=Versioning+%26+Docs>Versioning & Docs</a>
        </td><td>Document repository automation in <code>CLAUDE.md</code> and custom command scripts while synchronizing all podspecs and <code>Global.sdk</code> with version <code>2.6.2</code> for the release.<details><summary>Modified files (8)</summary><ul><li>.claude/CLAUDE.md</li>
<li>.claude/commands/bump-version.md</li>
<li>.claude/commands/fix-issues.md</li>
<li>.claude/commands/pr-review.md</li>
<li>Coralogix.podspec</li>
<li>CoralogixInternal.podspec</li>
<li>CoralogixInternal/Sources/Utils.swift</li>
<li>SessionReplay.podspec</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/190?tool=ast&topic=Session+Replay+Capture>Session Replay Capture</a>
        </td><td>Ensure session replay capture uses <code>drawHierarchy(in:afterScreenUpdates:false)</code> in <code>UIViewExt</code> so screenshot grabs happen immediately without blocking the main thread and Flutter scroll gestures stay smooth.<details><summary>Modified files (1)</summary><ul><li>CoralogixInternal/Sources/Extention/UIViewExt.swift</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>ALPH-22252 masking bri...</td><td>December 03, 2025</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/coralogix/cx-ios-sdk/190?tool=ast>(Baz)</a>.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted screenshot capture rendering behavior.

* **Chores**
  * Bumped SDK version to 2.6.2 across all iOS pods with synchronized dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->