### PR TITLE
feat: SwiftUI swipe detection + DemoAppSwiftUI full UI rebuild (CX-33282)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ tech-debt/
 
 # Jira MCP local install (not part of iOS SDK; keep local only)
 package/
+
+# CocoaPods (example app dependencies)
+Example/Pods/
+Example/Podfile.lock

--- a/Coralogix/Sources/Actions/SwiftUI/SwiftUIActionModifier.swift
+++ b/Coralogix/Sources/Actions/SwiftUI/SwiftUIActionModifier.swift
@@ -113,6 +113,7 @@ private final class SwipeDetectorGestureRecognizer: UIPanGestureRecognizer {
 @available(iOS 13, *)
 struct SwipeDetectorView: UIViewRepresentable {
 
+    @available(iOS 13, *)
     class Coordinator: NSObject {
         @objc func handlePan(_ gesture: UIPanGestureRecognizer) {
             guard gesture.state == .ended, let view = gesture.view else { return }

--- a/Coralogix/Sources/Actions/SwiftUI/SwiftUIActionModifier.swift
+++ b/Coralogix/Sources/Actions/SwiftUI/SwiftUIActionModifier.swift
@@ -128,7 +128,12 @@ private final class SwipeDetectorGestureRecognizer: UIPanGestureRecognizer {
 struct SwipeDetectorView: UIViewRepresentable {
 
     @available(iOS 13, *)
-    class Coordinator: NSObject {
+    class Coordinator: NSObject, UIGestureRecognizerDelegate {
+        func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer,
+                               shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+            return true
+        }
+
         @objc func handlePan(_ gesture: UIPanGestureRecognizer) {
             guard gesture.state == .ended, let view = gesture.view else { return }
             let loc = gesture.location(in: nil)
@@ -152,6 +157,9 @@ struct SwipeDetectorView: UIViewRepresentable {
         )
         pan.minimumNumberOfTouches = 1
         pan.maximumNumberOfTouches = 1
+        pan.cancelsTouchesInView = false
+        pan.delaysTouchesEnded = false
+        pan.delegate = context.coordinator
         view.addGestureRecognizer(pan)
         return view
     }

--- a/Coralogix/Sources/Actions/SwiftUI/SwiftUIActionModifier.swift
+++ b/Coralogix/Sources/Actions/SwiftUI/SwiftUIActionModifier.swift
@@ -9,6 +9,9 @@ import CoralogixInternal
 #if canImport(SwiftUI)
 import SwiftUI
 #endif
+#if canImport(UIKit)
+import UIKit
+#endif
 
 @available(iOS 13, *)
 internal struct CXTapModifier: SwiftUI.ViewModifier {
@@ -87,4 +90,72 @@ struct TapView: UIViewRepresentable {
     }
 
     func updateUIView(_ uiView: UIView, context: Context) {}
+}
+
+// MARK: - SwiftUI Swipe Detection
+
+/// Subclass of UIPanGestureRecognizer that calls ScrollTracker.discardTouch when the
+/// gesture is recognized, preventing cx_sendEvent's processEnded from also emitting a
+/// redundant .scroll span for the same gesture.
+/// Only discards when state == .ended (recognized) — taps and micro-drags that fail to
+/// recognize (state == .failed) do not discard, so their click events still fire.
+@available(iOS 13, *)
+private final class SwipeDetectorGestureRecognizer: UIPanGestureRecognizer {
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent) {
+        super.touchesEnded(touches, with: event)
+        if state == .ended {
+            touches.forEach { ScrollTracker.shared.discardTouch($0) }
+        }
+    }
+}
+
+/// Transparent overlay UIView that attaches a SwipeDetectorGestureRecognizer to detect
+/// single-finger swipes. On gesture end, posts a TouchEvent(.swipe) notification which
+/// UserActionsInstrumentation converts into a user-interaction span.
+@available(iOS 13, *)
+struct SwipeDetectorView: UIViewRepresentable {
+
+    class Coordinator: NSObject {
+        @objc func handlePan(_ gesture: UIPanGestureRecognizer) {
+            guard gesture.state == .ended, let view = gesture.view else { return }
+            let loc = gesture.location(in: nil)
+            let translation = gesture.translation(in: nil)
+            let start = CGPoint(x: loc.x - translation.x, y: loc.y - translation.y)
+            guard let dir = ScrollTracker.direction(from: start, to: loc) else { return }
+            NotificationCenter.default.post(
+                name: .cxRumNotificationUserActions,
+                object: TouchEvent(view: view, location: loc, eventType: .swipe, scrollDirection: dir)
+            )
+        }
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
+
+    func makeUIView(context: Context) -> UIView {
+        let view = UIView()
+        let pan = SwipeDetectorGestureRecognizer(
+            target: context.coordinator,
+            action: #selector(Coordinator.handlePan)
+        )
+        pan.minimumNumberOfTouches = 1
+        pan.maximumNumberOfTouches = 1
+        view.addGestureRecognizer(pan)
+        return view
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {}
+}
+
+@available(iOS 13, *)
+internal struct CXSwipeModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        content.overlay(SwipeDetectorView())
+    }
+}
+
+@available(iOS 13, *)
+public extension SwiftUI.View {
+    func trackCXSwipeAction() -> some View {
+        modifier(CXSwipeModifier())
+    }
 }

--- a/Coralogix/Sources/Actions/SwiftUI/SwiftUIActionModifier.swift
+++ b/Coralogix/Sources/Actions/SwiftUI/SwiftUIActionModifier.swift
@@ -97,13 +97,27 @@ struct TapView: UIViewRepresentable {
 /// redundant .scroll span for the same gesture.
 /// Only discards when state == .ended (recognized) — taps and micro-drags that fail to
 /// recognize (state == .failed) do not discard, so their click events still fire.
+/// Skips discarding when the gesture's view is nested inside a UIScrollView: in that
+/// context the underlying scroll view's own pan gesture is legitimate and its scroll
+/// span must not be suppressed.
 @available(iOS 13, *)
 private final class SwipeDetectorGestureRecognizer: UIPanGestureRecognizer {
     override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent) {
         super.touchesEnded(touches, with: event)
-        if state == .ended {
+        if state == .ended && !isInScrollViewContext() {
             touches.forEach { ScrollTracker.shared.discardTouch($0) }
         }
+    }
+
+    /// Returns true if any ancestor of the gesture's view in the responder chain is a
+    /// UIScrollView (covers UITableView, UICollectionView, SwiftUI List/ScrollView, etc.).
+    private func isInScrollViewContext() -> Bool {
+        var ancestor = view?.superview
+        while let v = ancestor {
+            if v is UIScrollView { return true }
+            ancestor = v.superview
+        }
+        return false
     }
 }
 

--- a/Coralogix/Sources/Actions/SwiftUI/SwiftUIActionModifier.swift
+++ b/Coralogix/Sources/Actions/SwiftUI/SwiftUIActionModifier.swift
@@ -6,11 +6,9 @@
 //
 
 import CoralogixInternal
+import UIKit
 #if canImport(SwiftUI)
 import SwiftUI
-#endif
-#if canImport(UIKit)
-import UIKit
 #endif
 
 @available(iOS 13, *)

--- a/Example/DemoApp.xcodeproj/project.pbxproj
+++ b/Example/DemoApp.xcodeproj/project.pbxproj
@@ -75,6 +75,7 @@
 		E6D4BBF92DE336310096B46D /* CoralogixRumManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D4BBF62DE336310096B46D /* CoralogixRumManager.swift */; };
 		E6E515FE2EBB8644008EC19A /* MaskViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6E515FD2EBB8644008EC19A /* MaskViewController.swift */; };
 		E6E516002EBC957D008EC19A /* MaskViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6E515FF2EBC957D008EC19A /* MaskViewController.swift */; };
+		E6CF001B2BFDEB8C00000001 /* DemoRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6CF000B2BFDEB8C00000001 /* DemoRow.swift */; };
 		E6CF00112BFDEB8C00000001 /* Toast.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6CF00012BFDEB8C00000001 /* Toast.swift */; };
 		E6CF00122BFDEB8C00000001 /* NetworkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6CF00022BFDEB8C00000001 /* NetworkView.swift */; };
 		E6CF00132BFDEB8C00000001 /* ErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6CF00032BFDEB8C00000001 /* ErrorView.swift */; };
@@ -179,6 +180,7 @@
 		E6D4BBF62DE336310096B46D /* CoralogixRumManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoralogixRumManager.swift; sourceTree = "<group>"; };
 		E6E515FD2EBB8644008EC19A /* MaskViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaskViewController.swift; sourceTree = "<group>"; };
 		E6E515FF2EBC957D008EC19A /* MaskViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaskViewController.swift; sourceTree = "<group>"; };
+		E6CF000B2BFDEB8C00000001 /* DemoRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoRow.swift; sourceTree = "<group>"; };
 		E6CF00012BFDEB8C00000001 /* Toast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Toast.swift; sourceTree = "<group>"; };
 		E6CF00022BFDEB8C00000001 /* NetworkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkView.swift; sourceTree = "<group>"; };
 		E6CF00032BFDEB8C00000001 /* ErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorView.swift; sourceTree = "<group>"; };
@@ -253,6 +255,7 @@
 				E622115A2BFDEB8B00052682 /* DemoAppSwiftUIApp.swift */,
 				E6E515FF2EBC957D008EC19A /* MaskViewController.swift */,
 				E622115C2BFDEB8B00052682 /* ContentView.swift */,
+				E6CF000B2BFDEB8C00000001 /* DemoRow.swift */,
 				E6CF00012BFDEB8C00000001 /* Toast.swift */,
 				E6CF00022BFDEB8C00000001 /* NetworkView.swift */,
 				E6CF00032BFDEB8C00000001 /* ErrorView.swift */,
@@ -629,6 +632,7 @@
 				E622115D2BFDEB8B00052682 /* ContentView.swift in Sources */,
 				E6E516002EBC957D008EC19A /* MaskViewController.swift in Sources */,
 				E622115B2BFDEB8B00052682 /* DemoAppSwiftUIApp.swift in Sources */,
+				E6CF001B2BFDEB8C00000001 /* DemoRow.swift in Sources */,
 				E6CF00112BFDEB8C00000001 /* Toast.swift in Sources */,
 				E6CF00122BFDEB8C00000001 /* NetworkView.swift in Sources */,
 				E6CF00132BFDEB8C00000001 /* ErrorView.swift in Sources */,

--- a/Example/DemoApp.xcodeproj/project.pbxproj
+++ b/Example/DemoApp.xcodeproj/project.pbxproj
@@ -22,6 +22,9 @@
 		E64ABB282F3C5CFA00D990A9 /* AFNetworking in Frameworks */ = {isa = PBXBuildFile; productRef = E64ABB272F3C5CFA00D990A9 /* AFNetworking */; };
 		E64ABB2B2F3C5ECB00D990A9 /* SDWebImage in Frameworks */ = {isa = PBXBuildFile; productRef = E64ABB2A2F3C5ECB00D990A9 /* SDWebImage */; };
 		E64ABB2E2F3C5F0300D990A9 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = E64ABB2D2F3C5F0300D990A9 /* Alamofire */; };
+		E64ABB312F3C5CFA00D990B9 /* AFNetworking in Frameworks */ = {isa = PBXBuildFile; productRef = E64ABB302F3C5CFA00D990B9 /* AFNetworking */; };
+		E64ABB332F3C5ECB00D990B9 /* SDWebImage in Frameworks */ = {isa = PBXBuildFile; productRef = E64ABB322F3C5ECB00D990B9 /* SDWebImage */; };
+		E64ABB352F3C5F0300D990B9 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = E64ABB342F3C5F0300D990B9 /* Alamofire */; };
 		E6525B5B2E38BE3C006DB4AA /* envs.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6525B5A2E38BE3A006DB4AA /* envs.swift */; };
 		E6525B602E38C548006DB4AA /* envs.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6525B5A2E38BE3A006DB4AA /* envs.swift */; };
 		E6525B612E38C548006DB4AA /* envs.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6525B5A2E38BE3A006DB4AA /* envs.swift */; };
@@ -191,6 +194,9 @@
 			files = (
 				E66E3B6C2DA7FB6400FBC86B /* Coralogix in Frameworks */,
 				E6B60A022DB4E53F003AD35D /* SessionReplay in Frameworks */,
+				E64ABB312F3C5CFA00D990B9 /* AFNetworking in Frameworks */,
+				E64ABB332F3C5ECB00D990B9 /* SDWebImage in Frameworks */,
+				E64ABB352F3C5F0300D990B9 /* Alamofire in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -390,6 +396,9 @@
 			packageProductDependencies = (
 				E66E3B6B2DA7FB6400FBC86B /* Coralogix */,
 				E6B60A012DB4E53F003AD35D /* SessionReplay */,
+				E64ABB302F3C5CFA00D990B9 /* AFNetworking */,
+				E64ABB322F3C5ECB00D990B9 /* SDWebImage */,
+				E64ABB342F3C5F0300D990B9 /* Alamofire */,
 			);
 			productName = DemoAppSwiftUI;
 			productReference = E62211582BFDEB8B00052682 /* DemoAppSwiftUI.app */;
@@ -1129,6 +1138,21 @@
 			productName = SDWebImage;
 		};
 		E64ABB2D2F3C5F0300D990A9 /* Alamofire */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E64ABB2C2F3C5F0300D990A9 /* XCRemoteSwiftPackageReference "Alamofire" */;
+			productName = Alamofire;
+		};
+		E64ABB302F3C5CFA00D990B9 /* AFNetworking */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E64ABB262F3C5CFA00D990A9 /* XCRemoteSwiftPackageReference "AFNetworking" */;
+			productName = AFNetworking;
+		};
+		E64ABB322F3C5ECB00D990B9 /* SDWebImage */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E64ABB292F3C5ECB00D990A9 /* XCRemoteSwiftPackageReference "SDWebImage" */;
+			productName = SDWebImage;
+		};
+		E64ABB342F3C5F0300D990B9 /* Alamofire */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = E64ABB2C2F3C5F0300D990A9 /* XCRemoteSwiftPackageReference "Alamofire" */;
 			productName = Alamofire;

--- a/Example/DemoApp.xcodeproj/project.pbxproj
+++ b/Example/DemoApp.xcodeproj/project.pbxproj
@@ -75,6 +75,16 @@
 		E6D4BBF92DE336310096B46D /* CoralogixRumManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D4BBF62DE336310096B46D /* CoralogixRumManager.swift */; };
 		E6E515FE2EBB8644008EC19A /* MaskViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6E515FD2EBB8644008EC19A /* MaskViewController.swift */; };
 		E6E516002EBC957D008EC19A /* MaskViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6E515FF2EBC957D008EC19A /* MaskViewController.swift */; };
+		E6CF00112BFDEB8C00000001 /* Toast.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6CF00012BFDEB8C00000001 /* Toast.swift */; };
+		E6CF00122BFDEB8C00000001 /* NetworkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6CF00022BFDEB8C00000001 /* NetworkView.swift */; };
+		E6CF00132BFDEB8C00000001 /* ErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6CF00032BFDEB8C00000001 /* ErrorView.swift */; };
+		E6CF00142BFDEB8C00000001 /* SdkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6CF00042BFDEB8C00000001 /* SdkView.swift */; };
+		E6CF00152BFDEB8C00000001 /* CustomSpansView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6CF00052BFDEB8C00000001 /* CustomSpansView.swift */; };
+		E6CF00162BFDEB8C00000001 /* UserActionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6CF00062BFDEB8C00000001 /* UserActionsView.swift */; };
+		E6CF00172BFDEB8C00000001 /* SessionReplayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6CF00072BFDEB8C00000001 /* SessionReplayView.swift */; };
+		E6CF00182BFDEB8C00000001 /* ClockView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6CF00082BFDEB8C00000001 /* ClockView.swift */; };
+		E6CF00192BFDEB8C00000001 /* SchemaValidationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6CF00092BFDEB8C00000001 /* SchemaValidationView.swift */; };
+		E6CF001A2BFDEB8C00000001 /* TracesExporterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6CF000A2BFDEB8C00000001 /* TracesExporterView.swift */; };
 		E6FD68F82D01D5570066BDE8 /* CreditCardInputCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6FD68F72D01D5570066BDE8 /* CreditCardInputCell.swift */; };
 		E6FDDA2D2DF176DC0005F274 /* ClockViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6FDDA2C2DF176DC0005F274 /* ClockViewController.swift */; };
 		E6FDDA2E2DF176DC0005F275 /* SchemaValidationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6FDDA312DF176DC0005F275 /* SchemaValidationViewController.swift */; };
@@ -169,6 +179,16 @@
 		E6D4BBF62DE336310096B46D /* CoralogixRumManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoralogixRumManager.swift; sourceTree = "<group>"; };
 		E6E515FD2EBB8644008EC19A /* MaskViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaskViewController.swift; sourceTree = "<group>"; };
 		E6E515FF2EBC957D008EC19A /* MaskViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaskViewController.swift; sourceTree = "<group>"; };
+		E6CF00012BFDEB8C00000001 /* Toast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Toast.swift; sourceTree = "<group>"; };
+		E6CF00022BFDEB8C00000001 /* NetworkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkView.swift; sourceTree = "<group>"; };
+		E6CF00032BFDEB8C00000001 /* ErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorView.swift; sourceTree = "<group>"; };
+		E6CF00042BFDEB8C00000001 /* SdkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SdkView.swift; sourceTree = "<group>"; };
+		E6CF00052BFDEB8C00000001 /* CustomSpansView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomSpansView.swift; sourceTree = "<group>"; };
+		E6CF00062BFDEB8C00000001 /* UserActionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserActionsView.swift; sourceTree = "<group>"; };
+		E6CF00072BFDEB8C00000001 /* SessionReplayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionReplayView.swift; sourceTree = "<group>"; };
+		E6CF00082BFDEB8C00000001 /* ClockView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClockView.swift; sourceTree = "<group>"; };
+		E6CF00092BFDEB8C00000001 /* SchemaValidationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaValidationView.swift; sourceTree = "<group>"; };
+		E6CF000A2BFDEB8C00000001 /* TracesExporterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracesExporterView.swift; sourceTree = "<group>"; };
 		E6FD68F72D01D5570066BDE8 /* CreditCardInputCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreditCardInputCell.swift; sourceTree = "<group>"; };
 		E6FDDA2C2DF176DC0005F274 /* ClockViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClockViewController.swift; sourceTree = "<group>"; };
 		E6FDDA312DF176DC0005F275 /* SchemaValidationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaValidationViewController.swift; sourceTree = "<group>"; };
@@ -233,6 +253,16 @@
 				E622115A2BFDEB8B00052682 /* DemoAppSwiftUIApp.swift */,
 				E6E515FF2EBC957D008EC19A /* MaskViewController.swift */,
 				E622115C2BFDEB8B00052682 /* ContentView.swift */,
+				E6CF00012BFDEB8C00000001 /* Toast.swift */,
+				E6CF00022BFDEB8C00000001 /* NetworkView.swift */,
+				E6CF00032BFDEB8C00000001 /* ErrorView.swift */,
+				E6CF00042BFDEB8C00000001 /* SdkView.swift */,
+				E6CF00052BFDEB8C00000001 /* CustomSpansView.swift */,
+				E6CF00062BFDEB8C00000001 /* UserActionsView.swift */,
+				E6CF00072BFDEB8C00000001 /* SessionReplayView.swift */,
+				E6CF00082BFDEB8C00000001 /* ClockView.swift */,
+				E6CF00092BFDEB8C00000001 /* SchemaValidationView.swift */,
+				E6CF000A2BFDEB8C00000001 /* TracesExporterView.swift */,
 				E622115E2BFDEB8C00052682 /* Assets.xcassets */,
 				E62211602BFDEB8C00052682 /* Preview Content */,
 			);
@@ -599,6 +629,16 @@
 				E622115D2BFDEB8B00052682 /* ContentView.swift in Sources */,
 				E6E516002EBC957D008EC19A /* MaskViewController.swift in Sources */,
 				E622115B2BFDEB8B00052682 /* DemoAppSwiftUIApp.swift in Sources */,
+				E6CF00112BFDEB8C00000001 /* Toast.swift in Sources */,
+				E6CF00122BFDEB8C00000001 /* NetworkView.swift in Sources */,
+				E6CF00132BFDEB8C00000001 /* ErrorView.swift in Sources */,
+				E6CF00142BFDEB8C00000001 /* SdkView.swift in Sources */,
+				E6CF00152BFDEB8C00000001 /* CustomSpansView.swift in Sources */,
+				E6CF00162BFDEB8C00000001 /* UserActionsView.swift in Sources */,
+				E6CF00172BFDEB8C00000001 /* SessionReplayView.swift in Sources */,
+				E6CF00182BFDEB8C00000001 /* ClockView.swift in Sources */,
+				E6CF00192BFDEB8C00000001 /* SchemaValidationView.swift in Sources */,
+				E6CF001A2BFDEB8C00000001 /* TracesExporterView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/DemoApp.xcodeproj/project.pbxproj
+++ b/Example/DemoApp.xcodeproj/project.pbxproj
@@ -75,6 +75,8 @@
 		E6D4BBF92DE336310096B46D /* CoralogixRumManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D4BBF62DE336310096B46D /* CoralogixRumManager.swift */; };
 		E6E515FE2EBB8644008EC19A /* MaskViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6E515FD2EBB8644008EC19A /* MaskViewController.swift */; };
 		E6E516002EBC957D008EC19A /* MaskViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6E515FF2EBC957D008EC19A /* MaskViewController.swift */; };
+		E6CF001C2BFDEB8C00000001 /* ActionItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6CF000C2BFDEB8C00000001 /* ActionItem.swift */; };
+		E6CF001D2BFDEB8C00000001 /* ActionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6CF000D2BFDEB8C00000001 /* ActionListView.swift */; };
 		E6CF001B2BFDEB8C00000001 /* DemoRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6CF000B2BFDEB8C00000001 /* DemoRow.swift */; };
 		E6CF00112BFDEB8C00000001 /* Toast.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6CF00012BFDEB8C00000001 /* Toast.swift */; };
 		E6CF00122BFDEB8C00000001 /* NetworkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6CF00022BFDEB8C00000001 /* NetworkView.swift */; };
@@ -180,6 +182,8 @@
 		E6D4BBF62DE336310096B46D /* CoralogixRumManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoralogixRumManager.swift; sourceTree = "<group>"; };
 		E6E515FD2EBB8644008EC19A /* MaskViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaskViewController.swift; sourceTree = "<group>"; };
 		E6E515FF2EBC957D008EC19A /* MaskViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaskViewController.swift; sourceTree = "<group>"; };
+		E6CF000C2BFDEB8C00000001 /* ActionItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionItem.swift; sourceTree = "<group>"; };
+		E6CF000D2BFDEB8C00000001 /* ActionListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionListView.swift; sourceTree = "<group>"; };
 		E6CF000B2BFDEB8C00000001 /* DemoRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoRow.swift; sourceTree = "<group>"; };
 		E6CF00012BFDEB8C00000001 /* Toast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Toast.swift; sourceTree = "<group>"; };
 		E6CF00022BFDEB8C00000001 /* NetworkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkView.swift; sourceTree = "<group>"; };
@@ -255,6 +259,8 @@
 				E622115A2BFDEB8B00052682 /* DemoAppSwiftUIApp.swift */,
 				E6E515FF2EBC957D008EC19A /* MaskViewController.swift */,
 				E622115C2BFDEB8B00052682 /* ContentView.swift */,
+				E6CF000C2BFDEB8C00000001 /* ActionItem.swift */,
+				E6CF000D2BFDEB8C00000001 /* ActionListView.swift */,
 				E6CF000B2BFDEB8C00000001 /* DemoRow.swift */,
 				E6CF00012BFDEB8C00000001 /* Toast.swift */,
 				E6CF00022BFDEB8C00000001 /* NetworkView.swift */,
@@ -632,6 +638,8 @@
 				E622115D2BFDEB8B00052682 /* ContentView.swift in Sources */,
 				E6E516002EBC957D008EC19A /* MaskViewController.swift in Sources */,
 				E622115B2BFDEB8B00052682 /* DemoAppSwiftUIApp.swift in Sources */,
+				E6CF001C2BFDEB8C00000001 /* ActionItem.swift in Sources */,
+				E6CF001D2BFDEB8C00000001 /* ActionListView.swift in Sources */,
 				E6CF001B2BFDEB8C00000001 /* DemoRow.swift in Sources */,
 				E6CF00112BFDEB8C00000001 /* Toast.swift in Sources */,
 				E6CF00122BFDEB8C00000001 /* NetworkView.swift in Sources */,

--- a/Example/DemoAppSwiftUI/ActionItem.swift
+++ b/Example/DemoAppSwiftUI/ActionItem.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+struct ActionItem {
+    let title: String
+    let subtitle: String
+    let icon: String
+    let action: () -> Void
+}

--- a/Example/DemoAppSwiftUI/ActionListView.swift
+++ b/Example/DemoAppSwiftUI/ActionListView.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+import Coralogix
+
+struct ActionListView: View {
+    let title: String
+    let cxViewName: String
+    let items: [ActionItem]
+    var titleDisplayMode: NavigationBarItem.TitleDisplayMode = .large
+
+    @State private var toastMessage: String?
+
+    var body: some View {
+        List {
+            ForEach(items, id: \.title) { item in
+                Button {
+                    toastMessage = "Selected: \(item.title)"
+                    item.action()
+                } label: {
+                    DemoRow(icon: item.icon, title: item.title, subtitle: item.subtitle)
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+        .navigationTitle(title)
+        .navigationBarTitleDisplayMode(titleDisplayMode)
+        .trackCXView(name: cxViewName)
+        .toast(message: $toastMessage)
+    }
+}

--- a/Example/DemoAppSwiftUI/ClockView.swift
+++ b/Example/DemoAppSwiftUI/ClockView.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+struct ClockView: View {
+    @State private var timeString = ""
+    private let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
+
+    var body: some View {
+        VStack {
+            Spacer()
+            Text(timeString)
+                .font(.system(size: 40, weight: .medium, design: .monospaced))
+            Spacer()
+        }
+        .frame(maxWidth: .infinity)
+        .background(Color(.systemBackground))
+        .navigationTitle("Clock")
+        .navigationBarTitleDisplayMode(.inline)
+        .trackCXView(name: "Clock")
+        .onAppear { updateTime() }
+        .onReceive(timer) { _ in updateTime() }
+    }
+
+    private func updateTime() {
+        let formatter = DateFormatter()
+        formatter.timeStyle = .medium
+        timeString = formatter.string(from: Date())
+    }
+}

--- a/Example/DemoAppSwiftUI/ContentView.swift
+++ b/Example/DemoAppSwiftUI/ContentView.swift
@@ -128,7 +128,7 @@ struct ContentView: View {
         .toast(message: $toastMessage)
     }
 
-    @ViewBuilder
+    @SwiftUI.ViewBuilder
     private var sessionHeader: some View {
         Section {
             HStack {

--- a/Example/DemoAppSwiftUI/ContentView.swift
+++ b/Example/DemoAppSwiftUI/ContentView.swift
@@ -115,6 +115,7 @@ struct ContentView: View {
             }
             .trackCXView(name: "Main View")
             .onAppear {
+                sessionID = CoralogixRumManager.shared.getSessionId()?.lowercased() ?? "No session"
                 CoralogixRumManager.shared.sdk.setUserContext(
                     userContext: UserContext(
                         userId: "1234",
@@ -154,7 +155,8 @@ struct ContentView: View {
             toastMessage = "No session ID available"
             return
         }
-        UIPasteboard.general.string = id
+        sessionID = id.lowercased()
+        UIPasteboard.general.string = sessionID
         toastMessage = "Session ID copied"
     }
 }

--- a/Example/DemoAppSwiftUI/ContentView.swift
+++ b/Example/DemoAppSwiftUI/ContentView.swift
@@ -82,8 +82,6 @@ struct ContentView: View {
             List {
                 sessionHeader
 
-                swipeDemo
-
                 ForEach(menuItems, id: \.title) { item in
                     NavigationLink(destination: item.destination) {
                         Label {
@@ -148,24 +146,6 @@ struct ContentView: View {
                 }
             }
             .padding(.vertical, 2)
-        }
-    }
-
-    private var swipeDemo: some View {
-        Section("Swipe Demo") {
-            VStack(spacing: 6) {
-                Image(systemName: "antenna.radiowaves.left.and.right")
-                    .font(.system(size: 36, weight: .medium))
-                    .foregroundColor(.accentColor)
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 12)
-                    .trackCXSwipeAction()
-                Text("Swipe the icon to emit a RUM swipe span")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                    .frame(maxWidth: .infinity)
-                    .padding(.bottom, 8)
-            }
         }
     }
 

--- a/Example/DemoAppSwiftUI/ContentView.swift
+++ b/Example/DemoAppSwiftUI/ContentView.swift
@@ -82,6 +82,8 @@ struct ContentView: View {
             List {
                 sessionHeader
 
+                swipeDemo
+
                 ForEach(menuItems, id: \.title) { item in
                     NavigationLink(destination: item.destination) {
                         Label {
@@ -131,19 +133,6 @@ struct ContentView: View {
     @SwiftUI.ViewBuilder
     private var sessionHeader: some View {
         Section {
-            VStack(spacing: 8) {
-                Image(systemName: "antenna.radiowaves.left.and.right")
-                    .font(.system(size: 32, weight: .medium))
-                    .foregroundColor(.accentColor)
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 8)
-                    .trackCXSwipeAction()
-                Text("Swipe the icon above to test swipe tracking")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                    .frame(maxWidth: .infinity)
-            }
-
             HStack {
                 VStack(alignment: .leading, spacing: 4) {
                     Text("Session ID")
@@ -159,6 +148,24 @@ struct ContentView: View {
                 }
             }
             .padding(.vertical, 2)
+        }
+    }
+
+    private var swipeDemo: some View {
+        Section("Swipe Demo") {
+            VStack(spacing: 6) {
+                Image(systemName: "antenna.radiowaves.left.and.right")
+                    .font(.system(size: 36, weight: .medium))
+                    .foregroundColor(.accentColor)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 12)
+                    .trackCXSwipeAction()
+                Text("Swipe the icon to emit a RUM swipe span")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .frame(maxWidth: .infinity)
+                    .padding(.bottom, 8)
+            }
         }
     }
 

--- a/Example/DemoAppSwiftUI/ContentView.swift
+++ b/Example/DemoAppSwiftUI/ContentView.swift
@@ -1,123 +1,160 @@
-//
-//  ContentView.swift
-//  DemoApp
-//
-//  Created by Coralogix DEV TEAM on 05/05/2024.
-//
-
 import SwiftUI
 import Coralogix
 
 struct ContentView: View {
-    @Binding var coralogixRum: CoralogixRum
-    let items = [Keys.failureNetworkRequest.rawValue,
-                 Keys.succesfullNetworkRequest.rawValue,
-                 Keys.succesfullNetworkRequestFlutter.rawValue,
-                 Keys.failureNetworkRequestFlutter.rawValue,
-                 Keys.sendNSException.rawValue,
-                 Keys.sendNSError.rawValue,
-                 Keys.sendErrorString.rawValue,
-                 Keys.sendLogWithData.rawValue,
-                 Keys.sendCrash.rawValue,
-                 Keys.shutDownCoralogixRum.rawValue,
-                 Keys.updateLabels.rawValue,
-                 Keys.maskUI.rawValue]
-    
+    @State private var toastMessage: String?
+    @State private var sessionID: String = CoralogixRumManager.shared.getSessionId()?.lowercased() ?? "No session"
+
+    private struct MenuItem {
+        let title: String
+        let subtitle: String
+        let icon: String
+        let destination: AnyView
+    }
+
+    private var menuItems: [MenuItem] {
+        [
+            MenuItem(
+                title: "Network instrumentation",
+                subtitle: "Track requests, responses & timings",
+                icon: "antenna.radiowaves.left.and.right",
+                destination: AnyView(NetworkView())
+            ),
+            MenuItem(
+                title: "Error instrumentation",
+                subtitle: "Capture crashes, errors & exceptions",
+                icon: "exclamationmark.triangle",
+                destination: AnyView(ErrorView())
+            ),
+            MenuItem(
+                title: "SDK functions",
+                subtitle: "Test core Coralogix APIs",
+                icon: "gearshape",
+                destination: AnyView(SdkView())
+            ),
+            MenuItem(
+                title: "Custom spans",
+                subtitle: "Manual global & nested spans (Browser API parity)",
+                icon: "timeline.selection",
+                destination: AnyView(CustomSpansView())
+            ),
+            MenuItem(
+                title: "User actions",
+                subtitle: "Buttons, screens & custom events",
+                icon: "hand.tap",
+                destination: AnyView(UserActionsView())
+            ),
+            MenuItem(
+                title: "Session replay",
+                subtitle: "Replay user sessions visually",
+                icon: "film.stack",
+                destination: AnyView(SessionReplayView())
+            ),
+            MenuItem(
+                title: "Clock",
+                subtitle: "Timing, spans & scheduling",
+                icon: "clock",
+                destination: AnyView(ClockView())
+            ),
+            MenuItem(
+                title: "Schema validation",
+                subtitle: "Validate payload structure & fields",
+                icon: "checkmark.shield",
+                destination: AnyView(SchemaValidationView())
+            ),
+            MenuItem(
+                title: "Mask UI",
+                subtitle: "Hide sensitive on-screen data",
+                icon: "eye.slash",
+                destination: AnyView(MaskDemoView())
+            ),
+            MenuItem(
+                title: "Traces Exporter",
+                subtitle: "Test OTLP trace export callback",
+                icon: "arrow.up.doc",
+                destination: AnyView(TracesExporterView())
+            )
+        ]
+    }
+
     var body: some View {
         NavigationView {
-            VStack {
-                Image(systemName: "globe")
-                    .imageScale(.large)
-                    .foregroundColor(.accentColor)
-                    .trackCXSwipeAction()
-                    .onAppear {
-                        let userContext = UserContext(userId: "1234",
-                                                      userName: "Daffy Duck",
-                                                      userEmail: "daffy.duck@coralogix.com",
-                                                      userMetadata: ["age": "18", "profession" : "duck"])
-                        coralogixRum.setUserContext(userContext: userContext)
-                    }.padding(10)
-                    .border(.gray)
+            List {
+                sessionHeader
 
-                NavigationLink(destination: SecondView(coralogixRum: $coralogixRum)) {
-                                    Text("Go to Second View")
-                                }
-                                .navigationTitle("Main View")
-                                .trackCXView(name: "Main View")
-                                .trackCXTapAction(name: "second View")
-                
-                NavigationLink(destination: MaskDemoView()) {
-                    Text("UI Mask Demo")
-                }
-                .navigationTitle("UI Mask Demo")
-                
-                List(items, id: \.self) { item in
-                    CustomButton(item: item, coralogixRum: $coralogixRum)
+                ForEach(menuItems, id: \.title) { item in
+                    NavigationLink(destination: item.destination) {
+                        Label {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(item.title)
+                                    .font(.body)
+                                Text(item.subtitle)
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            }
+                        } icon: {
+                            Image(systemName: item.icon)
+                                .font(.system(size: 20, weight: .medium))
+                                .frame(width: 28)
+                        }
+                        .padding(.vertical, 2)
+                    }
                 }
             }
-            .padding()
+            .listStyle(.insetGrouped)
+            .navigationTitle("Coralogix Demo")
+            .navigationBarTitleDisplayMode(.large)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button {
+                        copySessionID()
+                    } label: {
+                        Image(systemName: "doc.on.doc")
+                    }
+                }
+            }
+            .trackCXView(name: "Main View")
+            .onAppear {
+                CoralogixRumManager.shared.sdk.setUserContext(
+                    userContext: UserContext(
+                        userId: "1234",
+                        userName: "Daffy Duck",
+                        userEmail: "daffy.duck@coralogix.com",
+                        userMetadata: ["age": "18", "profession": "duck"]
+                    )
+                )
+            }
+        }
+        .toast(message: $toastMessage)
+    }
+
+    @ViewBuilder
+    private var sessionHeader: some View {
+        Section {
+            HStack {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Session ID")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                    Text(sessionID)
+                        .font(.system(.footnote, design: .monospaced))
+                        .foregroundColor(.primary)
+                }
+                Spacer()
+                Button("Copy") {
+                    copySessionID()
+                }
+            }
+            .padding(.vertical, 2)
         }
     }
-}
 
-struct SecondView: View {
-    @Binding var coralogixRum: CoralogixRum
-    
-    let items = ["Send NSError",
-                 "Send Crash"]
-    var body: some View {
-        Text("Welcome to the Second View!")
-            .navigationTitle("Second View")
-            .trackCXView(name: "Second View")
-        
-//        List(items, id: \.self) { item in
-//            Button(action: {
-//                print("Clicked on: \(item)")
-//                if item == "Send Crash" {
-//                    CrashSim.simulateRandomCrash()
-//                } else if item == "Send NSError" {
-//                    ErrorSim.sendNSError(cxRum: self.coralogixRum)
-//                }
-//            },label: {
-//               Text(item)
-//            }).trackCXTapAction(name: "\(item)")
-//        }
-//        .padding()
-    }
-}
-
-struct CustomButton: View {
-    var item: String
-    @Binding var coralogixRum: CoralogixRum
-    
-    var body: some View {
-        Button(action: {
-            print("Clicked on: \(item)")
-            if item == Keys.failureNetworkRequest.rawValue {
-                NetworkSim.failureNetworkRequest()
-            } else if item == Keys.succesfullNetworkRequest.rawValue {
-                NetworkSim.sendSuccesfullRequest()
-            } else if item == Keys.sendNSException.rawValue {
-                ErrorSim.sendNSException()
-            } else if item == Keys.sendNSError.rawValue {
-                ErrorSim.sendNSError()
-            } else if item == Keys.sendErrorString.rawValue {
-                ErrorSim.sendError()
-            } else if item == Keys.sendCrash.rawValue {
-                CrashSim.simulateRandomCrash()
-            } else if item == Keys.shutDownCoralogixRum.rawValue {
-                coralogixRum.shutdown()
-            } else if item == Keys.sendLogWithData.rawValue {
-                ErrorSim.sendErrorLog()
-            } else if item == Keys.updateLabels.rawValue {
-                coralogixRum.set(labels: ["item3" : "playstation 4", "itemPrice" : 400])
-            } else if item == Keys.succesfullNetworkRequestFlutter.rawValue {
-                NetworkSim.setNetworkRequestContextSuccsess()
-            } else if item == Keys.failureNetworkRequestFlutter.rawValue {
-                NetworkSim.setNetworkRequestContextFailure()
-            } 
-        }, label: {
-            Text(item)
-        }).trackCXTapAction(name: "\(item)")
+    private func copySessionID() {
+        guard let id = CoralogixRumManager.shared.getSessionId() else {
+            toastMessage = "No session ID available"
+            return
+        }
+        UIPasteboard.general.string = id
+        toastMessage = "Session ID copied"
     }
 }

--- a/Example/DemoAppSwiftUI/ContentView.swift
+++ b/Example/DemoAppSwiftUI/ContentView.swift
@@ -29,6 +29,7 @@ struct ContentView: View {
                 Image(systemName: "globe")
                     .imageScale(.large)
                     .foregroundColor(.accentColor)
+                    .trackCXSwipeAction()
                     .onAppear {
                         let userContext = UserContext(userId: "1234",
                                                       userName: "Daffy Duck",
@@ -101,13 +102,13 @@ struct CustomButton: View {
             } else if item == Keys.sendNSError.rawValue {
                 ErrorSim.sendNSError()
             } else if item == Keys.sendErrorString.rawValue {
-                ErrorSim.sendStringError()
+                ErrorSim.sendError()
             } else if item == Keys.sendCrash.rawValue {
                 CrashSim.simulateRandomCrash()
             } else if item == Keys.shutDownCoralogixRum.rawValue {
                 coralogixRum.shutdown()
             } else if item == Keys.sendLogWithData.rawValue {
-                ErrorSim.sendLog()
+                ErrorSim.sendErrorLog()
             } else if item == Keys.updateLabels.rawValue {
                 coralogixRum.set(labels: ["item3" : "playstation 4", "itemPrice" : 400])
             } else if item == Keys.succesfullNetworkRequestFlutter.rawValue {

--- a/Example/DemoAppSwiftUI/ContentView.swift
+++ b/Example/DemoAppSwiftUI/ContentView.swift
@@ -131,6 +131,19 @@ struct ContentView: View {
     @SwiftUI.ViewBuilder
     private var sessionHeader: some View {
         Section {
+            VStack(spacing: 8) {
+                Image(systemName: "antenna.radiowaves.left.and.right")
+                    .font(.system(size: 32, weight: .medium))
+                    .foregroundColor(.accentColor)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 8)
+                    .trackCXSwipeAction()
+                Text("Swipe the icon above to test swipe tracking")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .frame(maxWidth: .infinity)
+            }
+
             HStack {
                 VStack(alignment: .leading, spacing: 4) {
                     Text("Session ID")

--- a/Example/DemoAppSwiftUI/CustomSpansView.swift
+++ b/Example/DemoAppSwiftUI/CustomSpansView.swift
@@ -1,0 +1,167 @@
+import SwiftUI
+import Coralogix
+
+struct CustomSpansView: View {
+    @State private var toastMessage: String?
+    @State private var cachedTracer: CoralogixCustomTracer?
+    @State private var cachedTracerPreferIgnored: Bool?
+
+    private struct DemoItem {
+        let title: String
+        let subtitle: String
+        let icon: String
+        let action: () -> Void
+    }
+
+    private var items: [DemoItem] {
+        [
+            DemoItem(
+                title: "Simple global + child spans",
+                subtitle: "Simulates a small user flow: startGlobalSpan → startCustomSpan (child) → set attribute, event, status → end child → end global. You should see two custom-span events on one trace in Coralogix.",
+                icon: "point.3.connected.trianglepath.dotted",
+                action: { runSimpleFlow(useIgnoredTracer: false) }
+            ),
+            DemoItem(
+                title: "withContext + GET request",
+                subtitle: "Simulates doing work (here a demo GET) while the global span is open. Shows that withContext is safe when the global is already active.",
+                icon: "network",
+                action: { runWithContextNetwork() }
+            ),
+            DemoItem(
+                title: "Second startGlobalSpan rejected",
+                subtitle: "Simulates the Browser rule: with a global still open, a second startGlobalSpan returns nil. After endSpan(), a new global can start.",
+                icon: "exclamationmark.triangle",
+                action: { runSecondGlobalRejectedDemo() }
+            ),
+            DemoItem(
+                title: "Tracer with ignoredInstruments",
+                subtitle: "Same span sequence as the first row, but using getCustomTracer(ignoredInstruments: [.networkRequests, .errors]).",
+                icon: "eye.slash",
+                action: { runSimpleFlow(useIgnoredTracer: true) }
+            )
+        ]
+    }
+
+    var body: some View {
+        List {
+            Section {
+                Text(introText)
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+            }
+
+            Section("Demos") {
+                ForEach(items, id: \.title) { item in
+                    Button {
+                        item.action()
+                    } label: {
+                        Label {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(item.title)
+                                    .font(.body)
+                                    .foregroundColor(.primary)
+                                Text(item.subtitle)
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                                    .fixedSize(horizontal: false, vertical: true)
+                            }
+                        } icon: {
+                            Image(systemName: item.icon)
+                                .font(.system(size: 20, weight: .medium))
+                                .frame(width: 28)
+                        }
+                        .padding(.vertical, 4)
+                    }
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+        .navigationTitle("Custom Spans")
+        .navigationBarTitleDisplayMode(.inline)
+        .trackCXView(name: "Custom Spans")
+        .toast(message: $toastMessage)
+    }
+
+    private let introText = """
+    Custom spans are manual RUM spans (exported like the Browser SDK, type custom-span). A global span is the "root" for a flow; nested spans are children. Only one global may exist at a time.
+
+    startGlobalSpan registers that span as OpenTelemetry's active context. Auto-instrumentation (e.g. URLSession) can then use the same traceId until you call endSpan().
+
+    Tap a row below to run a scripted sequence; check Coralogix for span names and the shared trace.
+    """
+
+    private func tracerForSession(preferIgnored: Bool) -> CoralogixCustomTracer? {
+        if let c = cachedTracer {
+            if (cachedTracerPreferIgnored ?? false) != preferIgnored {
+                toastMessage = "Reusing earlier tracer — ignored-instruments setting differs. Relaunch to switch."
+            }
+            return c
+        }
+        let rum = CoralogixRumManager.shared.sdk
+        let t: CoralogixCustomTracer?
+        if preferIgnored {
+            t = rum.getCustomTracer(ignoredInstruments: [.networkRequests, .errors])
+        } else {
+            t = rum.getCustomTracer()
+        }
+        guard let tracer = t else {
+            toastMessage = "Custom tracer unavailable — set traceParentInHeader with enable: true."
+            return nil
+        }
+        cachedTracer = tracer
+        cachedTracerPreferIgnored = preferIgnored
+        return tracer
+    }
+
+    private func runSimpleFlow(useIgnoredTracer: Bool) {
+        let rum = CoralogixRumManager.shared.sdk
+        guard rum.isInitialized else { toastMessage = "SDK not initialized"; return }
+        guard let tracer = tracerForSession(preferIgnored: useIgnoredTracer) else { return }
+        guard let global = tracer.startGlobalSpan(name: "demo.custom.global", labels: ["demo.screen": "CustomSpans"]) else {
+            toastMessage = "startGlobalSpan returned nil"
+            return
+        }
+        let child = global.startCustomSpan(name: "demo.custom.child")
+        child.setAttribute(key: "demo.step", value: "authorize")
+        child.addEvent(name: "demo.checkpoint")
+        child.setStatus(.ok)
+        child.endSpan()
+        global.endSpan()
+        toastMessage = useIgnoredTracer ? "Finished (ignored-instruments tracer)" : "Finished simple flow"
+    }
+
+    private func runSecondGlobalRejectedDemo() {
+        let rum = CoralogixRumManager.shared.sdk
+        guard rum.isInitialized else { toastMessage = "SDK not initialized"; return }
+        guard let tracer = tracerForSession(preferIgnored: false) else { return }
+        guard let first = tracer.startGlobalSpan(name: "demo.custom.first_global") else {
+            toastMessage = "Unexpected: first startGlobalSpan failed"
+            return
+        }
+        if tracer.startGlobalSpan(name: "demo.custom.should_fail") != nil {
+            toastMessage = "Bug: second startGlobalSpan should return nil"
+            first.endSpan()
+            return
+        }
+        first.endSpan()
+        guard let after = tracer.startGlobalSpan(name: "demo.custom.after_end") else {
+            toastMessage = "Unexpected: global after endSpan should succeed"
+            return
+        }
+        after.endSpan()
+        toastMessage = "OK: 2nd global rejected; new global after endSpan works"
+    }
+
+    private func runWithContextNetwork() {
+        let rum = CoralogixRumManager.shared.sdk
+        guard rum.isInitialized else { toastMessage = "SDK not initialized"; return }
+        guard let tracer = tracerForSession(preferIgnored: false) else { return }
+        guard let global = tracer.startGlobalSpan(name: "demo.custom.with_context", labels: ["demo.flow": "network"]) else {
+            toastMessage = "startGlobalSpan returned nil"
+            return
+        }
+        global.withContext { NetworkSim.sendSuccesfullRequest() }
+        global.endSpan()
+        toastMessage = "GET started under withContext; global span ended"
+    }
+}

--- a/Example/DemoAppSwiftUI/DemoAppSwiftUIApp.swift
+++ b/Example/DemoAppSwiftUI/DemoAppSwiftUIApp.swift
@@ -20,7 +20,7 @@ struct DemoAppSwiftUIApp: App {
                                                         captureScale: 2.0,
                                                         captureCompressionQuality: 0.8,
                                                         maskText: [],
-                                                        maskCreditCard: false,
+                                                        maskOnlyCreditCards: false,
                                                         maskAllImages: false,
                                                         autoStartSessionRecording: true)
         SessionReplay.initializeWithOptions(sessionReplayOptions:sessionReplayOptions)

--- a/Example/DemoAppSwiftUI/DemoAppSwiftUIApp.swift
+++ b/Example/DemoAppSwiftUI/DemoAppSwiftUIApp.swift
@@ -11,10 +11,8 @@ import SessionReplay
 @main
 
 struct DemoAppSwiftUIApp: App {
-    @State private var coralogixRum: CoralogixRum
     init() {
         CoralogixRumManager.shared.initialize()
-        // Must be initialized after CoralogixRum
         let sessionReplayOptions = SessionReplayOptions(recordingType: .image,
                                                         captureTimeInterval: 10.0,
                                                         captureScale: 2.0,
@@ -23,14 +21,12 @@ struct DemoAppSwiftUIApp: App {
                                                         maskOnlyCreditCards: false,
                                                         maskAllImages: false,
                                                         autoStartSessionRecording: true)
-        SessionReplay.initializeWithOptions(sessionReplayOptions:sessionReplayOptions)
-        
-        self.coralogixRum = CoralogixRumManager.shared.sdk
+        SessionReplay.initializeWithOptions(sessionReplayOptions: sessionReplayOptions)
     }
-    
+
     var body: some Scene {
         WindowGroup {
-            ContentView(coralogixRum: $coralogixRum)
+            ContentView()
         }
     }
 }

--- a/Example/DemoAppSwiftUI/DemoRow.swift
+++ b/Example/DemoAppSwiftUI/DemoRow.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+struct DemoRow: View {
+    let icon: String
+    let title: String
+    let subtitle: String
+
+    var body: some View {
+        Label {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.body)
+                    .foregroundColor(.primary)
+                Text(subtitle)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+        } icon: {
+            Image(systemName: icon)
+                .font(.system(size: 20, weight: .medium))
+                .frame(width: 28)
+        }
+        .padding(.vertical, 2)
+    }
+}

--- a/Example/DemoAppSwiftUI/ErrorView.swift
+++ b/Example/DemoAppSwiftUI/ErrorView.swift
@@ -1,0 +1,89 @@
+import SwiftUI
+
+struct ErrorView: View {
+    @State private var toastMessage: String?
+
+    private struct Item {
+        let title: String
+        let subtitle: String
+        let icon: String
+        let action: () -> Void
+    }
+
+    private var items: [Item] {
+        [
+            Item(title: "NSException",
+                 subtitle: "Send NSException error",
+                 icon: "exclamationmark.triangle",
+                 action: { ErrorSim.sendNSException() }),
+            Item(title: "NSError",
+                 subtitle: "Send NSError error",
+                 icon: "exclamationmark.circle",
+                 action: { ErrorSim.sendNSError() }),
+            Item(title: "Error",
+                 subtitle: "Send Swift Error",
+                 icon: "xmark.circle",
+                 action: { ErrorSim.sendError() }),
+            Item(title: "Message Data Error",
+                 subtitle: "Custom log with error message",
+                 icon: "doc.text",
+                 action: { ErrorSim.sendMessageDataError() }),
+            Item(title: "Stack Trace Error",
+                 subtitle: "Error with stack trace and type",
+                 icon: "list.bullet.rectangle",
+                 action: { ErrorSim.sendMessageStackTraceTypeIsCarshError() }),
+            Item(title: "Log Error",
+                 subtitle: "Send error via logging",
+                 icon: "doc.append",
+                 action: { ErrorSim.sendErrorLog() }),
+            Item(title: "Crash",
+                 subtitle: "Simulate a random crash",
+                 icon: "bolt.trianglebadge.exclamationmark",
+                 action: { CrashSim.simulateRandomCrash() }),
+            Item(title: "Simulate ANR",
+                 subtitle: "Application Not Responding",
+                 icon: "hourglass",
+                 action: { ErrorSim.simulateANR() }),
+            Item(title: "Flutter Symbolicated Error",
+                 subtitle: "Simulate readable Dart stack trace",
+                 icon: "curlybraces",
+                 action: { ErrorSim.sendFlutterSymbolicatedError() }),
+            Item(title: "Flutter Obfuscated Error",
+                 subtitle: "Simulate obfuscated Dart stack trace (virt addresses)",
+                 icon: "eye.slash",
+                 action: { ErrorSim.sendFlutterObfuscatedError() })
+        ]
+    }
+
+    var body: some View {
+        List {
+            ForEach(items, id: \.title) { item in
+                Button {
+                    toastMessage = "Selected: \(item.title)"
+                    item.action()
+                } label: {
+                    Label {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(item.title)
+                                .font(.body)
+                                .foregroundColor(.primary)
+                            Text(item.subtitle)
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                    } icon: {
+                        Image(systemName: item.icon)
+                            .font(.system(size: 20, weight: .medium))
+                            .frame(width: 28)
+                    }
+                    .padding(.vertical, 2)
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+        .navigationTitle("Error instrumentation")
+        .navigationBarTitleDisplayMode(.large)
+        .trackCXView(name: "Error instrumentation")
+        .toast(message: $toastMessage)
+    }
+}

--- a/Example/DemoAppSwiftUI/ErrorView.swift
+++ b/Example/DemoAppSwiftUI/ErrorView.swift
@@ -1,89 +1,52 @@
 import SwiftUI
 
 struct ErrorView: View {
-    @State private var toastMessage: String?
-
-    private struct Item {
-        let title: String
-        let subtitle: String
-        let icon: String
-        let action: () -> Void
-    }
-
-    private var items: [Item] {
-        [
-            Item(title: "NSException",
-                 subtitle: "Send NSException error",
-                 icon: "exclamationmark.triangle",
-                 action: { ErrorSim.sendNSException() }),
-            Item(title: "NSError",
-                 subtitle: "Send NSError error",
-                 icon: "exclamationmark.circle",
-                 action: { ErrorSim.sendNSError() }),
-            Item(title: "Error",
-                 subtitle: "Send Swift Error",
-                 icon: "xmark.circle",
-                 action: { ErrorSim.sendError() }),
-            Item(title: "Message Data Error",
-                 subtitle: "Custom log with error message",
-                 icon: "doc.text",
-                 action: { ErrorSim.sendMessageDataError() }),
-            Item(title: "Stack Trace Error",
-                 subtitle: "Error with stack trace and type",
-                 icon: "list.bullet.rectangle",
-                 action: { ErrorSim.sendMessageStackTraceTypeIsCarshError() }),
-            Item(title: "Log Error",
-                 subtitle: "Send error via logging",
-                 icon: "doc.append",
-                 action: { ErrorSim.sendErrorLog() }),
-            Item(title: "Crash",
-                 subtitle: "Simulate a random crash",
-                 icon: "bolt.trianglebadge.exclamationmark",
-                 action: { CrashSim.simulateRandomCrash() }),
-            Item(title: "Simulate ANR",
-                 subtitle: "Application Not Responding",
-                 icon: "hourglass",
-                 action: { ErrorSim.simulateANR() }),
-            Item(title: "Flutter Symbolicated Error",
-                 subtitle: "Simulate readable Dart stack trace",
-                 icon: "curlybraces",
-                 action: { ErrorSim.sendFlutterSymbolicatedError() }),
-            Item(title: "Flutter Obfuscated Error",
-                 subtitle: "Simulate obfuscated Dart stack trace (virt addresses)",
-                 icon: "eye.slash",
-                 action: { ErrorSim.sendFlutterObfuscatedError() })
-        ]
-    }
-
     var body: some View {
-        List {
-            ForEach(items, id: \.title) { item in
-                Button {
-                    toastMessage = "Selected: \(item.title)"
-                    item.action()
-                } label: {
-                    Label {
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text(item.title)
-                                .font(.body)
-                                .foregroundColor(.primary)
-                            Text(item.subtitle)
-                                .font(.caption)
-                                .foregroundColor(.secondary)
-                        }
-                    } icon: {
-                        Image(systemName: item.icon)
-                            .font(.system(size: 20, weight: .medium))
-                            .frame(width: 28)
-                    }
-                    .padding(.vertical, 2)
-                }
-            }
-        }
-        .listStyle(.insetGrouped)
-        .navigationTitle("Error instrumentation")
-        .navigationBarTitleDisplayMode(.large)
-        .trackCXView(name: "Error instrumentation")
-        .toast(message: $toastMessage)
+        ActionListView(
+            title: "Error instrumentation",
+            cxViewName: "Error instrumentation",
+            items: [
+                ActionItem(title: "NSException",
+                           subtitle: "Send NSException error",
+                           icon: "exclamationmark.triangle",
+                           action: { ErrorSim.sendNSException() }),
+                ActionItem(title: "NSError",
+                           subtitle: "Send NSError error",
+                           icon: "exclamationmark.circle",
+                           action: { ErrorSim.sendNSError() }),
+                ActionItem(title: "Error",
+                           subtitle: "Send Swift Error",
+                           icon: "xmark.circle",
+                           action: { ErrorSim.sendError() }),
+                ActionItem(title: "Message Data Error",
+                           subtitle: "Custom log with error message",
+                           icon: "doc.text",
+                           action: { ErrorSim.sendMessageDataError() }),
+                ActionItem(title: "Stack Trace Error",
+                           subtitle: "Error with stack trace and type",
+                           icon: "list.bullet.rectangle",
+                           action: { ErrorSim.sendMessageStackTraceTypeIsCarshError() }),
+                ActionItem(title: "Log Error",
+                           subtitle: "Send error via logging",
+                           icon: "doc.append",
+                           action: { ErrorSim.sendErrorLog() }),
+                ActionItem(title: "Crash",
+                           subtitle: "Simulate a random crash",
+                           icon: "bolt.trianglebadge.exclamationmark",
+                           action: { CrashSim.simulateRandomCrash() }),
+                ActionItem(title: "Simulate ANR",
+                           subtitle: "Application Not Responding",
+                           icon: "hourglass",
+                           action: { ErrorSim.simulateANR() }),
+                ActionItem(title: "Flutter Symbolicated Error",
+                           subtitle: "Simulate readable Dart stack trace",
+                           icon: "curlybraces",
+                           action: { ErrorSim.sendFlutterSymbolicatedError() }),
+                ActionItem(title: "Flutter Obfuscated Error",
+                           subtitle: "Simulate obfuscated Dart stack trace (virt addresses)",
+                           icon: "eye.slash",
+                           action: { ErrorSim.sendFlutterObfuscatedError() })
+            ]
+        )
     }
 }

--- a/Example/DemoAppSwiftUI/NetworkView.swift
+++ b/Example/DemoAppSwiftUI/NetworkView.swift
@@ -1,108 +1,71 @@
 import SwiftUI
 
 struct NetworkView: View {
-    @State private var toastMessage: String?
-
-    private struct Item {
-        let title: String
-        let subtitle: String
-        let icon: String
-        let action: () -> Void
-    }
-
-    private var items: [Item] {
-        [
-            Item(title: "Failing network request",
-                 subtitle: "Simulate a client/server error",
-                 icon: "xmark.octagon",
-                 action: { NetworkSim.failureNetworkRequest() }),
-            Item(title: "Successful network request",
-                 subtitle: "Standard URLSession request",
-                 icon: "checkmark.circle",
-                 action: { NetworkSim.sendSuccesfullRequest() }),
-            Item(title: "Flutter success request",
-                 subtitle: "Simulate successful Flutter network",
-                 icon: "bolt.horizontal.circle",
-                 action: { NetworkSim.setNetworkRequestContextFlutterSuccsess() }),
-            Item(title: "Flutter failure request",
-                 subtitle: "Simulate failed Flutter network",
-                 icon: "bolt.horizontal.circle.fill",
-                 action: { NetworkSim.setNetworkRequestContextFailure() }),
-            Item(title: "Alamofire success",
-                 subtitle: "Successful Alamofire request",
-                 icon: "bolt.circle",
-                 action: { NetworkSim.succesfullAlamofire() }),
-            Item(title: "Alamofire failure",
-                 subtitle: "Failing Alamofire request",
-                 icon: "bolt.slash",
-                 action: { NetworkSim.failureAlamofire() }),
-            Item(title: "Alamofire upload",
-                 subtitle: "Upload a 2MB sample file",
-                 icon: "arrow.up.doc",
-                 action: {
-                     let url = NetworkSim.createSampleFile(sizeInMB: 2)
-                     NetworkSim.uploadFile(fileURL: url)
-                 }),
-            Item(title: "AFNetworking request",
-                 subtitle: "Legacy AFNetworking example",
-                 icon: "antenna.radiowaves.left.and.right",
-                 action: { NetworkSim.sendAFNetworkingRequest() }),
-            Item(title: "Download image (SDWebImage)",
-                 subtitle: "Image download & caching",
-                 icon: "photo.on.rectangle",
-                 action: { NetworkSim.downloadImage() }),
-            Item(title: "POST request",
-                 subtitle: "Send JSON data to server",
-                 icon: "arrow.up.circle",
-                 action: { NetworkSim.performPostRequest() }),
-            Item(title: "GET request",
-                 subtitle: "Fetch data from server",
-                 icon: "arrow.down.circle",
-                 action: { NetworkSim.performGetRequest() }),
-            Item(title: "Async/Await example",
-                 subtitle: "async await in action",
-                 icon: "arrow.triangle.2.circlepath",
-                 action: { NetworkSim.callAsyncAwait() }),
-            Item(title: "Async/Await with SSL Pinning",
-                 subtitle: "async/await + custom delegate",
-                 icon: "lock.shield",
-                 action: { NetworkSim.callAsyncAwaitWithSSLPinning() }),
-            Item(title: "Header & response body capture",
-                 subtitle: "One POST showing all 4 fields: request_headers, response_headers, request_payload, response_payload",
-                 icon: "list.bullet.rectangle",
-                 action: { NetworkSim.sendRequestWithHeaderCapture() })
-        ]
-    }
-
     var body: some View {
-        List {
-            ForEach(items, id: \.title) { item in
-                Button {
-                    toastMessage = "Selected: \(item.title)"
-                    item.action()
-                } label: {
-                    Label {
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text(item.title)
-                                .font(.body)
-                                .foregroundColor(.primary)
-                            Text(item.subtitle)
-                                .font(.caption)
-                                .foregroundColor(.secondary)
-                        }
-                    } icon: {
-                        Image(systemName: item.icon)
-                            .font(.system(size: 20, weight: .medium))
-                            .frame(width: 28)
-                    }
-                    .padding(.vertical, 2)
-                }
-            }
-        }
-        .listStyle(.insetGrouped)
-        .navigationTitle("Network instrumentation")
-        .navigationBarTitleDisplayMode(.large)
-        .trackCXView(name: "Network instrumentation")
-        .toast(message: $toastMessage)
+        ActionListView(
+            title: "Network instrumentation",
+            cxViewName: "Network instrumentation",
+            items: [
+                ActionItem(title: "Failing network request",
+                           subtitle: "Simulate a client/server error",
+                           icon: "xmark.octagon",
+                           action: { NetworkSim.failureNetworkRequest() }),
+                ActionItem(title: "Successful network request",
+                           subtitle: "Standard URLSession request",
+                           icon: "checkmark.circle",
+                           action: { NetworkSim.sendSuccesfullRequest() }),
+                ActionItem(title: "Flutter success request",
+                           subtitle: "Simulate successful Flutter network",
+                           icon: "bolt.horizontal.circle",
+                           action: { NetworkSim.setNetworkRequestContextFlutterSuccsess() }),
+                ActionItem(title: "Flutter failure request",
+                           subtitle: "Simulate failed Flutter network",
+                           icon: "bolt.horizontal.circle.fill",
+                           action: { NetworkSim.setNetworkRequestContextFailure() }),
+                ActionItem(title: "Alamofire success",
+                           subtitle: "Successful Alamofire request",
+                           icon: "bolt.circle",
+                           action: { NetworkSim.succesfullAlamofire() }),
+                ActionItem(title: "Alamofire failure",
+                           subtitle: "Failing Alamofire request",
+                           icon: "bolt.slash",
+                           action: { NetworkSim.failureAlamofire() }),
+                ActionItem(title: "Alamofire upload",
+                           subtitle: "Upload a 2MB sample file",
+                           icon: "arrow.up.doc",
+                           action: {
+                               let url = NetworkSim.createSampleFile(sizeInMB: 2)
+                               NetworkSim.uploadFile(fileURL: url)
+                           }),
+                ActionItem(title: "AFNetworking request",
+                           subtitle: "Legacy AFNetworking example",
+                           icon: "antenna.radiowaves.left.and.right",
+                           action: { NetworkSim.sendAFNetworkingRequest() }),
+                ActionItem(title: "Download image (SDWebImage)",
+                           subtitle: "Image download & caching",
+                           icon: "photo.on.rectangle",
+                           action: { NetworkSim.downloadImage() }),
+                ActionItem(title: "POST request",
+                           subtitle: "Send JSON data to server",
+                           icon: "arrow.up.circle",
+                           action: { NetworkSim.performPostRequest() }),
+                ActionItem(title: "GET request",
+                           subtitle: "Fetch data from server",
+                           icon: "arrow.down.circle",
+                           action: { NetworkSim.performGetRequest() }),
+                ActionItem(title: "Async/Await example",
+                           subtitle: "async await in action",
+                           icon: "arrow.triangle.2.circlepath",
+                           action: { NetworkSim.callAsyncAwait() }),
+                ActionItem(title: "Async/Await with SSL Pinning",
+                           subtitle: "async/await + custom delegate",
+                           icon: "lock.shield",
+                           action: { NetworkSim.callAsyncAwaitWithSSLPinning() }),
+                ActionItem(title: "Header & response body capture",
+                           subtitle: "One POST showing all 4 fields: request_headers, response_headers, request_payload, response_payload",
+                           icon: "list.bullet.rectangle",
+                           action: { NetworkSim.sendRequestWithHeaderCapture() })
+            ]
+        )
     }
 }

--- a/Example/DemoAppSwiftUI/NetworkView.swift
+++ b/Example/DemoAppSwiftUI/NetworkView.swift
@@ -1,0 +1,108 @@
+import SwiftUI
+
+struct NetworkView: View {
+    @State private var toastMessage: String?
+
+    private struct Item {
+        let title: String
+        let subtitle: String
+        let icon: String
+        let action: () -> Void
+    }
+
+    private var items: [Item] {
+        [
+            Item(title: "Failing network request",
+                 subtitle: "Simulate a client/server error",
+                 icon: "xmark.octagon",
+                 action: { NetworkSim.failureNetworkRequest() }),
+            Item(title: "Successful network request",
+                 subtitle: "Standard URLSession request",
+                 icon: "checkmark.circle",
+                 action: { NetworkSim.sendSuccesfullRequest() }),
+            Item(title: "Flutter success request",
+                 subtitle: "Simulate successful Flutter network",
+                 icon: "bolt.horizontal.circle",
+                 action: { NetworkSim.setNetworkRequestContextFlutterSuccsess() }),
+            Item(title: "Flutter failure request",
+                 subtitle: "Simulate failed Flutter network",
+                 icon: "bolt.horizontal.circle.fill",
+                 action: { NetworkSim.setNetworkRequestContextFailure() }),
+            Item(title: "Alamofire success",
+                 subtitle: "Successful Alamofire request",
+                 icon: "bolt.circle",
+                 action: { NetworkSim.succesfullAlamofire() }),
+            Item(title: "Alamofire failure",
+                 subtitle: "Failing Alamofire request",
+                 icon: "bolt.slash",
+                 action: { NetworkSim.failureAlamofire() }),
+            Item(title: "Alamofire upload",
+                 subtitle: "Upload a 2MB sample file",
+                 icon: "arrow.up.doc",
+                 action: {
+                     let url = NetworkSim.createSampleFile(sizeInMB: 2)
+                     NetworkSim.uploadFile(fileURL: url)
+                 }),
+            Item(title: "AFNetworking request",
+                 subtitle: "Legacy AFNetworking example",
+                 icon: "antenna.radiowaves.left.and.right",
+                 action: { NetworkSim.sendAFNetworkingRequest() }),
+            Item(title: "Download image (SDWebImage)",
+                 subtitle: "Image download & caching",
+                 icon: "photo.on.rectangle",
+                 action: { NetworkSim.downloadImage() }),
+            Item(title: "POST request",
+                 subtitle: "Send JSON data to server",
+                 icon: "arrow.up.circle",
+                 action: { NetworkSim.performPostRequest() }),
+            Item(title: "GET request",
+                 subtitle: "Fetch data from server",
+                 icon: "arrow.down.circle",
+                 action: { NetworkSim.performGetRequest() }),
+            Item(title: "Async/Await example",
+                 subtitle: "async await in action",
+                 icon: "arrow.triangle.2.circlepath",
+                 action: { NetworkSim.callAsyncAwait() }),
+            Item(title: "Async/Await with SSL Pinning",
+                 subtitle: "async/await + custom delegate",
+                 icon: "lock.shield",
+                 action: { NetworkSim.callAsyncAwaitWithSSLPinning() }),
+            Item(title: "Header & response body capture",
+                 subtitle: "One POST showing all 4 fields: request_headers, response_headers, request_payload, response_payload",
+                 icon: "list.bullet.rectangle",
+                 action: { NetworkSim.sendRequestWithHeaderCapture() })
+        ]
+    }
+
+    var body: some View {
+        List {
+            ForEach(items, id: \.title) { item in
+                Button {
+                    toastMessage = "Selected: \(item.title)"
+                    item.action()
+                } label: {
+                    Label {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(item.title)
+                                .font(.body)
+                                .foregroundColor(.primary)
+                            Text(item.subtitle)
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                    } icon: {
+                        Image(systemName: item.icon)
+                            .font(.system(size: 20, weight: .medium))
+                            .frame(width: 28)
+                    }
+                    .padding(.vertical, 2)
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+        .navigationTitle("Network instrumentation")
+        .navigationBarTitleDisplayMode(.large)
+        .trackCXView(name: "Network instrumentation")
+        .toast(message: $toastMessage)
+    }
+}

--- a/Example/DemoAppSwiftUI/SchemaValidationView.swift
+++ b/Example/DemoAppSwiftUI/SchemaValidationView.swift
@@ -1,0 +1,175 @@
+import SwiftUI
+import Coralogix
+
+struct SchemaValidationView: View {
+    @State private var statusText = "Ready to validate schema"
+    @State private var statusColor = Color.secondary
+    @State private var isValidating = false
+    @State private var lastRequestURL: String?
+    @State private var toastMessage: String?
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 24) {
+                sessionIDCard
+
+                statusCard
+
+                VStack(spacing: 12) {
+                    Button {
+                        validateSchema()
+                    } label: {
+                        Text("Validate Schema")
+                            .font(.headline)
+                            .frame(maxWidth: .infinity)
+                            .padding()
+                            .background(isValidating ? Color.gray : Color.blue)
+                            .foregroundColor(.white)
+                            .cornerRadius(10)
+                    }
+                    .disabled(isValidating)
+
+                    Button {
+                        copyRequest()
+                    } label: {
+                        Text("Copy Request")
+                            .font(.subheadline)
+                            .frame(maxWidth: 150)
+                            .padding(.vertical, 10)
+                            .background(Color(.systemGray4))
+                            .foregroundColor(.primary)
+                            .cornerRadius(8)
+                    }
+                }
+            }
+            .padding(20)
+        }
+        .navigationTitle("Verify schema")
+        .navigationBarTitleDisplayMode(.inline)
+        .trackCXView(name: "Schema Validation")
+        .toast(message: $toastMessage)
+    }
+
+    private var sessionIDCard: some View {
+        let sessionID = CoralogixRumManager.shared.getSessionId()?.lowercased() ?? "No session available"
+        return VStack(alignment: .center, spacing: 4) {
+            Text("Session ID:")
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+            Text(sessionID)
+                .font(.system(.footnote, design: .monospaced))
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+        .padding()
+        .background(Color(.secondarySystemBackground))
+        .cornerRadius(10)
+    }
+
+    private var statusCard: some View {
+        Group {
+            if isValidating {
+                HStack(spacing: 12) {
+                    ProgressView()
+                    Text("Validating schema...")
+                        .foregroundColor(.secondary)
+                }
+            } else {
+                Text(statusText)
+                    .font(.system(size: 16, weight: .medium))
+                    .foregroundColor(statusColor)
+                    .multilineTextAlignment(.center)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding()
+        .background(Color(.secondarySystemBackground))
+        .cornerRadius(10)
+    }
+
+    private func validateSchema() {
+        guard let sessionId = CoralogixRumManager.shared.getSessionId() else {
+            statusText = "Error: No session ID available"
+            statusColor = .red
+            return
+        }
+        isValidating = true
+        statusColor = .secondary
+
+        let proxyUrl = Envs.PROXY_URL.rawValue
+        let urlString = "\(proxyUrl)/validate/\(sessionId.lowercased())"
+        lastRequestURL = urlString
+        guard let url = URL(string: urlString) else {
+            handleError("Invalid URL")
+            return
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.timeoutInterval = 30
+
+        let config = URLSessionConfiguration.default
+        config.connectionProxyDictionary = [:]
+        config.requestCachePolicy = .reloadIgnoringLocalCacheData
+
+        URLSession(configuration: config).dataTask(with: request) { data, response, error in
+            DispatchQueue.main.async { handleResponse(data: data, response: response, error: error) }
+        }.resume()
+    }
+
+    private func handleResponse(data: Data?, response: URLResponse?, error: Error?) {
+        isValidating = false
+        if let error = error { handleError("Network error: \(error.localizedDescription)"); return }
+        guard let http = response as? HTTPURLResponse else { handleError("Invalid response"); return }
+        if http.statusCode == 200 {
+            parseValidationResponse(data: data)
+        } else {
+            handleError("HTTP Error: \(http.statusCode)")
+        }
+    }
+
+    private func parseValidationResponse(data: Data?) {
+        guard let data = data,
+              let jsonArray = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
+            handleError("Invalid JSON format")
+            return
+        }
+        if jsonArray.isEmpty {
+            handleError("No logs found for validation.")
+            return
+        }
+        var allValid = true
+        var errorMessages: [String] = []
+        for item in jsonArray {
+            if let result = item["validationResult"] as? [String: Any],
+               let code = result["statusCode"] as? Int, code != 200 {
+                allValid = false
+                if let msgs = result["message"] as? [String] { errorMessages.append(contentsOf: msgs) }
+                else if let msg = result["message"] as? String { errorMessages.append(msg) }
+                else { errorMessages.append("Invalid status code: \(code)") }
+            }
+        }
+        if allValid {
+            statusText = "All logs are valid! ✅"
+            statusColor = .green
+        } else {
+            statusText = "Validation Failed:\n" + errorMessages.joined(separator: "\n")
+            statusColor = .red
+        }
+    }
+
+    private func handleError(_ message: String) {
+        isValidating = false
+        statusText = message
+        statusColor = .red
+    }
+
+    private func copyRequest() {
+        guard let urlString = lastRequestURL else {
+            toastMessage = "No request URL available"
+            return
+        }
+        UIPasteboard.general.string = urlString
+        toastMessage = "Request URL copied to clipboard!"
+    }
+}

--- a/Example/DemoAppSwiftUI/SdkView.swift
+++ b/Example/DemoAppSwiftUI/SdkView.swift
@@ -61,16 +61,31 @@ struct SdkView: View {
         .navigationBarTitleDisplayMode(.large)
         .trackCXView(name: "SDK Functions")
         .toast(message: $toastMessage)
-        .alert("Test Session Sampler", isPresented: $showSamplerSheet, actions: {
-            TextField("Sample rate (0–100)", text: $samplerRateText)
-                .keyboardType(.numberPad)
-            Button("Cancel", role: .cancel) {}
-            Button("Run 1000 trials") {
-                runSamplerTest()
+        .sheet(isPresented: $showSamplerSheet) {
+            VStack(spacing: 20) {
+                Text("Test Session Sampler")
+                    .font(.headline)
+                Text("Enter sample rate (0–100). We'll run 1000 trials and show how many would initialize.")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                    .multilineTextAlignment(.center)
+                TextField("Sample rate (0–100)", text: $samplerRateText)
+                    .keyboardType(.numberPad)
+                    .textFieldStyle(.roundedBorder)
+                HStack {
+                    Button("Cancel") {
+                        showSamplerSheet = false
+                    }
+                    Spacer()
+                    Button("Run 1000 trials") {
+                        showSamplerSheet = false
+                        runSamplerTest()
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
             }
-        }, message: {
-            Text("Enter sample rate (0–100). We'll run 1000 trials and show how many would initialize.")
-        })
+            .padding(32)
+        }
         .alert("Sampler result", isPresented: Binding(
             get: { samplerResult != nil },
             set: { if !$0 { samplerResult = nil } }

--- a/Example/DemoAppSwiftUI/SdkView.swift
+++ b/Example/DemoAppSwiftUI/SdkView.swift
@@ -1,0 +1,112 @@
+import SwiftUI
+import Coralogix
+
+struct SdkView: View {
+    @State private var toastMessage: String?
+    @State private var showSamplerSheet = false
+    @State private var samplerRateText = "50"
+    @State private var samplerResult: String?
+
+    var body: some View {
+        List {
+            Button {
+                toastMessage = "Selected: SDK Shutdown"
+                CoralogixRumManager.shared.sdk.shutdown()
+            } label: {
+                demoRow(icon: "power", title: "SDK Shutdown", subtitle: "Stop the Coralogix SDK")
+            }
+
+            Button {
+                toastMessage = "Selected: Update Labels"
+                CoralogixRumManager.shared.sdk.set(labels: ["item3": "playstation 4", "itemPrice": 400])
+            } label: {
+                demoRow(icon: "tag", title: "Update Labels", subtitle: "Set custom session labels")
+            }
+
+            Button {
+                toastMessage = "Selected: Report Mobile Vitals"
+                CoralogixRumManager.shared.sdk.reportMobileVitalsMeasurement(
+                    type: "custom metric", value: 10.0, units: "ms"
+                )
+            } label: {
+                demoRow(icon: "chart.xyaxis.line", title: "Report Mobile Vitals", subtitle: "Custom performance measurement")
+            }
+
+            Button {
+                toastMessage = "Selected: Custom Labels Log"
+                CoralogixRumManager.shared.sdk.log(
+                    severity: .info,
+                    message: "Custom labels",
+                    labels: ["im custom label": "label value", "thats wrong": 0]
+                )
+            } label: {
+                demoRow(icon: "tag.circle", title: "Custom Labels Log", subtitle: "Log message with custom labels")
+            }
+
+            Button {
+                toastMessage = "Selected: Custom Measurement"
+                CoralogixRumManager.shared.sdk.sendCustomMeasurement(name: "LSD", value: 43.0)
+            } label: {
+                demoRow(icon: "gauge.with.dots.needle.67percent", title: "Custom Measurement", subtitle: "Send custom metric data")
+            }
+
+            Button {
+                showSamplerSheet = true
+            } label: {
+                demoRow(icon: "percent", title: "Test Session Sampler", subtitle: "Run sampler trials with a chosen rate (0–100%)")
+            }
+        }
+        .listStyle(.insetGrouped)
+        .navigationTitle("SDK Functions")
+        .navigationBarTitleDisplayMode(.large)
+        .trackCXView(name: "SDK Functions")
+        .toast(message: $toastMessage)
+        .alert("Test Session Sampler", isPresented: $showSamplerSheet, actions: {
+            TextField("Sample rate (0–100)", text: $samplerRateText)
+                .keyboardType(.numberPad)
+            Button("Cancel", role: .cancel) {}
+            Button("Run 1000 trials") {
+                runSamplerTest()
+            }
+        }, message: {
+            Text("Enter sample rate (0–100). We'll run 1000 trials and show how many would initialize.")
+        })
+        .alert("Sampler result", isPresented: Binding(
+            get: { samplerResult != nil },
+            set: { if !$0 { samplerResult = nil } }
+        ), actions: {
+            Button("OK", role: .cancel) { samplerResult = nil }
+        }, message: {
+            Text(samplerResult ?? "")
+        })
+    }
+
+    private func demoRow(icon: String, title: String, subtitle: String) -> some View {
+        Label {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.body)
+                    .foregroundColor(.primary)
+                Text(subtitle)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+        } icon: {
+            Image(systemName: icon)
+                .font(.system(size: 20, weight: .medium))
+                .frame(width: 28)
+        }
+        .padding(.vertical, 2)
+    }
+
+    private func runSamplerTest() {
+        let rate = max(0, min(100, Int(samplerRateText) ?? 50))
+        let sampler = SDKSampler(sampleRate: rate)
+        var initialized = 0
+        for _ in 0..<1000 {
+            if sampler.shouldInitialized() { initialized += 1 }
+        }
+        let dropped = 1000 - initialized
+        samplerResult = "At \(rate)%: \(initialized) would initialize, \(dropped) would not (\(String(format: "%.1f", Double(initialized) / 10))% sampled)."
+    }
+}

--- a/Example/DemoAppSwiftUI/SdkView.swift
+++ b/Example/DemoAppSwiftUI/SdkView.swift
@@ -13,14 +13,14 @@ struct SdkView: View {
                 toastMessage = "Selected: SDK Shutdown"
                 CoralogixRumManager.shared.sdk.shutdown()
             } label: {
-                demoRow(icon: "power", title: "SDK Shutdown", subtitle: "Stop the Coralogix SDK")
+                DemoRow(icon: "power", title: "SDK Shutdown", subtitle: "Stop the Coralogix SDK")
             }
 
             Button {
                 toastMessage = "Selected: Update Labels"
                 CoralogixRumManager.shared.sdk.set(labels: ["item3": "playstation 4", "itemPrice": 400])
             } label: {
-                demoRow(icon: "tag", title: "Update Labels", subtitle: "Set custom session labels")
+                DemoRow(icon: "tag", title: "Update Labels", subtitle: "Set custom session labels")
             }
 
             Button {
@@ -29,7 +29,7 @@ struct SdkView: View {
                     type: "custom metric", value: 10.0, units: "ms"
                 )
             } label: {
-                demoRow(icon: "chart.xyaxis.line", title: "Report Mobile Vitals", subtitle: "Custom performance measurement")
+                DemoRow(icon: "chart.xyaxis.line", title: "Report Mobile Vitals", subtitle: "Custom performance measurement")
             }
 
             Button {
@@ -40,20 +40,20 @@ struct SdkView: View {
                     labels: ["im custom label": "label value", "thats wrong": 0]
                 )
             } label: {
-                demoRow(icon: "tag.circle", title: "Custom Labels Log", subtitle: "Log message with custom labels")
+                DemoRow(icon: "tag.circle", title: "Custom Labels Log", subtitle: "Log message with custom labels")
             }
 
             Button {
                 toastMessage = "Selected: Custom Measurement"
                 CoralogixRumManager.shared.sdk.sendCustomMeasurement(name: "LSD", value: 43.0)
             } label: {
-                demoRow(icon: "gauge.with.dots.needle.67percent", title: "Custom Measurement", subtitle: "Send custom metric data")
+                DemoRow(icon: "gauge.with.dots.needle.67percent", title: "Custom Measurement", subtitle: "Send custom metric data")
             }
 
             Button {
                 showSamplerSheet = true
             } label: {
-                demoRow(icon: "percent", title: "Test Session Sampler", subtitle: "Run sampler trials with a chosen rate (0–100%)")
+                DemoRow(icon: "percent", title: "Test Session Sampler", subtitle: "Run sampler trials with a chosen rate (0–100%)")
             }
         }
         .listStyle(.insetGrouped)
@@ -79,24 +79,6 @@ struct SdkView: View {
         }, message: {
             Text(samplerResult ?? "")
         })
-    }
-
-    private func demoRow(icon: String, title: String, subtitle: String) -> some View {
-        Label {
-            VStack(alignment: .leading, spacing: 2) {
-                Text(title)
-                    .font(.body)
-                    .foregroundColor(.primary)
-                Text(subtitle)
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-            }
-        } icon: {
-            Image(systemName: icon)
-                .font(.system(size: 20, weight: .medium))
-                .frame(width: 28)
-        }
-        .padding(.vertical, 2)
     }
 
     private func runSamplerTest() {

--- a/Example/DemoAppSwiftUI/SessionReplayView.swift
+++ b/Example/DemoAppSwiftUI/SessionReplayView.swift
@@ -1,0 +1,132 @@
+import SwiftUI
+import Coralogix
+import SessionReplay
+
+struct SessionReplayView: View {
+    @State private var toastMessage: String?
+    @State private var alertMessage: String?
+    @State private var showAlert = false
+    @State private var creditCardText = ""
+
+    var body: some View {
+        List {
+            Section {
+                Text("Quick controls for Session Replay recording, masking and events.")
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+            }
+
+            Section {
+                actionRow(icon: "record.circle", title: "Start Recording",
+                          subtitle: "Begin capturing user interactions for this session.") {
+                    CoralogixRumManager.shared.sdk.startRecording()
+                    toastMessage = "Recording started"
+                }
+
+                actionRow(icon: "stop.circle", title: "Stop Recording",
+                          subtitle: "Stop recording and finalize the current session.") {
+                    CoralogixRumManager.shared.sdk.stopRecording()
+                    toastMessage = "Recording stopped"
+                }
+
+                actionRow(icon: "sparkles", title: "Capture Event",
+                          subtitle: "Manually send a custom event to Session Replay.") {
+                    CoralogixRumManager.shared.sdk.captureEvent()
+                    toastMessage = "Event captured"
+                }
+
+                actionRow(icon: "waveform.circle", title: "Is Recording?",
+                          subtitle: "Check if Session Replay is currently recording.") {
+                    alertMessage = "isRecording: \(CoralogixRumManager.shared.sdk.isSRRecording())"
+                    showAlert = true
+                }
+
+                actionRow(icon: "checkmark.seal", title: "Is Initialized?",
+                          subtitle: "Check if the SDK has been initialized.") {
+                    alertMessage = "isInitialized: \(CoralogixRumManager.shared.sdk.isSRInitialized())"
+                    showAlert = true
+                }
+
+                actionRow(icon: "arrow.triangle.2.circlepath", title: "Update Session ID",
+                          subtitle: "Generate and apply a fresh session identifier.") {
+                    CoralogixRumManager.shared.sdk.update(sessionId: UUID().uuidString.lowercased())
+                    toastMessage = "Session ID updated"
+                }
+
+                actionRow(icon: "eye.slash", title: "Register Mask Region",
+                          subtitle: "Mask a region of the screen from recording.") {
+                    let id = "demoMaskRegion"
+                    CoralogixRumManager.shared.sdk.registerMaskRegion(id)
+                    alertMessage = "Registered mask region with id: \(id)"
+                    showAlert = true
+                }
+
+                actionRow(icon: "eye", title: "Unregister Mask Region",
+                          subtitle: "Remove the mask from the demo region.") {
+                    let id = "demoMaskRegion"
+                    CoralogixRumManager.shared.sdk.unregisterMaskRegion(id)
+                    alertMessage = "Unregistered mask region with id: \(id)"
+                    showAlert = true
+                }
+            }
+
+            Section("Credit Card Input") {
+                HStack {
+                    Text("Card Number")
+                        .font(.body)
+                    Spacer()
+                    TextField("0000 0000 0000 0000", text: $creditCardText)
+                        .keyboardType(.numberPad)
+                        .multilineTextAlignment(.trailing)
+                        .frame(maxWidth: 200)
+                }
+                .cxMask()
+            }
+
+            Section("Sample Images") {
+                ForEach(["creditcard.fill", "person.crop.rectangle", "photo.fill", "cart.fill", "star.fill"], id: \.self) { icon in
+                    HStack {
+                        Spacer()
+                        Image(systemName: icon)
+                            .resizable()
+                            .scaledToFit()
+                            .frame(height: 80)
+                            .foregroundColor(.accentColor)
+                        Spacer()
+                    }
+                    .frame(height: 150)
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+        .navigationTitle("Session Replay")
+        .navigationBarTitleDisplayMode(.inline)
+        .trackCXView(name: "Session Replay")
+        .alert("Alert", isPresented: $showAlert, actions: {
+            Button("OK", role: .cancel) {}
+        }, message: {
+            Text(alertMessage ?? "")
+        })
+        .toast(message: $toastMessage)
+    }
+
+    private func actionRow(icon: String, title: String, subtitle: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Label {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(title)
+                        .font(.body)
+                        .foregroundColor(.primary)
+                    Text(subtitle)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            } icon: {
+                Image(systemName: icon)
+                    .font(.system(size: 20, weight: .regular))
+                    .frame(width: 28)
+            }
+            .padding(.vertical, 2)
+        }
+    }
+}

--- a/Example/DemoAppSwiftUI/Toast.swift
+++ b/Example/DemoAppSwiftUI/Toast.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+struct ToastModifier: ViewModifier {
+    @Binding var message: String?
+
+    func body(content: Content) -> some View {
+        content
+            .overlay(alignment: .bottom) {
+                if let msg = message {
+                    Text(msg)
+                        .font(.subheadline)
+                        .foregroundColor(.white)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 20)
+                        .padding(.vertical, 12)
+                        .background(Color.black.opacity(0.8))
+                        .cornerRadius(12)
+                        .padding(.bottom, 32)
+                        .transition(.opacity.animation(.easeInOut(duration: 0.3)))
+                        .onAppear {
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                                withAnimation { message = nil }
+                            }
+                        }
+                }
+            }
+    }
+}
+
+extension View {
+    func toast(message: Binding<String?>) -> some View {
+        modifier(ToastModifier(message: message))
+    }
+}

--- a/Example/DemoAppSwiftUI/TracesExporterView.swift
+++ b/Example/DemoAppSwiftUI/TracesExporterView.swift
@@ -36,11 +36,13 @@ struct TracesExporterView: View {
         .navigationTitle("Traces Exporter")
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
-            if !spans.isEmpty {
-                ToolbarItemGroup(placement: .navigationBarTrailing) {
-                    Button { copyAll() } label: { Image(systemName: "doc.on.doc") }
-                    Button { clearSpans() } label: { Image(systemName: "trash").foregroundColor(.red) }
-                }
+            ToolbarItemGroup(placement: .navigationBarTrailing) {
+                Button { copyAll() } label: { Image(systemName: "doc.on.doc") }
+                    .opacity(spans.isEmpty ? 0 : 1)
+                    .disabled(spans.isEmpty)
+                Button { clearSpans() } label: { Image(systemName: "trash").foregroundColor(.red) }
+                    .opacity(spans.isEmpty ? 0 : 1)
+                    .disabled(spans.isEmpty)
             }
         }
         .trackCXView(name: "Traces Exporter")
@@ -99,32 +101,35 @@ struct TracesExporterView: View {
         .opacity(enabled ? 1 : 0.4)
     }
 
-    @ViewBuilder
     private var spanList: some View {
-        if spans.isEmpty {
-            VStack {
-                Spacer()
-                Text("No spans received yet.\nReinitialize the SDK and trigger a request.")
-                    .font(.subheadline)
-                    .foregroundColor(.secondary)
-                    .multilineTextAlignment(.center)
-                    .padding()
-                Spacer()
-            }
-        } else {
-            List {
-                ForEach($spans) { $span in
-                    spanRow(span: $span)
+        List {
+            if spans.isEmpty {
+                HStack {
+                    Spacer()
+                    Text("No spans received yet.\nReinitialize the SDK and trigger a request.")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                        .multilineTextAlignment(.center)
+                        .padding()
+                    Spacer()
+                }
+                .listRowBackground(Color.clear)
+            } else {
+                ForEach(spans, id: \.id) { span in
+                    spanRow(spanId: span.id)
                         .listRowInsets(EdgeInsets(top: 10, leading: 16, bottom: 10, trailing: 8))
                 }
             }
-            .listStyle(.plain)
         }
+        .listStyle(.plain)
     }
 
-    private func spanRow(span: Binding<SpanRow>) -> some View {
-        let s = span.wrappedValue
-        return VStack(alignment: .leading, spacing: 4) {
+    private func spanRow(spanId: UUID) -> some View {
+        guard let index = spans.firstIndex(where: { $0.id == spanId }) else {
+            return AnyView(EmptyView())
+        }
+        let s = spans[index]
+        return AnyView(VStack(alignment: .leading, spacing: 4) {
             HStack(spacing: 8) {
                 Text("  \(s.kindShort)  ")
                     .font(.system(size: 9, weight: .bold, design: .monospaced))
@@ -154,7 +159,8 @@ struct TracesExporterView: View {
                 }
 
                 Button {
-                    span.isExpanded.toggle()
+                    guard let i = spans.firstIndex(where: { $0.id == spanId }) else { return }
+                    spans[i].isExpanded.toggle()
                     updateState()
                 } label: {
                     Image(systemName: s.isExpanded ? "chevron.up" : "chevron.down")
@@ -180,7 +186,7 @@ struct TracesExporterView: View {
                     .padding(.top, 6)
                     .padding(.horizontal, 2)
             }
-        }
+        })
     }
 
     private func performReinitialize() {

--- a/Example/DemoAppSwiftUI/TracesExporterView.swift
+++ b/Example/DemoAppSwiftUI/TracesExporterView.swift
@@ -1,0 +1,279 @@
+import SwiftUI
+import Coralogix
+
+private struct SpanRow: Identifiable {
+    let id = UUID()
+    let name: String
+    let spanId: String
+    let traceId: String
+    let parentSpanId: String?
+    let kindShort: String
+    let receivedAt: Date
+    let prettyJson: String
+    var isExpanded = false
+
+    var timeString: String {
+        let f = DateFormatter()
+        f.dateFormat = "HH:mm:ss"
+        return f.string(from: receivedAt)
+    }
+
+    var isChild: Bool { parentSpanId != nil }
+}
+
+struct TracesExporterView: View {
+    @State private var isEnabled = TracesExporterState.isEnabled
+    @State private var spans: [SpanRow] = TracesExporterState.spans
+    @State private var toastMessage: String?
+    @State private var showReinitAlert = false
+
+    var body: some View {
+        VStack(spacing: 0) {
+            controlsPanel
+            Divider()
+            spanList
+        }
+        .navigationTitle("Traces Exporter")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            if !spans.isEmpty {
+                ToolbarItemGroup(placement: .navigationBarTrailing) {
+                    Button { copyAll() } label: { Image(systemName: "doc.on.doc") }
+                    Button { clearSpans() } label: { Image(systemName: "trash").foregroundColor(.red) }
+                }
+            }
+        }
+        .trackCXView(name: "Traces Exporter")
+        .alert("Reinitialize SDK", isPresented: $showReinitAlert) {
+            Button("Cancel", role: .cancel) {}
+            Button("Reinitialize") { performReinitialize() }
+        } message: {
+            Text("Shuts down the current SDK and reinitializes it with the tracesExporter callback enabled.")
+        }
+        .toast(message: $toastMessage)
+    }
+
+    private var controlsPanel: some View {
+        VStack(spacing: 6) {
+            Text(isEnabled
+                 ? "✅ Traces Exporter enabled — \(spans.count) span(s) received"
+                 : "⚠️ Reinitialize SDK to enable the Traces Exporter"
+            )
+            .font(.footnote)
+            .foregroundColor(isEnabled ? .secondary : .orange)
+            .multilineTextAlignment(.center)
+
+            HStack(spacing: 0) {
+                controlButton(icon: "arrow.clockwise.circle", title: "Reinitialize SDK\nwith Traces Exporter",
+                              enabled: !isEnabled) {
+                    showReinitAlert = true
+                }
+                controlButton(icon: "network", title: "Trigger Network\nRequest",
+                              enabled: isEnabled) {
+                    NetworkSim.sendSuccesfullRequest()
+                    toastMessage = "Network request sent"
+                }
+                controlButton(icon: "point.3.connected.trianglepath.dotted", title: "Trigger Custom\nSpan",
+                              enabled: isEnabled) {
+                    triggerCustomSpan()
+                }
+            }
+        }
+        .padding(.vertical, 10)
+        .padding(.horizontal, 16)
+    }
+
+    private func controlButton(icon: String, title: String, enabled: Bool, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            VStack(spacing: 3) {
+                Image(systemName: icon)
+                    .font(.system(size: 22))
+                Text(title)
+                    .font(.caption2)
+                    .multilineTextAlignment(.center)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 6)
+        }
+        .disabled(!enabled)
+        .opacity(enabled ? 1 : 0.4)
+    }
+
+    @ViewBuilder
+    private var spanList: some View {
+        if spans.isEmpty {
+            VStack {
+                Spacer()
+                Text("No spans received yet.\nReinitialize the SDK and trigger a request.")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                    .multilineTextAlignment(.center)
+                    .padding()
+                Spacer()
+            }
+        } else {
+            List {
+                ForEach($spans) { $span in
+                    spanRow(span: $span)
+                        .listRowInsets(EdgeInsets(top: 10, leading: 16, bottom: 10, trailing: 8))
+                }
+            }
+            .listStyle(.plain)
+        }
+    }
+
+    private func spanRow(span: Binding<SpanRow>) -> some View {
+        let s = span.wrappedValue
+        return VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 8) {
+                Text("  \(s.kindShort)  ")
+                    .font(.system(size: 9, weight: .bold, design: .monospaced))
+                    .foregroundColor(.white)
+                    .padding(.horizontal, 2)
+                    .background(s.isChild ? Color.green : Color.indigo)
+                    .cornerRadius(6)
+                    .frame(minWidth: 52)
+
+                Text(s.name)
+                    .font(.subheadline)
+                    .lineLimit(1)
+                    .layoutPriority(1)
+
+                Spacer()
+
+                Text(s.timeString)
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+
+                Button {
+                    UIPasteboard.general.string = s.prettyJson
+                    toastMessage = "Copied"
+                } label: {
+                    Image(systemName: "doc.on.doc")
+                        .font(.caption)
+                }
+
+                Button {
+                    span.isExpanded.toggle()
+                    updateState()
+                } label: {
+                    Image(systemName: s.isExpanded ? "chevron.up" : "chevron.down")
+                        .font(.caption)
+                }
+            }
+
+            Text("spanId: \(s.spanId)")
+                .font(.system(size: 10, design: .monospaced))
+                .foregroundColor(.secondary)
+
+            let tracePrefix = s.traceId.count > 16 ? String(s.traceId.prefix(16)) + "…" : s.traceId
+            let traceText = s.parentSpanId.map { "traceId: \(tracePrefix)  ↑ \($0)" } ?? "traceId: \(tracePrefix)"
+            Text(traceText)
+                .font(.system(size: 10, design: .monospaced))
+                .foregroundColor(Color(.tertiaryLabel))
+
+            if s.isExpanded {
+                Divider()
+                Text(s.prettyJson)
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundColor(.secondary)
+                    .padding(.top, 6)
+                    .padding(.horizontal, 2)
+            }
+        }
+    }
+
+    private func performReinitialize() {
+        CoralogixRumManager.shared.sdk.shutdown()
+        let options = CoralogixExporterOptions(
+            coralogixDomain: .EU2,
+            userContext: UserContext(userId: "traces-exporter-test", userName: "Test User",
+                                     userEmail: "test@example.com", userMetadata: ["test": "tracesExporter"]),
+            environment: "PROD",
+            application: "DemoApp-iOS-TracesExporter",
+            version: "1",
+            publicKey: Envs.PUBLIC_KEY.rawValue,
+            instrumentations: [.mobileVitals: true, .custom: true, .errors: true,
+                                .userActions: true, .network: true, .anr: true, .lifeCycle: true],
+            collectIPData: true,
+            traceParentInHeader: ["enable": true],
+            tracesExporter: { data in
+                let now = Date()
+                var newRows: [SpanRow] = []
+                for resourceSpan in data.tracesData.resourceSpans {
+                    for scopeSpan in resourceSpan.scopeSpans {
+                        for span in scopeSpan.spans {
+                            let kind: String
+                            switch span.kind {
+                            case .client:     kind = "CLIENT"
+                            case .server:     kind = "SERVER"
+                            case .internal:   kind = "INTERNAL"
+                            case .producer:   kind = "PRODUCER"
+                            case .consumer:   kind = "CONSUMER"
+                            case .unspecified: kind = "SPAN"
+                            }
+                            let json: String
+                            if let d = try? JSONEncoder().encode(span),
+                               let obj = try? JSONSerialization.jsonObject(with: d),
+                               let pretty = try? JSONSerialization.data(withJSONObject: obj, options: [.prettyPrinted, .sortedKeys]),
+                               let str = String(data: pretty, encoding: .utf8) {
+                                json = str
+                            } else {
+                                json = span.spanId
+                            }
+                            newRows.append(SpanRow(name: span.name, spanId: span.spanId,
+                                                   traceId: span.traceId, parentSpanId: span.parentSpanId,
+                                                   kindShort: kind, receivedAt: now, prettyJson: json))
+                        }
+                    }
+                }
+                guard !newRows.isEmpty else { return }
+                DispatchQueue.main.async {
+                    TracesExporterState.spans.insert(contentsOf: newRows.reversed(), at: 0)
+                    self.spans = TracesExporterState.spans
+                }
+            },
+            debug: true
+        )
+        CoralogixRumManager.shared.reinitialize(with: options)
+        TracesExporterState.isEnabled = true
+        isEnabled = true
+        toastMessage = "SDK reinitialized with Traces Exporter"
+    }
+
+    private func triggerCustomSpan() {
+        let rum = CoralogixRumManager.shared.sdk
+        guard rum.isInitialized else { toastMessage = "SDK not initialized"; return }
+        guard let tracer = rum.getCustomTracer() else { toastMessage = "Failed to get custom tracer"; return }
+        guard let global = tracer.startGlobalSpan(name: "traces-exporter-test.global",
+                                                   labels: ["test.source": "TracesExporterView"]) else {
+            toastMessage = "startGlobalSpan returned nil"
+            return
+        }
+        let child = global.startCustomSpan(name: "traces-exporter-test.child")
+        child.setAttribute(key: "test.step", value: "demo")
+        child.endSpan()
+        global.endSpan()
+        toastMessage = "Custom span triggered"
+    }
+
+    private func copyAll() {
+        let all = spans.map(\.prettyJson).joined(separator: "\n\n---\n\n")
+        UIPasteboard.general.string = all
+        toastMessage = "All spans copied"
+    }
+
+    private func clearSpans() {
+        TracesExporterState.spans = []
+        spans = []
+    }
+
+    private func updateState() {
+        TracesExporterState.spans = spans
+    }
+}
+
+private enum TracesExporterState {
+    static var isEnabled = false
+    static var spans: [SpanRow] = []
+}

--- a/Example/DemoAppSwiftUI/UserActionsView.swift
+++ b/Example/DemoAppSwiftUI/UserActionsView.swift
@@ -87,7 +87,7 @@ struct UserActionsView: View {
         .navigationTitle("User Actions")
         .navigationBarTitleDisplayMode(.large)
         .trackCXView(name: "User Actions")
-        .fullScreenCover(isPresented: $showModal) {
+        .sheet(isPresented: $showModal) {
             SimpleModalView()
         }
         .alert("Alert", isPresented: $showAlert) {
@@ -222,7 +222,7 @@ struct PageCarouselView: View {
             }
         }
         .tabViewStyle(.page(indexDisplayMode: .always))
-        .indexViewStyle(.page(backgroundDisplayMode: .always))
+        .indexViewStyle(.page())
         .navigationTitle("Page Controller")
         .navigationBarTitleDisplayMode(.inline)
         .trackCXView(name: "Page Controller")

--- a/Example/DemoAppSwiftUI/UserActionsView.swift
+++ b/Example/DemoAppSwiftUI/UserActionsView.swift
@@ -9,6 +9,22 @@ struct UserActionsView: View {
 
     var body: some View {
         List {
+            Section("Swipe Demo") {
+                VStack(spacing: 6) {
+                    Image(systemName: "antenna.radiowaves.left.and.right")
+                        .font(.system(size: 36, weight: .medium))
+                        .foregroundColor(.accentColor)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 12)
+                        .trackCXSwipeAction()
+                    Text("Swipe the icon to emit a RUM swipe span")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .frame(maxWidth: .infinity)
+                        .padding(.bottom, 8)
+                }
+            }
+
             Section {
                 Button("Log In (resolveTargetName demo)") {
                     toastMessage = "Login tapped — target_element will be 'Login Button' in RUM"

--- a/Example/DemoAppSwiftUI/UserActionsView.swift
+++ b/Example/DemoAppSwiftUI/UserActionsView.swift
@@ -118,7 +118,7 @@ struct UserActionsView: View {
         .padding(.vertical, 2)
     }
 
-    @objc private func triggerBadAccessCrash() {
+    private func triggerBadAccessCrash() {
         let pointer = UnsafeMutablePointer<Int>(bitPattern: 0x16)!
         pointer.pointee = 42
     }

--- a/Example/DemoAppSwiftUI/UserActionsView.swift
+++ b/Example/DemoAppSwiftUI/UserActionsView.swift
@@ -1,0 +1,232 @@
+import SwiftUI
+
+struct UserActionsView: View {
+    @State private var toastMessage: String?
+    @State private var showModal = false
+    @State private var showAlert = false
+    @State private var showCrashBadAccessConfirm = false
+    @State private var showCrashFatalConfirm = false
+
+    var body: some View {
+        List {
+            Section {
+                Button("Log In (resolveTargetName demo)") {
+                    toastMessage = "Login tapped — target_element will be 'Login Button' in RUM"
+                }
+                .accessibilityIdentifier("loginButton")
+                .trackCXTapAction(name: "Log In")
+            }
+
+            Section {
+                Button {
+                    showModal = true
+                } label: {
+                    demoRow(icon: "rectangle.on.rectangle", title: "Modal Presentation",
+                            subtitle: "Track full-screen modals and presentation flows")
+                }
+                .trackCXTapAction(name: "Modal Presentation")
+
+                NavigationLink(destination: SegmentedGridView()) {
+                    demoRow(icon: "square.grid.2x2", title: "Segmented Collection",
+                            subtitle: "Monitor segmented controls & collection interactions")
+                }
+
+                NavigationLink(destination: PageCarouselView()) {
+                    demoRow(icon: "rectangle.portrait.on.rectangle.portrait", title: "Page Controller",
+                            subtitle: "Capture page swipes and transitions")
+                }
+
+                Button {
+                    showAlert = true
+                } label: {
+                    demoRow(icon: "exclamationmark.triangle", title: "Alert View",
+                            subtitle: "Instrument alerts and user confirmations")
+                }
+                .trackCXTapAction(name: "Alert View")
+
+                Button {
+                    toastMessage = "Tapped — but text is suppressed in RUM (shouldSendText → false)"
+                } label: {
+                    demoRow(icon: "eye.slash", title: "Sensitive Label (text suppressed)",
+                            subtitle: "Tap this — shouldSendText returns false, so no text is captured in RUM")
+                }
+                .accessibilityIdentifier("sensitiveLabel")
+
+                Button {
+                    showCrashBadAccessConfirm = true
+                } label: {
+                    demoRow(icon: "xmark.octagon.fill", title: "Simulate Crash: Bad Access",
+                            subtitle: "Trigger an EXC_BAD_ACCESS crash for testing")
+                }
+
+                Button {
+                    showCrashFatalConfirm = true
+                } label: {
+                    demoRow(icon: "xmark.octagon", title: "Simulate Crash: Fatal Error",
+                            subtitle: "Trigger a fatalError() crash for testing")
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+        .navigationTitle("User Actions")
+        .navigationBarTitleDisplayMode(.large)
+        .trackCXView(name: "User Actions")
+        .fullScreenCover(isPresented: $showModal) {
+            SimpleModalView()
+        }
+        .alert("Alert", isPresented: $showAlert) {
+            Button("OK") { toastMessage = "Alert dismissed" }
+        } message: {
+            Text("I'm an alert")
+        }
+        .alert("⚠️ Simulate Crash", isPresented: $showCrashBadAccessConfirm) {
+            Button("Cancel", role: .cancel) { toastMessage = "Crash cancelled" }
+            Button("Crash Now", role: .destructive) {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                    triggerBadAccessCrash()
+                }
+            }
+        } message: {
+            Text("This will crash the app to test crash reporting. Continue?")
+        }
+        .alert("⚠️ Simulate Fatal Error Crash", isPresented: $showCrashFatalConfirm) {
+            Button("Cancel", role: .cancel) { toastMessage = "Crash cancelled" }
+            Button("Crash Now", role: .destructive) {
+                fatalError("Simulated crash (fatalError)")
+            }
+        } message: {
+            Text("This will crash the app using fatalError(). Continue?")
+        }
+        .toast(message: $toastMessage)
+    }
+
+    private func demoRow(icon: String, title: String, subtitle: String) -> some View {
+        Label {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.body)
+                    .foregroundColor(.primary)
+                Text(subtitle)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+        } icon: {
+            Image(systemName: icon)
+                .font(.system(size: 20, weight: .medium))
+                .frame(width: 28)
+        }
+        .padding(.vertical, 2)
+    }
+
+    @objc private func triggerBadAccessCrash() {
+        let pointer = UnsafeMutablePointer<Int>(bitPattern: 0x16)!
+        pointer.pointee = 42
+    }
+}
+
+struct SimpleModalView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Text("Modal View")
+                .font(.title2)
+                .fontWeight(.semibold)
+            Text("This modal was presented full-screen.")
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+            Button("Dismiss") { dismiss() }
+                .buttonStyle(.borderedProminent)
+        }
+        .padding(32)
+        .trackCXView(name: "Modal View")
+    }
+}
+
+struct SegmentedGridView: View {
+    @State private var selectedSegment = 0
+
+    private let segments = ["Animals", "Plants", "Objects"]
+    private let data: [[String]] = [
+        ["🐶", "🐱", "🐭", "🐹", "🐰", "🦊", "🐻", "🐼", "🐨", "🐯", "🦁", "🐮"],
+        ["🌱", "🌿", "🍀", "🌺", "🌸", "🌼", "🌻", "🌹", "🌷", "🍁", "🍂", "🎋"],
+        ["⚽️", "🏀", "🏈", "⚾️", "🎾", "🏐", "🏉", "🎱", "🏓", "🏸", "🥊", "🎯"]
+    ]
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Picker("Category", selection: $selectedSegment) {
+                ForEach(0..<segments.count, id: \.self) { i in
+                    Text(segments[i]).tag(i)
+                }
+            }
+            .pickerStyle(.segmented)
+            .padding()
+
+            ScrollView {
+                LazyVGrid(columns: Array(repeating: GridItem(.flexible()), count: 4), spacing: 16) {
+                    ForEach(data[selectedSegment], id: \.self) { item in
+                        Text(item)
+                            .font(.largeTitle)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 8)
+                            .background(Color(.secondarySystemGroupedBackground))
+                            .cornerRadius(8)
+                    }
+                }
+                .padding()
+            }
+        }
+        .navigationTitle("Segmented Collection")
+        .navigationBarTitleDisplayMode(.inline)
+        .trackCXView(name: "Segmented Collection")
+    }
+}
+
+struct PageCarouselView: View {
+    @State private var currentPage = 0
+
+    private let pages: [(title: String, subtitle: String, icon: String, color: Color)] = [
+        ("Overview", "Total sessions & key metrics for your app", "chart.bar.fill", .indigo),
+        ("Sessions", "Recent user sessions and replay data", "person.2.fill", .teal),
+        ("Performance", "FPS, CPU & memory vitals", "gauge.medium", .orange)
+    ]
+
+    var body: some View {
+        TabView(selection: $currentPage) {
+            ForEach(0..<pages.count, id: \.self) { index in
+                let page = pages[index]
+                ZStack {
+                    LinearGradient(
+                        colors: [page.color.opacity(0.8), page.color.opacity(0.4)],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                    VStack(spacing: 16) {
+                        Image(systemName: page.icon)
+                            .font(.system(size: 56, weight: .medium))
+                            .foregroundColor(.white)
+                        Text(page.title)
+                            .font(.title)
+                            .fontWeight(.bold)
+                            .foregroundColor(.white)
+                        Text(page.subtitle)
+                            .font(.subheadline)
+                            .foregroundColor(.white.opacity(0.85))
+                            .multilineTextAlignment(.center)
+                            .padding(.horizontal, 32)
+                    }
+                }
+                .cornerRadius(20)
+                .padding(.horizontal, 24)
+                .tag(index)
+            }
+        }
+        .tabViewStyle(.page(indexDisplayMode: .always))
+        .indexViewStyle(.page(backgroundDisplayMode: .always))
+        .navigationTitle("Page Controller")
+        .navigationBarTitleDisplayMode(.inline)
+        .trackCXView(name: "Page Controller")
+    }
+}

--- a/Example/DemoAppSwiftUI/UserActionsView.swift
+++ b/Example/DemoAppSwiftUI/UserActionsView.swift
@@ -3,9 +3,12 @@ import SwiftUI
 struct UserActionsView: View {
     @State private var toastMessage: String?
     @State private var showModal = false
-    @State private var showAlert = false
-    @State private var showCrashBadAccessConfirm = false
-    @State private var showCrashFatalConfirm = false
+    @State private var activeAlert: AlertType?
+
+    private enum AlertType: Identifiable {
+        case alert, crashBadAccess, crashFatal
+        var id: Self { self }
+    }
 
     var body: some View {
         List {
@@ -53,7 +56,7 @@ struct UserActionsView: View {
                 }
 
                 Button {
-                    showAlert = true
+                    activeAlert = .alert
                 } label: {
                     DemoRow(icon: "exclamationmark.triangle", title: "Alert View",
                             subtitle: "Instrument alerts and user confirmations")
@@ -69,14 +72,14 @@ struct UserActionsView: View {
                 .accessibilityIdentifier("sensitiveLabel")
 
                 Button {
-                    showCrashBadAccessConfirm = true
+                    activeAlert = .crashBadAccess
                 } label: {
                     DemoRow(icon: "xmark.octagon.fill", title: "Simulate Crash: Bad Access",
                             subtitle: "Trigger an EXC_BAD_ACCESS crash for testing")
                 }
 
                 Button {
-                    showCrashFatalConfirm = true
+                    activeAlert = .crashFatal
                 } label: {
                     DemoRow(icon: "xmark.octagon", title: "Simulate Crash: Fatal Error",
                             subtitle: "Trigger a fatalError() crash for testing")
@@ -90,28 +93,35 @@ struct UserActionsView: View {
         .sheet(isPresented: $showModal) {
             SimpleModalView()
         }
-        .alert("Alert", isPresented: $showAlert) {
-            Button("OK") { toastMessage = "Alert dismissed" }
-        } message: {
-            Text("I'm an alert")
-        }
-        .alert("⚠️ Simulate Crash", isPresented: $showCrashBadAccessConfirm) {
-            Button("Cancel", role: .cancel) { toastMessage = "Crash cancelled" }
-            Button("Crash Now", role: .destructive) {
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                    triggerBadAccessCrash()
-                }
+        .alert(item: $activeAlert) { type in
+            switch type {
+            case .alert:
+                return Alert(
+                    title: Text("Alert"),
+                    message: Text("I'm an alert"),
+                    dismissButton: .default(Text("OK")) { toastMessage = "Alert dismissed" }
+                )
+            case .crashBadAccess:
+                return Alert(
+                    title: Text("⚠️ Simulate Crash"),
+                    message: Text("This will crash the app to test crash reporting. Continue?"),
+                    primaryButton: .destructive(Text("Crash Now")) {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                            triggerBadAccessCrash()
+                        }
+                    },
+                    secondaryButton: .cancel(Text("Cancel")) { toastMessage = "Crash cancelled" }
+                )
+            case .crashFatal:
+                return Alert(
+                    title: Text("⚠️ Simulate Fatal Error Crash"),
+                    message: Text("This will crash the app using fatalError(). Continue?"),
+                    primaryButton: .destructive(Text("Crash Now")) {
+                        fatalError("Simulated crash (fatalError)")
+                    },
+                    secondaryButton: .cancel(Text("Cancel")) { toastMessage = "Crash cancelled" }
+                )
             }
-        } message: {
-            Text("This will crash the app to test crash reporting. Continue?")
-        }
-        .alert("⚠️ Simulate Fatal Error Crash", isPresented: $showCrashFatalConfirm) {
-            Button("Cancel", role: .cancel) { toastMessage = "Crash cancelled" }
-            Button("Crash Now", role: .destructive) {
-                fatalError("Simulated crash (fatalError)")
-            }
-        } message: {
-            Text("This will crash the app using fatalError(). Continue?")
         }
         .toast(message: $toastMessage)
     }

--- a/Example/DemoAppSwiftUI/UserActionsView.swift
+++ b/Example/DemoAppSwiftUI/UserActionsView.swift
@@ -37,25 +37,25 @@ struct UserActionsView: View {
                 Button {
                     showModal = true
                 } label: {
-                    demoRow(icon: "rectangle.on.rectangle", title: "Modal Presentation",
+                    DemoRow(icon: "rectangle.on.rectangle", title: "Modal Presentation",
                             subtitle: "Track full-screen modals and presentation flows")
                 }
                 .trackCXTapAction(name: "Modal Presentation")
 
                 NavigationLink(destination: SegmentedGridView()) {
-                    demoRow(icon: "square.grid.2x2", title: "Segmented Collection",
+                    DemoRow(icon: "square.grid.2x2", title: "Segmented Collection",
                             subtitle: "Monitor segmented controls & collection interactions")
                 }
 
                 NavigationLink(destination: PageCarouselView()) {
-                    demoRow(icon: "rectangle.portrait.on.rectangle.portrait", title: "Page Controller",
+                    DemoRow(icon: "rectangle.portrait.on.rectangle.portrait", title: "Page Controller",
                             subtitle: "Capture page swipes and transitions")
                 }
 
                 Button {
                     showAlert = true
                 } label: {
-                    demoRow(icon: "exclamationmark.triangle", title: "Alert View",
+                    DemoRow(icon: "exclamationmark.triangle", title: "Alert View",
                             subtitle: "Instrument alerts and user confirmations")
                 }
                 .trackCXTapAction(name: "Alert View")
@@ -63,7 +63,7 @@ struct UserActionsView: View {
                 Button {
                     toastMessage = "Tapped — but text is suppressed in RUM (shouldSendText → false)"
                 } label: {
-                    demoRow(icon: "eye.slash", title: "Sensitive Label (text suppressed)",
+                    DemoRow(icon: "eye.slash", title: "Sensitive Label (text suppressed)",
                             subtitle: "Tap this — shouldSendText returns false, so no text is captured in RUM")
                 }
                 .accessibilityIdentifier("sensitiveLabel")
@@ -71,14 +71,14 @@ struct UserActionsView: View {
                 Button {
                     showCrashBadAccessConfirm = true
                 } label: {
-                    demoRow(icon: "xmark.octagon.fill", title: "Simulate Crash: Bad Access",
+                    DemoRow(icon: "xmark.octagon.fill", title: "Simulate Crash: Bad Access",
                             subtitle: "Trigger an EXC_BAD_ACCESS crash for testing")
                 }
 
                 Button {
                     showCrashFatalConfirm = true
                 } label: {
-                    demoRow(icon: "xmark.octagon", title: "Simulate Crash: Fatal Error",
+                    DemoRow(icon: "xmark.octagon", title: "Simulate Crash: Fatal Error",
                             subtitle: "Trigger a fatalError() crash for testing")
                 }
             }
@@ -114,24 +114,6 @@ struct UserActionsView: View {
             Text("This will crash the app using fatalError(). Continue?")
         }
         .toast(message: $toastMessage)
-    }
-
-    private func demoRow(icon: String, title: String, subtitle: String) -> some View {
-        Label {
-            VStack(alignment: .leading, spacing: 2) {
-                Text(title)
-                    .font(.body)
-                    .foregroundColor(.primary)
-                Text(subtitle)
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-            }
-        } icon: {
-            Image(systemName: icon)
-                .font(.system(size: 20, weight: .medium))
-                .frame(width: 28)
-        }
-        .padding(.vertical, 2)
     }
 
     private func triggerBadAccessCrash() {

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,0 +1,14 @@
+platform :ios, '13.0'
+use_frameworks!
+
+target 'DemoAppSwift' do
+  pod 'Alamofire'
+  pod 'AFNetworking'
+  pod 'SDWebImage'
+end
+
+target 'DemoAppSwiftUI' do
+  pod 'Alamofire'
+  pod 'AFNetworking'
+  pod 'SDWebImage'
+end

--- a/Example/Shared/SimulateFolder/NetworkSim.swift
+++ b/Example/Shared/SimulateFolder/NetworkSim.swift
@@ -82,18 +82,10 @@ class NetworkSim {
     
     static func sendAFNetworkingRequest() {
         let manager = AFHTTPSessionManager()
-        
-        // Set response serializer (JSON in this case)
         manager.responseSerializer = AFJSONResponseSerializer()
-        
-        // Perform GET request
         manager.get(url, parameters: nil, headers: nil, progress: nil, success: { task, responseObject in
-            // Success block
-            if let response = responseObject {
-                print("Response: \(response)")
-            }
+            if let response = responseObject { print("Response: \(response)") }
         }) { task, error in
-            // Failure block
             print("Error: \(error.localizedDescription)")
         }
     }
@@ -197,42 +189,29 @@ class NetworkSim {
     }
     
     static func succesfullAlamofire() {
-        // Create a request using Alamofire
-        AF.request(url, method: .get)
-            .validate()  // Validates the response status code
-            .responseData { response in
-                switch response.result {
-                case .success(let data):
-                    do {
-                        let json = try JSONSerialization.jsonObject(with: data, options: [])
-                        print("Request Successful")
-                        print("Response Data: \(json)")
-                    } catch {
-                        print("JSON Parsing Error: \(error)")
-                    }
-                case .failure(let error):
-                    print("Request failed with error: \(error)")
+        AF.request(url, method: .get).validate().responseData { response in
+            switch response.result {
+            case .success(let data):
+                if let json = try? JSONSerialization.jsonObject(with: data, options: []) {
+                    print("Request Successful\nResponse Data: \(json)")
                 }
+            case .failure(let error):
+                print("Request failed with error: \(error)")
             }
+        }
     }
-    
+
     static func failureAlamofire() {
-        AF.request(errorUrl, method: .get)
-            .validate()  // Validates the response status code
-            .responseData { response in
-                switch response.result {
-                case .success(let data):
-                    do {
-                        let json = try JSONSerialization.jsonObject(with: data, options: [])
-                        print("Request Successful")
-                        print("Response Data: \(json)")
-                    } catch {
-                        print("JSON Parsing Error: \(error)")
-                    }
-                case .failure(let error):
-                    print("Request failed with error: \(error)")
+        AF.request(errorUrl, method: .get).validate().responseData { response in
+            switch response.result {
+            case .success(let data):
+                if let json = try? JSONSerialization.jsonObject(with: data, options: []) {
+                    print("Request Successful\nResponse Data: \(json)")
                 }
+            case .failure(let error):
+                print("Request failed with error: \(error)")
             }
+        }
     }
     
     static func createSampleFile() -> URL? {
@@ -275,7 +254,6 @@ class NetworkSim {
             return
         }
         
-        // Start upload
         AF.upload(multipartFormData: { multipartFormData in
             multipartFormData.append(fileURL, withName: "file", fileName: "sample.txt", mimeType: "text/plain")
         }, to: url)
@@ -298,19 +276,12 @@ class NetworkSim {
     static func downloadImage() {
         let urlString = "https://www.google.com/url?sa=i&url=https%3A%2F%2Funikal.az%2Fnews%2F490204%2Ftramp-meshur-aparicinin-verilisini-baglatdirir&psig=AOvVaw1NJs_lRnGqkjnhDu8j3AOd&ust=1753266023938000&source=images&cd=vfe&opi=89978449&ved=2ahUKEwjIstmFn9COAxX0UqQEHfprJpkQjRx6BAgAEBo"
         guard let url = URL(string: urlString) else { return }
-        
         DispatchQueue.global(qos: .background).async {
-            SDWebImageDownloader.shared.downloadImage(
-                with: url,
-                options: [],
-                progress: nil
-            ) { image, data, error, finished in
+            SDWebImageDownloader.shared.downloadImage(with: url, options: [], progress: nil) { image, _, _, finished in
                 guard let image = image, finished else { return }
                 DispatchQueue.main.async {
                     let imageView = UIImageView(image: image)
-                    if imageView.image != nil {
-                        print("Image downloaded")
-                    }
+                    if imageView.image != nil { print("Image downloaded") }
                 }
             }
         }

--- a/Tests/CoralogixRumTests/InteractionContextTests.swift
+++ b/Tests/CoralogixRumTests/InteractionContextTests.swift
@@ -780,4 +780,103 @@ final class InteractionContextTests: XCTestCase {
         XCTAssertNil(context.scrollDirection)
         XCTAssertNil(context.attributes)
     }
+
+    // MARK: - SwipeDetectorView.Coordinator — direction mapping
+
+    /// Stub UIPanGestureRecognizer that returns fixed values for location(in:) and translation(in:).
+    private final class StubPanGesture: UIPanGestureRecognizer {
+        var stubLocation: CGPoint = .zero
+        var stubTranslation: CGPoint = .zero
+        private var _stubState: UIGestureRecognizer.State = .ended
+        private let stubView: UIView = UIView()
+
+        var stubState: UIGestureRecognizer.State {
+            get { _stubState }
+            set { _stubState = newValue }
+        }
+        override var state: UIGestureRecognizer.State {
+            get { _stubState }
+            set { _stubState = newValue }
+        }
+        override var view: UIView? { stubView }
+        override func location(in view: UIView?) -> CGPoint { stubLocation }
+        override func translation(in view: UIView?) -> CGPoint { stubTranslation }
+    }
+
+    private func makeCoordinatorAndObserve(
+        location: CGPoint,
+        translation: CGPoint,
+        state: UIGestureRecognizer.State = .ended,
+        block: (TouchEvent?) -> Void
+    ) {
+        let coordinator = SwipeDetectorView.Coordinator()
+        let gesture = StubPanGesture()
+        gesture.stubLocation = location
+        gesture.stubTranslation = translation
+        gesture.stubState = state
+
+        var received: TouchEvent?
+        let token = NotificationCenter.default.addObserver(
+            forName: .cxRumNotificationUserActions,
+            object: nil,
+            queue: .main
+        ) { note in
+            received = note.object as? TouchEvent
+        }
+        coordinator.handlePan(gesture)
+        NotificationCenter.default.removeObserver(token)
+        block(received)
+    }
+
+    func testSwipeDetector_downSwipe_postsSwipeNotification() {
+        makeCoordinatorAndObserve(location: CGPoint(x: 100, y: 150), translation: CGPoint(x: 0, y: 50)) { event in
+            XCTAssertNotNil(event, "A 50 pt downward pan must post a swipe notification")
+            XCTAssertEqual(event?.eventType, .swipe)
+            XCTAssertEqual(event?.scrollDirection, .down)
+        }
+    }
+
+    func testSwipeDetector_upSwipe_directionIsUp() {
+        makeCoordinatorAndObserve(location: CGPoint(x: 100, y: 100), translation: CGPoint(x: 0, y: -50)) { event in
+            XCTAssertEqual(event?.scrollDirection, .up)
+        }
+    }
+
+    func testSwipeDetector_leftSwipe_directionIsLeft() {
+        makeCoordinatorAndObserve(location: CGPoint(x: 50, y: 100), translation: CGPoint(x: -50, y: 0)) { event in
+            XCTAssertEqual(event?.scrollDirection, .left)
+        }
+    }
+
+    func testSwipeDetector_rightSwipe_directionIsRight() {
+        makeCoordinatorAndObserve(location: CGPoint(x: 150, y: 100), translation: CGPoint(x: 50, y: 0)) { event in
+            XCTAssertEqual(event?.scrollDirection, .right)
+        }
+    }
+
+    func testSwipeDetector_belowThreshold_noNotification() {
+        makeCoordinatorAndObserve(location: CGPoint(x: 100, y: 115), translation: CGPoint(x: 0, y: 15)) { event in
+            XCTAssertNil(event, "A 15 pt pan is below the 20 pt threshold — no swipe notification should fire")
+        }
+    }
+
+    func testSwipeDetector_exactThreshold_postsNotification() {
+        makeCoordinatorAndObserve(
+            location: CGPoint(x: 100, y: 100 + ScrollTracker.threshold),
+            translation: CGPoint(x: 0, y: ScrollTracker.threshold)
+        ) { event in
+            XCTAssertNotNil(event, "Movement exactly at threshold must fire a swipe event")
+            XCTAssertEqual(event?.scrollDirection, .down)
+        }
+    }
+
+    func testSwipeDetector_nonEndedState_noNotification() {
+        makeCoordinatorAndObserve(
+            location: CGPoint(x: 100, y: 150),
+            translation: CGPoint(x: 0, y: 50),
+            state: .changed
+        ) { event in
+            XCTAssertNil(event, "handlePan must only fire for state == .ended")
+        }
+    }
 }

--- a/Tests/CoralogixRumTests/InteractionContextTests.swift
+++ b/Tests/CoralogixRumTests/InteractionContextTests.swift
@@ -790,10 +790,6 @@ final class InteractionContextTests: XCTestCase {
         private var _stubState: UIGestureRecognizer.State = .ended
         private let stubView: UIView = UIView()
 
-        var stubState: UIGestureRecognizer.State {
-            get { _stubState }
-            set { _stubState = newValue }
-        }
         override var state: UIGestureRecognizer.State {
             get { _stubState }
             set { _stubState = newValue }
@@ -813,7 +809,7 @@ final class InteractionContextTests: XCTestCase {
         let gesture = StubPanGesture()
         gesture.stubLocation = location
         gesture.stubTranslation = translation
-        gesture.stubState = state
+        gesture.state = state
 
         var received: TouchEvent?
         let token = NotificationCenter.default.addObserver(

--- a/Tests/CoralogixRumTests/InteractionContextTests.swift
+++ b/Tests/CoralogixRumTests/InteractionContextTests.swift
@@ -819,7 +819,7 @@ final class InteractionContextTests: XCTestCase {
         let token = NotificationCenter.default.addObserver(
             forName: .cxRumNotificationUserActions,
             object: nil,
-            queue: .main
+            queue: nil
         ) { note in
             received = note.object as? TouchEvent
         }


### PR DESCRIPTION
# User description
## Summary

- **CX-33282**: Adds `trackCXSwipeAction()` SwiftUI modifier that detects `DragGesture`-based swipes and emits a `user-interaction` span with `event_name = "swipe"` and `scroll_direction` (up/down/left/right)
- **DemoAppSwiftUI**: Full UI rebuild to match `DemoAppSwift` — replaces flat button list with hierarchical navigation across 10 dedicated screens (Network, Error, SDK, Custom Spans, User Actions, Session Replay, Clock, Schema Validation, Mask UI, Traces Exporter)

## Implementation details

**Swipe detection (`Coralogix/Sources/Actions/SwiftUI/SwiftUIActionModifier.swift`)**
- `SwipeDetectorGestureRecognizer` — `UIPanGestureRecognizer` subclass; calls `ScrollTracker.discardTouch` in `touchesEnded` to prevent duplicate scroll spans
- `SwipeDetectorView` — `UIViewRepresentable` overlay; fires `.cxRumNotificationUserActions` with a `TouchEvent(.swipe, scrollDirection:)` on gesture end
- `CXSwipeModifier` / `trackCXSwipeAction()` — public SwiftUI API, mirrors `trackCXTapAction()`

**DemoAppSwiftUI screens**
- `ContentView` — session-ID card + 10 nav rows
- `NetworkView`, `ErrorView`, `SdkView`, `CustomSpansView`, `UserActionsView`, `SessionReplayView`, `ClockView`, `SchemaValidationView`, `TracesExporterView`
- `Toast.swift` — shared bottom-toast `ViewModifier`
- Swipe demo lives in **User Actions** (antenna icon with `trackCXSwipeAction()`)

## Test plan

- [ ] Swipe the antenna icon in User Actions (up/down/left/right ≥20pt) → verify `user-interaction` span with `event_name = "swipe"` + correct `scroll_direction` in Coralogix RUM
- [ ] Scroll the main list → verify existing scroll span still fires (no regression)
- [ ] Tap items on all 10 screens → verify `user-interaction` tap spans fire
- [ ] `swift test` passes (7 new swipe-direction unit tests in `InteractionContextTests`)
- [ ] DemoAppSwiftUI scheme builds clean on iOS 13+ target

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Deliver SwiftUI gesture coverage by wiring <code>SwipeDetectorView</code>/<code>CXSwipeModifier</code> into the notification path so SwiftUI pans emit the same <code>.swipe</code> <code>user-interaction</code> spans as UIKit. Rebuild the DemoAppSwiftUI sample into a navigation-driven menu of instrumentation flows (network, error, SDK, custom spans, user actions, session replay, clock, schema validation, traces exporter) and refresh shared UI, dependency, and project metadata so the refreshed app compiles and showcases the new swipe demo.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/191?tool=ast&topic=SwiftUI+swipe+detection>SwiftUI swipe detection</a>
        </td><td>Enable SwiftUI swipe capture by overlaying <code>SwipeDetectorView</code>, posting <code>.cxRumNotificationUserActions</code> with the shared <code>ScrollTracker</code> direction/threshold logic, discarding touches on recognition to avoid duplicate scroll spans, and covering the coordinator with direction-mapping unit tests so SwiftUI pans deliver <code>.swipe</code> <code>user-interaction</code> spans exactly like UIKit.<details><summary>Modified files (2)</summary><ul><li>Coralogix/Sources/Actions/SwiftUI/SwiftUIActionModifier.swift</li>
<li>Tests/CoralogixRumTests/InteractionContextTests.swift</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>fix: iOS SDK custom sp...</td><td>April 23, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/191?tool=ast&topic=Demo+app+shell>Demo app shell</a>
        </td><td>Rebuild the DemoAppSwiftUI shell by defining reusable models/UI (<code>ActionItem</code>, <code>ActionListView</code>, <code>DemoRow</code>, <code>Toast</code>), crafting <code>ContentView</code>/<code>DemoAppSwiftUIApp</code> around a session-card header and navigation menu, and updating the project manifest (<code>DemoApp.xcodeproj</code>, <code>Podfile</code>, <code>.gitignore</code>) so the new screens compile with the required CocoaPods (<code>Alamofire</code>, <code>AFNetworking</code>, <code>SDWebImage</code>) and expose session-copy toasts.<details><summary>Modified files (9)</summary><ul><li>.gitignore</li>
<li>Example/DemoApp.xcodeproj/project.pbxproj</li>
<li>Example/DemoAppSwiftUI/ActionItem.swift</li>
<li>Example/DemoAppSwiftUI/ActionListView.swift</li>
<li>Example/DemoAppSwiftUI/ContentView.swift</li>
<li>Example/DemoAppSwiftUI/DemoAppSwiftUIApp.swift</li>
<li>Example/DemoAppSwiftUI/DemoRow.swift</li>
<li>Example/DemoAppSwiftUI/Toast.swift</li>
<li>Example/Podfile</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>fix: tracesExporter in...</td><td>April 26, 2026</td></tr>
<tr><td>NatanCoralogix</td><td>UI test (#85)</td><td>July 29, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/191?tool=ast&topic=Instrumentation+demos>Instrumentation demos</a>
        </td><td>Deliver the complete instrumentation showcase by creating dedicated SwiftUI screens for <code>NetworkView</code>, <code>ErrorView</code>, <code>SdkView</code>, <code>CustomSpansView</code>, <code>SessionReplayView</code>, <code>ClockView</code>, <code>SchemaValidationView</code>, <code>TracesExporterView</code>, and <code>UserActionsView</code>, each wired to the Coralogix SDK helpers plus the reusable <code>ActionListView</code>/<code>ActionItem</code> rows; refresh <code>NetworkSim</code> output formatting and add toasts so each demo row reliably executes the intended network, error, SDK, custom-span, session replay, tracing, clock, schema-validation, and swipe interactions.<details><summary>Modified files (10)</summary><ul><li>Example/DemoAppSwiftUI/ClockView.swift</li>
<li>Example/DemoAppSwiftUI/CustomSpansView.swift</li>
<li>Example/DemoAppSwiftUI/ErrorView.swift</li>
<li>Example/DemoAppSwiftUI/NetworkView.swift</li>
<li>Example/DemoAppSwiftUI/SchemaValidationView.swift</li>
<li>Example/DemoAppSwiftUI/SdkView.swift</li>
<li>Example/DemoAppSwiftUI/SessionReplayView.swift</li>
<li>Example/DemoAppSwiftUI/TracesExporterView.swift</li>
<li>Example/DemoAppSwiftUI/UserActionsView.swift</li>
<li>Example/Shared/SimulateFolder/NetworkSim.swift</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/coralogix/cx-ios-sdk/191?tool=ast>(Baz)</a>.