### PR TITLE
feat(CX-40199): ExcludableInstrumentation enum + excludeFromSampling

### DIFF
--- a/Coralogix/Sources/Model/CoralogixExporterOptions.swift
+++ b/Coralogix/Sources/Model/CoralogixExporterOptions.swift
@@ -63,7 +63,11 @@ public struct CoralogixExporterOptions {
     
     /// Number between 0-100 as a precentage of SDK should be init.
     var sdkSampler: SDKSampler
-    
+
+    /// Instrumentation categories that should keep emitting events regardless of the session
+    /// sampling decision. Empty by default (all event types follow the session sample rate).
+    var excludeFromSampling: Set<ExcludableInstrumentation>
+
     /// A list of instruments that you wish to switch off during runtime. all instrumentations are active by default.
     var instrumentations: [InstrumentationType: Bool]?
     
@@ -162,6 +166,7 @@ public struct CoralogixExporterOptions {
                 ignoreErrors: [String]? = nil,
                 labels: [String: Any]? = nil,
                 sessionSampleRate: Int = 100, // percent (0–100)
+                excludeFromSampling: Set<ExcludableInstrumentation> = [],
                 instrumentations: [InstrumentationType: Bool]? = nil,
                 collectIPData: Bool = true,
                 beforeSend: (([String: Any]) -> [String: Any]?)? = nil,
@@ -185,6 +190,7 @@ public struct CoralogixExporterOptions {
         self.version = version
         self.labels = labels
         self.sdkSampler = SDKSampler(sampleRate: sessionSampleRate)
+        self.excludeFromSampling = excludeFromSampling
         self.instrumentations = instrumentations
         self.collectIPData = collectIPData
         self.beforeSend = beforeSend
@@ -216,6 +222,7 @@ public struct CoralogixExporterOptions {
         initData[Keys.ignoreErrors.rawValue] = self.ignoreErrors
         initData[Keys.labels.rawValue] = self.labels
         initData[Keys.sessionSampleRate.rawValue] = self.sdkSampler.sampleRate
+        initData[Keys.excludeFromSampling.rawValue] = self.excludeFromSampling.map(\.rawValue).sorted()
         initData[Keys.instrumentations.rawValue] = self.getStatesAsDictionary(from: self.instrumentations)
         initData[Keys.collectIPData.rawValue] = self.collectIPData
         initData[Keys.enableSwizzling.rawValue] = self.enableSwizzling

--- a/CoralogixInternal/Sources/Keys.swift
+++ b/CoralogixInternal/Sources/Keys.swift
@@ -243,6 +243,7 @@ public enum Keys: String {
     case ignoreErrors
     case collectIPData
     case sessionSampleRate
+    case excludeFromSampling
     case traceParentInHeader
     case debug
     case proxyUrl
@@ -284,4 +285,32 @@ public enum CoralogixEventType: String {
     /// Manual spans from `getCustomTracer()` (parity with Browser SDK `CoralogixEventType.CUSTOM_SPAN`).
     case customSpan = "custom-span"
     case unknown
+}
+
+/// Public-facing instrumentation categories that can be excluded from session sampling.
+///
+/// Pass via `CoralogixExporterOptions.excludeFromSampling` to keep emitting these event
+/// types regardless of the session sample-rate decision. Mirrors the browser SDK's
+/// `ExcludableInstrumentation` (PR #800, v3.8.0).
+public enum ExcludableInstrumentation: String, CaseIterable, Sendable {
+    case errors
+    case logs
+    case network
+    case userInteractions
+    case mobileVitals
+    case customSpan
+    case customMeasurement
+
+    /// Internal `CoralogixEventType` this public case maps to.
+    public var eventType: CoralogixEventType {
+        switch self {
+        case .errors: return .error
+        case .logs: return .log
+        case .network: return .networkRequest
+        case .userInteractions: return .userInteraction
+        case .mobileVitals: return .mobileVitals
+        case .customSpan: return .customSpan
+        case .customMeasurement: return .customMeasurement
+        }
+    }
 }


### PR DESCRIPTION
# User description
## Summary

- Foundation ticket (T1) for parent epic [CX-40134](https://coralogix.atlassian.net/browse/CX-40134) — decouple session sampling from log/event sampling on iOS, matching the browser SDK behavior shipped in PR #800 (v3.8.0).
- Adds `public enum ExcludableInstrumentation` in `CoralogixInternal/Sources/Keys.swift` with 7 cases (`errors`, `logs`, `network`, `userInteractions`, `mobileVitals`, `customSpan`, `customMeasurement`) plus a `var eventType: CoralogixEventType` mapper. Conforms to `CaseIterable, Sendable` for ergonomics and forward concurrency safety.
- Adds `excludeFromSampling: Set<ExcludableInstrumentation>` option on `CoralogixExporterOptions` (slotted right after `sessionSampleRate`), surfaced in `getInitData()` for init telemetry. `Set` chosen over `[…]` because the semantics are membership-based; init-data emission uses `.map(\.rawValue).sorted()` for deterministic JSON output.

**Out of scope** (deferred to follow-up tickets in the epic): wiring into `CoralogixRum.init` and `CoralogixExporter.export()`. This PR is purely the public surface — no behavior change.

Ticket: https://coralogix.atlassian.net/browse/CX-40199

## Test plan

- [x] `xcodebuild build` — BUILD SUCCEEDED on iOS Simulator
- [x] `xcodebuild test -only-testing:CoralogixInternalTests` — 10/10 passed
- [ ] Verify `getInitData()` emits `excludeFromSampling` as a sorted `[String]` (manual smoke check after merge of follow-up wiring tickets)
- [ ] Verify default-empty case sends `[]`, not `null`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CX-40134]: https://coralogix.atlassian.net/browse/CX-40134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Introduce <code>ExcludableInstrumentation</code> as the public enum for instrumentation categories so each can map to an internal <code>CoralogixEventType</code>, laying the foundation to decouple session sampling from log/event sampling. Expose an <code>excludeFromSampling</code> option on <code>CoralogixExporterOptions</code> so callers can keep those instrumentations emitting regardless of the session sample-rate decision, and surface it in init telemetry.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/193?tool=ast&topic=Exporter+option>Exporter option</a>
        </td><td>Expose the <code>excludeFromSampling</code> set on <code>CoralogixExporterOptions</code>, keep it near <code>sessionSampleRate</code>, persist it on initialization, and emit a deterministic sorted list via <code>getInitData()</code>.<details><summary>Modified files (1)</summary><ul><li>Coralogix/Sources/Model/CoralogixExporterOptions.swift</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>feat(CX-40199): add Ex...</td><td>May 05, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/193?tool=ast&topic=Instrumentation+Enum>Instrumentation Enum</a>
        </td><td>Add and document the public <code>ExcludableInstrumentation</code> enum to represent errors, logs, network, user interactions, mobile vitals, custom spans, and custom measurements, and map each case to its <code>CoralogixEventType</code> counterpart for sampling exclusion.<details><summary>Modified files (1)</summary><ul><li>CoralogixInternal/Sources/Keys.swift</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>feat(CX-40199): add Ex...</td><td>May 05, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/coralogix/cx-ios-sdk/193?tool=ast>(Baz)</a>.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to exclude specific instrumentations from session sampling, providing fine-grained control over which telemetry data gets sampled in your application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->