### PR TITLE
feat(CX-40202): T4 — LogSamplingDecouplingTests + demo-app harness

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   ui-tests:
     name: Run DemoApp UI Tests
-    runs-on: macos-14
+    runs-on: macos-15
     timeout-minutes: 30
     permissions:
       contents: read
@@ -26,7 +26,15 @@ jobs:
 
       - name: Select Xcode (via DEVELOPER_DIR)
         run: |
-          if [ -d "/Applications/Xcode_16.2.app" ]; then
+          # Prefer Xcode 16.4 (default on macos-15) — Xcode 16.2 swiftc has
+          # been failing to compile firebase-ios-sdk's Package.swift under
+          # `-swift-version 6` (manifest resolution error). 16.3/16.2/16.1/16.0
+          # kept as fallbacks.
+          if [ -d "/Applications/Xcode_16.4.app" ]; then
+            echo "DEVELOPER_DIR=/Applications/Xcode_16.4.app/Contents/Developer" >> $GITHUB_ENV
+          elif [ -d "/Applications/Xcode_16.3.app" ]; then
+            echo "DEVELOPER_DIR=/Applications/Xcode_16.3.app/Contents/Developer" >> $GITHUB_ENV
+          elif [ -d "/Applications/Xcode_16.2.app" ]; then
             echo "DEVELOPER_DIR=/Applications/Xcode_16.2.app/Contents/Developer" >> $GITHUB_ENV
           elif [ -d "/Applications/Xcode_16.1.app" ]; then
             echo "DEVELOPER_DIR=/Applications/Xcode_16.1.app/Contents/Developer" >> $GITHUB_ENV
@@ -132,22 +140,27 @@ jobs:
           OUT=$(xcodebuild -showdestinations -workspace DemoApp.xcworkspace -scheme DemoAppSwift)
           echo "$OUT"
 
-          # Prefer iPhone 16 or newer with iOS 18.0+ (we override deployment target in CI)
-          LINE=$(echo "$OUT" | grep -E "platform:iOS Simulator, id:.*name:iPhone (1[6-9]|[2-9][0-9])" | grep -E "OS:1[89]\.[0-9]" | head -1 || true)
-          
-          # If not found, try any iPhone with iOS 18.0+
+          # Xcode 16.4 (macos-15) emits `platform:iOS Simulator, arch:arm64, id:...`
+          # whereas 16.2 emitted `platform:iOS Simulator, id:...` directly. Use
+          # `.*id:` so the regex tolerates intervening fields either way.
+          SIM_PREFIX="platform:iOS Simulator,.*id:"
+
+          # Prefer iPhone 16 or newer with iOS 18.x (we override deployment target in CI)
+          LINE=$(echo "$OUT" | grep -E "${SIM_PREFIX}.*name:iPhone (1[6-9]|[2-9][0-9])" | grep -E "OS:1[89]\.[0-9]" | head -1 || true)
+
+          # If not found, try any iPhone with iOS 18.x
           if [ -z "$LINE" ]; then
-            LINE=$(echo "$OUT" | grep -E "platform:iOS Simulator, id:.*name:iPhone" | grep -E "OS:1[89]\.[0-9]" | head -1 || true)
+            LINE=$(echo "$OUT" | grep -E "${SIM_PREFIX}.*name:iPhone" | grep -E "OS:1[89]\.[0-9]" | head -1 || true)
           fi
-          
-          # If still not found, try any iPhone with iOS 17.0+ (fallback)
+
+          # If still not found, accept iOS 17.x or the newer 26.x runtimes
           if [ -z "$LINE" ]; then
-            LINE=$(echo "$OUT" | grep -E "platform:iOS Simulator, id:.*name:iPhone" | grep -E "OS:1[7-9]\.[0-9]" | head -1 || true)
+            LINE=$(echo "$OUT" | grep -E "${SIM_PREFIX}.*name:iPhone" | grep -E "OS:(1[7-9]|2[6-9])\." | head -1 || true)
           fi
-          
+
           # Last resort: any iPhone simulator
           if [ -z "$LINE" ]; then
-            LINE=$(echo "$OUT" | grep -E "platform:iOS Simulator, id:.*name:iPhone" | head -1 || true)
+            LINE=$(echo "$OUT" | grep -E "${SIM_PREFIX}.*name:iPhone" | head -1 || true)
           fi
           
           if [ -z "$LINE" ]; then

--- a/Example/DemoApp.xcodeproj/project.pbxproj
+++ b/Example/DemoApp.xcodeproj/project.pbxproj
@@ -98,6 +98,8 @@
 		E6LSDC012F0C000010035952 /* LogSamplingDecouplingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6LSDC002F0C000010035952 /* LogSamplingDecouplingView.swift */; };
 		E6OTLP012F0C000010035951 /* OtlpSpan+EventType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6OTLP002F0C000010035951 /* OtlpSpan+EventType.swift */; };
 		E6OTLP012F0C000010035952 /* OtlpSpan+EventType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6OTLP002F0C000010035951 /* OtlpSpan+EventType.swift */; };
+		E6LSDM012F0C000010035951 /* LogSamplingDemoModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6LSDM002F0C000010035951 /* LogSamplingDemoModel.swift */; };
+		E6LSDM012F0C000010035952 /* LogSamplingDemoModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6LSDM002F0C000010035951 /* LogSamplingDemoModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -214,6 +216,7 @@
 		E6LSDC002F0C000010035951 /* LogSamplingDecouplingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogSamplingDecouplingViewController.swift; sourceTree = "<group>"; };
 		E6LSDC002F0C000010035952 /* LogSamplingDecouplingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogSamplingDecouplingView.swift; sourceTree = "<group>"; };
 		E6OTLP002F0C000010035951 /* OtlpSpan+EventType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OtlpSpan+EventType.swift"; sourceTree = "<group>"; };
+		E6LSDM002F0C000010035951 /* LogSamplingDemoModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogSamplingDemoModel.swift; sourceTree = "<group>"; };
 		2A8D067F2E27BBC8002C4FCE /* DemoAppSwiftUIUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DemoAppSwiftUIUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -416,6 +419,7 @@
 				E622116B2BFF2A7B00052682 /* Keys.swift */,
 				E6D4BBF62DE336310096B46D /* CoralogixRumManager.swift */,
 				E6OTLP002F0C000010035951 /* OtlpSpan+EventType.swift */,
+				E6LSDM002F0C000010035951 /* LogSamplingDemoModel.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -723,6 +727,7 @@
 				E6CF001A2BFDEB8C00000001 /* TracesExporterView.swift in Sources */,
 				E6LSDC012F0C000010035952 /* LogSamplingDecouplingView.swift in Sources */,
 				E6OTLP012F0C000010035952 /* OtlpSpan+EventType.swift in Sources */,
+				E6LSDM012F0C000010035952 /* LogSamplingDemoModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -757,6 +762,7 @@
 				E6TRACES012F0C000010035951 /* TracesExporterViewController.swift in Sources */,
 				E6LSDC012F0C000010035951 /* LogSamplingDecouplingViewController.swift in Sources */,
 				E6OTLP012F0C000010035951 /* OtlpSpan+EventType.swift in Sources */,
+				E6LSDM012F0C000010035951 /* LogSamplingDemoModel.swift in Sources */,
 				E669384F2C747E860002335F /* CustomView.swift in Sources */,
 				E6E515FE2EBB8644008EC19A /* MaskViewController.swift in Sources */,
 				E66938572C74A8830002335F /* UserActionsViewController.swift in Sources */,

--- a/Example/DemoApp.xcodeproj/project.pbxproj
+++ b/Example/DemoApp.xcodeproj/project.pbxproj
@@ -96,6 +96,8 @@
 		E6TRACES012F0C000010035951 /* TracesExporterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6TRACES002F0C000010035951 /* TracesExporterViewController.swift */; };
 		E6LSDC012F0C000010035951 /* LogSamplingDecouplingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6LSDC002F0C000010035951 /* LogSamplingDecouplingViewController.swift */; };
 		E6LSDC012F0C000010035952 /* LogSamplingDecouplingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6LSDC002F0C000010035952 /* LogSamplingDecouplingView.swift */; };
+		E6OTLP012F0C000010035951 /* OtlpSpan+EventType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6OTLP002F0C000010035951 /* OtlpSpan+EventType.swift */; };
+		E6OTLP012F0C000010035952 /* OtlpSpan+EventType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6OTLP002F0C000010035951 /* OtlpSpan+EventType.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -211,6 +213,7 @@
 		E6TRACES002F0C000010035951 /* TracesExporterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracesExporterViewController.swift; sourceTree = "<group>"; };
 		E6LSDC002F0C000010035951 /* LogSamplingDecouplingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogSamplingDecouplingViewController.swift; sourceTree = "<group>"; };
 		E6LSDC002F0C000010035952 /* LogSamplingDecouplingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogSamplingDecouplingView.swift; sourceTree = "<group>"; };
+		E6OTLP002F0C000010035951 /* OtlpSpan+EventType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OtlpSpan+EventType.swift"; sourceTree = "<group>"; };
 		2A8D067F2E27BBC8002C4FCE /* DemoAppSwiftUIUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DemoAppSwiftUIUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -412,6 +415,7 @@
 				E6320FB52BE7CE6800A4547E /* SimulateFolder */,
 				E622116B2BFF2A7B00052682 /* Keys.swift */,
 				E6D4BBF62DE336310096B46D /* CoralogixRumManager.swift */,
+				E6OTLP002F0C000010035951 /* OtlpSpan+EventType.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -718,6 +722,7 @@
 				E6CF00192BFDEB8C00000001 /* SchemaValidationView.swift in Sources */,
 				E6CF001A2BFDEB8C00000001 /* TracesExporterView.swift in Sources */,
 				E6LSDC012F0C000010035952 /* LogSamplingDecouplingView.swift in Sources */,
+				E6OTLP012F0C000010035952 /* OtlpSpan+EventType.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -751,6 +756,7 @@
 				E6C359522F04000510035951 /* CustomSpansViewController.swift in Sources */,
 				E6TRACES012F0C000010035951 /* TracesExporterViewController.swift in Sources */,
 				E6LSDC012F0C000010035951 /* LogSamplingDecouplingViewController.swift in Sources */,
+				E6OTLP012F0C000010035951 /* OtlpSpan+EventType.swift in Sources */,
 				E669384F2C747E860002335F /* CustomView.swift in Sources */,
 				E6E515FE2EBB8644008EC19A /* MaskViewController.swift in Sources */,
 				E66938572C74A8830002335F /* UserActionsViewController.swift in Sources */,

--- a/Example/DemoApp.xcodeproj/project.pbxproj
+++ b/Example/DemoApp.xcodeproj/project.pbxproj
@@ -94,6 +94,8 @@
 		E6C359522F04000510035951 /* CustomSpansViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6C359512F04000510035951 /* CustomSpansViewController.swift */; };
 		E6FDDA2F2DF176DC0005F274 /* ClockViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6FDDA2C2DF176DC0005F274 /* ClockViewController.swift */; };
 		E6TRACES012F0C000010035951 /* TracesExporterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6TRACES002F0C000010035951 /* TracesExporterViewController.swift */; };
+		E6LSDC012F0C000010035951 /* LogSamplingDecouplingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6LSDC002F0C000010035951 /* LogSamplingDecouplingViewController.swift */; };
+		E6LSDC012F0C000010035952 /* LogSamplingDecouplingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6LSDC002F0C000010035952 /* LogSamplingDecouplingView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -207,6 +209,8 @@
 		E6FDDA312DF176DC0005F275 /* SchemaValidationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaValidationViewController.swift; sourceTree = "<group>"; };
 		E6C359512F04000510035951 /* CustomSpansViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomSpansViewController.swift; sourceTree = "<group>"; };
 		E6TRACES002F0C000010035951 /* TracesExporterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracesExporterViewController.swift; sourceTree = "<group>"; };
+		E6LSDC002F0C000010035951 /* LogSamplingDecouplingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogSamplingDecouplingViewController.swift; sourceTree = "<group>"; };
+		E6LSDC002F0C000010035952 /* LogSamplingDecouplingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogSamplingDecouplingView.swift; sourceTree = "<group>"; };
 		2A8D067F2E27BBC8002C4FCE /* DemoAppSwiftUIUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DemoAppSwiftUIUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -288,6 +292,7 @@
 				E6CF00082BFDEB8C00000001 /* ClockView.swift */,
 				E6CF00092BFDEB8C00000001 /* SchemaValidationView.swift */,
 				E6CF000A2BFDEB8C00000001 /* TracesExporterView.swift */,
+				E6LSDC002F0C000010035952 /* LogSamplingDecouplingView.swift */,
 				E622115E2BFDEB8C00052682 /* Assets.xcassets */,
 				E62211602BFDEB8C00052682 /* Preview Content */,
 			);
@@ -382,6 +387,7 @@
 				E6FDDA312DF176DC0005F275 /* SchemaValidationViewController.swift */,
 				E6C359512F04000510035951 /* CustomSpansViewController.swift */,
 				E6TRACES002F0C000010035951 /* TracesExporterViewController.swift */,
+				E6LSDC002F0C000010035951 /* LogSamplingDecouplingViewController.swift */,
 				E6E515FD2EBB8644008EC19A /* MaskViewController.swift */,
 				E6B60A052DB4EAAC003AD35D /* Assets.xcassets */,
 				E68681AA2BFA279500B127E7 /* Main.storyboard */,
@@ -711,6 +717,7 @@
 				E6CF00182BFDEB8C00000001 /* ClockView.swift in Sources */,
 				E6CF00192BFDEB8C00000001 /* SchemaValidationView.swift in Sources */,
 				E6CF001A2BFDEB8C00000001 /* TracesExporterView.swift in Sources */,
+				E6LSDC012F0C000010035952 /* LogSamplingDecouplingView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -743,6 +750,7 @@
 				E6FDDA2E2DF176DC0005F275 /* SchemaValidationViewController.swift in Sources */,
 				E6C359522F04000510035951 /* CustomSpansViewController.swift in Sources */,
 				E6TRACES012F0C000010035951 /* TracesExporterViewController.swift in Sources */,
+				E6LSDC012F0C000010035951 /* LogSamplingDecouplingViewController.swift in Sources */,
 				E669384F2C747E860002335F /* CustomView.swift in Sources */,
 				E6E515FE2EBB8644008EC19A /* MaskViewController.swift in Sources */,
 				E66938572C74A8830002335F /* UserActionsViewController.swift in Sources */,

--- a/Example/DemoAppSwift/LogSamplingDecouplingViewController.swift
+++ b/Example/DemoAppSwift/LogSamplingDecouplingViewController.swift
@@ -207,10 +207,7 @@ final class LogSamplingDecouplingViewController: UIViewController {
 
     private func updateAppliedConfigLabel() {
         if model.isApplied {
-            appliedConfigLabel.text =
-                "rate=\(model.appliedSampleRate)\n" +
-                "exclude=\(model.formattedAppliedExclude)\n" +
-                "isInitialized=\(CoralogixRumManager.shared.sdk.isInitialized)"
+            appliedConfigLabel.text = model.appliedConfigDescription
         } else {
             appliedConfigLabel.text = "(not applied — tap Apply to reinit the SDK)"
         }

--- a/Example/DemoAppSwift/LogSamplingDecouplingViewController.swift
+++ b/Example/DemoAppSwift/LogSamplingDecouplingViewController.swift
@@ -2,45 +2,20 @@
 //  LogSamplingDecouplingViewController.swift
 //  DemoAppSwift
 //
-//  Manual harness for PIPEV2-3365: pick a sessionSampleRate (0/50/100) and an
-//  excludeFromSampling set, reinitialize the SDK with that config, then fire
-//  events and watch which event_types actually survive the sampling filter
-//  via the tracesExporter callback.
+//  UIKit presenter on top of LogSamplingDemoModel — pick a sessionSampleRate +
+//  excludeFromSampling set, reinitialize the SDK, fire events, and watch which
+//  event_types survive the sampling filter via the tracesExporter callback.
 //
 
 import UIKit
+import Combine
 import Coralogix
 import CoralogixInternal
 
-private struct CapturedSpan {
-    let eventType: String
-    let name: String
-    let receivedAt: Date
-
-    var timeString: String {
-        let f = DateFormatter()
-        f.dateFormat = "HH:mm:ss"
-        return f.string(from: receivedAt)
-    }
-}
-
 final class LogSamplingDecouplingViewController: UIViewController {
 
-    // MARK: - Persistent state
-
-    private static var currentSampleRate: Int = 0
-    private static var currentExclude: Set<ExcludableInstrumentation> = [.logs]
-    private static var isApplied = false
-    private static var captured: [CapturedSpan] = []
-    /// Bumped on every Apply. Each tracesExporter closure captures its token so late
-    /// callbacks from a previous run (e.g., flushed by BatchSpanProcessor after
-    /// shutdown but before reinit) can be discarded instead of polluting the list.
-    private static var currentRunToken: Int = 0
-
-    private static let allExcludable: [ExcludableInstrumentation] =
-        [.logs, .errors, .network, .userInteractions, .mobileVitals, .customSpan, .customMeasurement]
-
-    // MARK: - UI
+    private let model = LogSamplingDemoModel.shared
+    private var cancellables = Set<AnyCancellable>()
 
     private let scrollView = UIScrollView()
     private let contentStack = UIStackView()
@@ -74,20 +49,25 @@ final class LogSamplingDecouplingViewController: UIViewController {
 
     private let capturedTable = UITableView(frame: .zero, style: .plain)
 
-    // MARK: - Lifecycle
-
     override func viewDidLoad() {
         super.viewDidLoad()
         title = "Log Sampling Decoupling"
         view.backgroundColor = .systemBackground
 
         setupLayout()
-        configureFromState()
         capturedTable.dataSource = self
         capturedTable.delegate = self
         capturedTable.register(UITableViewCell.self, forCellReuseIdentifier: "captured")
-        updateAppliedConfigLabel()
-        updateButtonsEnabled()
+
+        configureFromModel()
+        refreshFromModel()
+
+        // The model emits objectWillChange before each @Published mutation; sink on the
+        // main queue and re-render the parts of the UI that depend on model state.
+        model.objectWillChange
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in self?.refreshFromModel() }
+            .store(in: &cancellables)
     }
 
     private func setupLayout() {
@@ -118,9 +98,8 @@ final class LogSamplingDecouplingViewController: UIViewController {
         contentStack.addArrangedSubview(sampleRateSegmented)
 
         contentStack.addArrangedSubview(makeSectionHeader("excludeFromSampling"))
-        for excludable in Self.allExcludable {
-            let row = makeExcludeRow(excludable)
-            contentStack.addArrangedSubview(row)
+        for excludable in LogSamplingDemoModel.allExcludable {
+            contentStack.addArrangedSubview(makeExcludeRow(excludable))
         }
 
         statusLabel.font = .preferredFont(forTextStyle: .footnote)
@@ -165,146 +144,53 @@ final class LogSamplingDecouplingViewController: UIViewController {
         contentStack.addArrangedSubview(capturedTable)
     }
 
-    private func configureFromState() {
-        switch Self.currentSampleRate {
+    private func configureFromModel() {
+        switch model.sampleRate {
         case 0:   sampleRateSegmented.selectedSegmentIndex = 0
         case 50:  sampleRateSegmented.selectedSegmentIndex = 1
         default:  sampleRateSegmented.selectedSegmentIndex = 2
         }
         for (excludable, toggle) in excludeToggles {
-            toggle.isOn = Self.currentExclude.contains(excludable)
+            toggle.isOn = model.exclude.contains(excludable)
         }
+    }
+
+    private func refreshFromModel() {
+        capturedTable.reloadData()
         updateStatusLabel()
+        updateAppliedConfigLabel()
+        updateButtonsEnabled()
     }
 
     // MARK: - Actions
 
     @objc private func sampleRateChanged() {
-        Self.currentSampleRate = [0, 50, 100][sampleRateSegmented.selectedSegmentIndex]
-        updateStatusLabel()
+        model.sampleRate = [0, 50, 100][sampleRateSegmented.selectedSegmentIndex]
     }
 
     @objc private func excludeToggleChanged(_ toggle: UISwitch) {
-        guard let excludable = Self.allExcludable.first(where: { excludeToggles[$0] === toggle }) else { return }
+        guard let excludable = LogSamplingDemoModel.allExcludable.first(where: { excludeToggles[$0] === toggle }) else { return }
         if toggle.isOn {
-            Self.currentExclude.insert(excludable)
+            model.exclude.insert(excludable)
         } else {
-            Self.currentExclude.remove(excludable)
+            model.exclude.remove(excludable)
         }
-        updateStatusLabel()
     }
 
-    @objc private func didTapApply() {
-        let rate = Self.currentSampleRate
-        let exclude = Self.currentExclude
-        if rate == 0 && exclude.isEmpty {
-            showToast("sampleRate=0 + exclude=[] would skip init (legacy contract). Pick a rate or an exclude.")
-            return
-        }
+    @objc private func didTapApply() { showToast(model.apply()) }
+    @objc private func didTapSendLog() { showToast(model.triggerLog()) }
+    @objc private func didTapSendError() { showToast(model.triggerError()) }
+    @objc private func didTapSendNetwork() { showToast(model.triggerNetwork()) }
+    @objc private func didTapSendCustomSpan() { showToast(model.triggerCustomSpan()) }
+    @objc private func didTapSendCustomMeasurement() { showToast(model.triggerCustomMeasurement()) }
+    @objc private func didTapClear() { model.clearCaptured() }
 
-        // Bump the run token first so any late callback from the previous run (still
-        // possibly in flight on the BatchSpanProcessor's queue) is discarded by the
-        // closure's token guard rather than re-filling the just-cleared list.
-        Self.currentRunToken += 1
-        let runToken = Self.currentRunToken
-        Self.captured.removeAll()
-        capturedTable.reloadData()
-
-        CoralogixRumManager.shared.sdk.shutdown()
-        let options = CoralogixExporterOptions(
-            coralogixDomain: .EU2,
-            userContext: UserContext(userId: "sampling-test",
-                                     userName: "Sampling Tester",
-                                     userEmail: "sampling@example.com",
-                                     userMetadata: ["test": "logSamplingDecoupling"]),
-            environment: "PROD",
-            application: "DemoApp-iOS-LogSamplingDecoupling",
-            version: "1",
-            publicKey: Envs.PUBLIC_KEY.rawValue,
-            sessionSampleRate: rate,
-            excludeFromSampling: exclude,
-            instrumentations: [.mobileVitals: true, .custom: true, .errors: true,
-                               .userActions: true, .network: true, .anr: true, .lifeCycle: true],
-            collectIPData: true,
-            traceParentInHeader: ["enable": true],
-            tracesExporter: { [weak self] data in
-                let now = Date()
-                var rows: [CapturedSpan] = []
-                for resourceSpan in data.tracesData.resourceSpans {
-                    for scopeSpan in resourceSpan.scopeSpans {
-                        for span in scopeSpan.spans {
-                            rows.append(CapturedSpan(
-                                eventType: span.eventType ?? "(no event_type)",
-                                name: span.name,
-                                receivedAt: now
-                            ))
-                        }
-                    }
-                }
-                guard !rows.isEmpty else { return }
-                DispatchQueue.main.async {
-                    guard runToken == Self.currentRunToken else { return }
-                    Self.captured.insert(contentsOf: rows.reversed(), at: 0)
-                    self?.capturedTable.reloadData()
-                }
-            },
-            debug: true
-        )
-        CoralogixRumManager.shared.reinitialize(with: options)
-        Self.isApplied = true
-        updateAppliedConfigLabel()
-        updateButtonsEnabled()
-        showToast("SDK reinitialized — rate=\(rate), exclude=\(formatExclude(exclude))")
-    }
-
-    @objc private func didTapSendLog() {
-        CoralogixRumManager.shared.sdk.log(severity: .info,
-                                           message: "Sampling demo log",
-                                           data: ["source": "LogSamplingDecouplingVC"])
-        showToast("log() called")
-    }
-
-    @objc private func didTapSendError() {
-        CoralogixRumManager.shared.sdk.reportError(message: "Sampling demo error", data: nil)
-        showToast("reportError() called")
-    }
-
-    @objc private func didTapSendNetwork() {
-        NetworkSim.sendSuccesfullRequest()
-        showToast("Network request sent")
-    }
-
-    @objc private func didTapSendCustomSpan() {
-        let rum = CoralogixRumManager.shared.sdk
-        guard rum.isInitialized else { showToast("SDK not initialized"); return }
-        guard let tracer = rum.getCustomTracer() else { showToast("Failed to get custom tracer"); return }
-        guard let global = tracer.startGlobalSpan(name: "sampling-demo.global",
-                                                   labels: ["source": "LogSamplingDecouplingVC"]) else {
-            showToast("startGlobalSpan returned nil")
-            return
-        }
-        let child = global.startCustomSpan(name: "sampling-demo.child")
-        child.endSpan()
-        global.endSpan()
-        showToast("Custom span emitted")
-    }
-
-    @objc private func didTapSendCustomMeasurement() {
-        CoralogixRumManager.shared.sdk.sendCustomMeasurement(name: "sampling-demo.measurement", value: 42.0)
-        showToast("sendCustomMeasurement() called")
-    }
-
-    @objc private func didTapClear() {
-        Self.captured.removeAll()
-        capturedTable.reloadData()
-    }
-
-    // MARK: - Helpers
+    // MARK: - View state derived from model
 
     private func updateStatusLabel() {
-        let rate = Self.currentSampleRate
-        let exclude = Self.currentExclude
-        if rate == 0 && exclude.isEmpty {
+        let rate = model.sampleRate
+        let empty = model.exclude.isEmpty
+        if rate == 0 && empty {
             statusLabel.text = "⚠️ rate=0 + exclude=[] would short-circuit init (legacy contract). Apply will refuse this combination."
             statusLabel.textColor = .systemOrange
         } else if rate == 100 {
@@ -320,10 +206,10 @@ final class LogSamplingDecouplingViewController: UIViewController {
     }
 
     private func updateAppliedConfigLabel() {
-        if Self.isApplied {
+        if model.isApplied {
             appliedConfigLabel.text =
-                "rate=\(Self.currentSampleRate)\n" +
-                "exclude=\(formatExclude(Self.currentExclude))\n" +
+                "rate=\(model.sampleRate)\n" +
+                "exclude=\(model.formattedExclude)\n" +
                 "isInitialized=\(CoralogixRumManager.shared.sdk.isInitialized)"
         } else {
             appliedConfigLabel.text = "(not applied — tap Apply to reinit the SDK)"
@@ -331,16 +217,11 @@ final class LogSamplingDecouplingViewController: UIViewController {
     }
 
     private func updateButtonsEnabled() {
-        let on = Self.isApplied
+        let on = model.isApplied
         for btn in [sendLogButton, sendErrorButton, sendNetworkButton, sendCustomSpanButton, sendCustomMeasurementButton] {
             btn.isEnabled = on
             btn.alpha = on ? 1 : 0.4
         }
-    }
-
-    private func formatExclude(_ set: Set<ExcludableInstrumentation>) -> String {
-        if set.isEmpty { return "[]" }
-        return "[" + set.map { ".\($0.rawValue)" }.sorted().joined(separator: ", ") + "]"
     }
 
     // MARK: - View builders
@@ -358,7 +239,7 @@ final class LogSamplingDecouplingViewController: UIViewController {
         label.font = .preferredFont(forTextStyle: .body)
 
         let toggle = UISwitch()
-        toggle.isOn = Self.currentExclude.contains(excludable)
+        toggle.isOn = model.exclude.contains(excludable)
         toggle.addTarget(self, action: #selector(excludeToggleChanged(_:)), for: .valueChanged)
         excludeToggles[excludable] = toggle
 
@@ -396,19 +277,19 @@ final class LogSamplingDecouplingViewController: UIViewController {
 extension LogSamplingDecouplingViewController: UITableViewDataSource, UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        max(Self.captured.count, 1)
+        max(model.captured.count, 1)
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "captured", for: indexPath)
         cell.selectionStyle = .none
         var config = UIListContentConfiguration.subtitleCell()
-        if Self.captured.isEmpty {
+        if model.captured.isEmpty {
             config.text = "(no spans yet — apply a config and trigger events)"
             config.textProperties.color = .secondaryLabel
             config.textProperties.font = .preferredFont(forTextStyle: .footnote)
         } else {
-            let row = Self.captured[indexPath.row]
+            let row = model.captured[indexPath.row]
             config.text = row.eventType
             config.secondaryText = "\(row.timeString)  ·  \(row.name)"
             config.textProperties.font = .monospacedSystemFont(ofSize: 13, weight: .medium)

--- a/Example/DemoAppSwift/LogSamplingDecouplingViewController.swift
+++ b/Example/DemoAppSwift/LogSamplingDecouplingViewController.swift
@@ -1,0 +1,396 @@
+//
+//  LogSamplingDecouplingViewController.swift
+//  DemoAppSwift
+//
+//  Manual harness for PIPEV2-3365: pick a sessionSampleRate (0/50/100) and an
+//  excludeFromSampling set, reinitialize the SDK with that config, then fire
+//  events and watch which event_types actually survive the sampling filter
+//  via the tracesExporter callback.
+//
+
+import UIKit
+import Coralogix
+import CoralogixInternal
+
+private struct CapturedSpan {
+    let eventType: String
+    let name: String
+    let receivedAt: Date
+
+    var timeString: String {
+        let f = DateFormatter()
+        f.dateFormat = "HH:mm:ss"
+        return f.string(from: receivedAt)
+    }
+}
+
+final class LogSamplingDecouplingViewController: UIViewController {
+
+    // MARK: - Persistent state
+
+    private static var currentSampleRate: Int = 0
+    private static var currentExclude: Set<ExcludableInstrumentation> = [.logs]
+    private static var isApplied = false
+    private static var captured: [CapturedSpan] = []
+
+    private static let allExcludable: [ExcludableInstrumentation] =
+        [.logs, .errors, .network, .userInteractions, .mobileVitals, .customSpan, .customMeasurement]
+
+    // MARK: - UI
+
+    private let scrollView = UIScrollView()
+    private let contentStack = UIStackView()
+
+    private let sampleRateSegmented = UISegmentedControl(items: ["0%", "50%", "100%"])
+    private let statusLabel = UILabel()
+    private let appliedConfigLabel = UILabel()
+    private var excludeToggles: [ExcludableInstrumentation: UISwitch] = [:]
+
+    private lazy var applyButton: UIButton = makeButton("Apply (reinit SDK)",
+                                                        icon: "arrow.clockwise.circle",
+                                                        action: #selector(didTapApply))
+    private lazy var sendLogButton: UIButton = makeButton("Send Log",
+                                                          icon: "text.bubble",
+                                                          action: #selector(didTapSendLog))
+    private lazy var sendErrorButton: UIButton = makeButton("Send Error",
+                                                            icon: "exclamationmark.triangle",
+                                                            action: #selector(didTapSendError))
+    private lazy var sendNetworkButton: UIButton = makeButton("Send Network",
+                                                              icon: "network",
+                                                              action: #selector(didTapSendNetwork))
+    private lazy var sendCustomSpanButton: UIButton = makeButton("Send Custom Span",
+                                                                  icon: "point.3.connected.trianglepath.dotted",
+                                                                  action: #selector(didTapSendCustomSpan))
+    private lazy var clearButton: UIButton = makeButton("Clear captured",
+                                                        icon: "trash",
+                                                        action: #selector(didTapClear))
+
+    private let capturedTable = UITableView(frame: .zero, style: .plain)
+
+    // MARK: - Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Log Sampling Decoupling"
+        view.backgroundColor = .systemBackground
+
+        setupLayout()
+        configureFromState()
+        capturedTable.dataSource = self
+        capturedTable.delegate = self
+        capturedTable.register(UITableViewCell.self, forCellReuseIdentifier: "captured")
+        updateAppliedConfigLabel()
+        updateButtonsEnabled()
+    }
+
+    private func setupLayout() {
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        contentStack.translatesAutoresizingMaskIntoConstraints = false
+        contentStack.axis = .vertical
+        contentStack.spacing = 14
+        contentStack.alignment = .fill
+
+        view.addSubview(scrollView)
+        scrollView.addSubview(contentStack)
+
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+
+            contentStack.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor, constant: 16),
+            contentStack.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor, constant: 16),
+            contentStack.trailingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.trailingAnchor, constant: -16),
+            contentStack.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor, constant: -16),
+            contentStack.widthAnchor.constraint(equalTo: scrollView.frameLayoutGuide.widthAnchor, constant: -32)
+        ])
+
+        contentStack.addArrangedSubview(makeSectionHeader("sessionSampleRate"))
+        sampleRateSegmented.addTarget(self, action: #selector(sampleRateChanged), for: .valueChanged)
+        contentStack.addArrangedSubview(sampleRateSegmented)
+
+        contentStack.addArrangedSubview(makeSectionHeader("excludeFromSampling"))
+        for excludable in Self.allExcludable {
+            let row = makeExcludeRow(excludable)
+            contentStack.addArrangedSubview(row)
+        }
+
+        statusLabel.font = .preferredFont(forTextStyle: .footnote)
+        statusLabel.numberOfLines = 0
+        contentStack.addArrangedSubview(statusLabel)
+        contentStack.addArrangedSubview(applyButton)
+
+        contentStack.addArrangedSubview(makeSectionHeader("Applied config"))
+        appliedConfigLabel.font = .monospacedSystemFont(ofSize: 12, weight: .regular)
+        appliedConfigLabel.textColor = .secondaryLabel
+        appliedConfigLabel.numberOfLines = 0
+        contentStack.addArrangedSubview(appliedConfigLabel)
+
+        contentStack.addArrangedSubview(makeSectionHeader("Trigger events"))
+        let triggers = UIStackView(arrangedSubviews: [sendLogButton, sendErrorButton])
+        triggers.axis = .horizontal
+        triggers.spacing = 8
+        triggers.distribution = .fillEqually
+        let triggers2 = UIStackView(arrangedSubviews: [sendNetworkButton, sendCustomSpanButton])
+        triggers2.axis = .horizontal
+        triggers2.spacing = 8
+        triggers2.distribution = .fillEqually
+        contentStack.addArrangedSubview(triggers)
+        contentStack.addArrangedSubview(triggers2)
+
+        contentStack.addArrangedSubview(makeSectionHeader("Captured (tracesExporter)"))
+        contentStack.addArrangedSubview(clearButton)
+
+        capturedTable.translatesAutoresizingMaskIntoConstraints = false
+        capturedTable.layer.cornerRadius = 10
+        capturedTable.layer.borderWidth = 0.5
+        capturedTable.layer.borderColor = UIColor.separator.cgColor
+        capturedTable.heightAnchor.constraint(equalToConstant: 240).isActive = true
+        contentStack.addArrangedSubview(capturedTable)
+    }
+
+    private func configureFromState() {
+        switch Self.currentSampleRate {
+        case 0:   sampleRateSegmented.selectedSegmentIndex = 0
+        case 50:  sampleRateSegmented.selectedSegmentIndex = 1
+        default:  sampleRateSegmented.selectedSegmentIndex = 2
+        }
+        for (excludable, toggle) in excludeToggles {
+            toggle.isOn = Self.currentExclude.contains(excludable)
+        }
+        updateStatusLabel()
+    }
+
+    // MARK: - Actions
+
+    @objc private func sampleRateChanged() {
+        Self.currentSampleRate = [0, 50, 100][sampleRateSegmented.selectedSegmentIndex]
+        updateStatusLabel()
+    }
+
+    @objc private func excludeToggleChanged(_ toggle: UISwitch) {
+        guard let excludable = Self.allExcludable.first(where: { excludeToggles[$0] === toggle }) else { return }
+        if toggle.isOn {
+            Self.currentExclude.insert(excludable)
+        } else {
+            Self.currentExclude.remove(excludable)
+        }
+        updateStatusLabel()
+    }
+
+    @objc private func didTapApply() {
+        let rate = Self.currentSampleRate
+        let exclude = Self.currentExclude
+        if rate == 0 && exclude.isEmpty {
+            showToast("sampleRate=0 + exclude=[] would skip init (legacy contract). Pick a rate or an exclude.")
+            return
+        }
+
+        CoralogixRumManager.shared.sdk.shutdown()
+        let options = CoralogixExporterOptions(
+            coralogixDomain: .EU2,
+            userContext: UserContext(userId: "sampling-test",
+                                     userName: "Sampling Tester",
+                                     userEmail: "sampling@example.com",
+                                     userMetadata: ["test": "logSamplingDecoupling"]),
+            environment: "PROD",
+            application: "DemoApp-iOS-LogSamplingDecoupling",
+            version: "1",
+            publicKey: Envs.PUBLIC_KEY.rawValue,
+            sessionSampleRate: rate,
+            excludeFromSampling: exclude,
+            instrumentations: [.mobileVitals: true, .custom: true, .errors: true,
+                               .userActions: true, .network: true, .anr: true, .lifeCycle: true],
+            collectIPData: true,
+            traceParentInHeader: ["enable": true],
+            tracesExporter: { [weak self] data in
+                let now = Date()
+                var rows: [CapturedSpan] = []
+                for resourceSpan in data.tracesData.resourceSpans {
+                    for scopeSpan in resourceSpan.scopeSpans {
+                        for span in scopeSpan.spans {
+                            rows.append(CapturedSpan(
+                                eventType: Self.eventType(in: span) ?? "(no event_type)",
+                                name: span.name,
+                                receivedAt: now
+                            ))
+                        }
+                    }
+                }
+                guard !rows.isEmpty else { return }
+                DispatchQueue.main.async {
+                    Self.captured.insert(contentsOf: rows.reversed(), at: 0)
+                    self?.capturedTable.reloadData()
+                }
+            },
+            debug: true
+        )
+        CoralogixRumManager.shared.reinitialize(with: options)
+        Self.isApplied = true
+        updateAppliedConfigLabel()
+        updateButtonsEnabled()
+        showToast("SDK reinitialized — rate=\(rate), exclude=\(formatExclude(exclude))")
+    }
+
+    @objc private func didTapSendLog() {
+        CoralogixRumManager.shared.sdk.log(severity: .info,
+                                           message: "Sampling demo log",
+                                           data: ["source": "LogSamplingDecouplingVC"])
+        showToast("log() called")
+    }
+
+    @objc private func didTapSendError() {
+        CoralogixRumManager.shared.sdk.reportError(message: "Sampling demo error", data: nil)
+        showToast("reportError() called")
+    }
+
+    @objc private func didTapSendNetwork() {
+        NetworkSim.sendSuccesfullRequest()
+        showToast("Network request sent")
+    }
+
+    @objc private func didTapSendCustomSpan() {
+        let rum = CoralogixRumManager.shared.sdk
+        guard rum.isInitialized else { showToast("SDK not initialized"); return }
+        guard let tracer = rum.getCustomTracer() else { showToast("Failed to get custom tracer"); return }
+        guard let global = tracer.startGlobalSpan(name: "sampling-demo.global",
+                                                   labels: ["source": "LogSamplingDecouplingVC"]) else {
+            showToast("startGlobalSpan returned nil")
+            return
+        }
+        let child = global.startCustomSpan(name: "sampling-demo.child")
+        child.endSpan()
+        global.endSpan()
+        showToast("Custom span emitted")
+    }
+
+    @objc private func didTapClear() {
+        Self.captured.removeAll()
+        capturedTable.reloadData()
+    }
+
+    // MARK: - Helpers
+
+    private static func eventType(in span: OtlpSpan) -> String? {
+        guard let kv = span.attributes.first(where: { $0.key == CoralogixInternal.Keys.eventType.rawValue }) else { return nil }
+        if case .stringValue(let value) = kv.value { return value }
+        return nil
+    }
+
+    private func updateStatusLabel() {
+        let rate = Self.currentSampleRate
+        let exclude = Self.currentExclude
+        if rate == 0 && exclude.isEmpty {
+            statusLabel.text = "⚠️ rate=0 + exclude=[] would short-circuit init (legacy contract). Apply will refuse this combination."
+            statusLabel.textColor = .systemOrange
+        } else if rate == 100 {
+            statusLabel.text = "ℹ️ Sampled in: every event passes regardless of excludeFromSampling."
+            statusLabel.textColor = .secondaryLabel
+        } else if rate == 0 {
+            statusLabel.text = "ℹ️ Sampled out (rate=0): only event_types in excludeFromSampling will be exported."
+            statusLabel.textColor = .secondaryLabel
+        } else {
+            statusLabel.text = "ℹ️ ~\(rate)% of fresh sessions roll sampled-in. Reinit (or relaunch) to roll a new session."
+            statusLabel.textColor = .secondaryLabel
+        }
+    }
+
+    private func updateAppliedConfigLabel() {
+        if Self.isApplied {
+            appliedConfigLabel.text =
+                "rate=\(Self.currentSampleRate)\n" +
+                "exclude=\(formatExclude(Self.currentExclude))\n" +
+                "isInitialized=\(CoralogixRumManager.shared.sdk.isInitialized)"
+        } else {
+            appliedConfigLabel.text = "(not applied — tap Apply to reinit the SDK)"
+        }
+    }
+
+    private func updateButtonsEnabled() {
+        let on = Self.isApplied
+        for btn in [sendLogButton, sendErrorButton, sendNetworkButton, sendCustomSpanButton] {
+            btn.isEnabled = on
+            btn.alpha = on ? 1 : 0.4
+        }
+    }
+
+    private func formatExclude(_ set: Set<ExcludableInstrumentation>) -> String {
+        if set.isEmpty { return "[]" }
+        return "[" + set.map { ".\($0.rawValue)" }.sorted().joined(separator: ", ") + "]"
+    }
+
+    // MARK: - View builders
+
+    private func makeSectionHeader(_ title: String) -> UILabel {
+        let l = UILabel()
+        l.text = title
+        l.font = .preferredFont(forTextStyle: .headline)
+        return l
+    }
+
+    private func makeExcludeRow(_ excludable: ExcludableInstrumentation) -> UIView {
+        let label = UILabel()
+        label.text = ".\(excludable.rawValue)"
+        label.font = .preferredFont(forTextStyle: .body)
+
+        let toggle = UISwitch()
+        toggle.isOn = Self.currentExclude.contains(excludable)
+        toggle.addTarget(self, action: #selector(excludeToggleChanged(_:)), for: .valueChanged)
+        excludeToggles[excludable] = toggle
+
+        let row = UIStackView(arrangedSubviews: [label, UIView(), toggle])
+        row.axis = .horizontal
+        row.alignment = .center
+        row.spacing = 8
+        return row
+    }
+
+    private func makeButton(_ title: String, icon: String, action: Selector) -> UIButton {
+        let btn = UIButton(type: .system)
+        btn.setTitle(" " + title, for: .normal)
+        btn.setImage(UIImage(systemName: icon), for: .normal)
+        btn.titleLabel?.font = .preferredFont(forTextStyle: .body)
+        btn.contentEdgeInsets = UIEdgeInsets(top: 10, left: 12, bottom: 10, right: 12)
+        btn.backgroundColor = UIColor.systemBlue.withAlphaComponent(0.12)
+        btn.layer.cornerRadius = 10
+        btn.tintColor = .systemBlue
+        btn.addTarget(self, action: action, for: .touchUpInside)
+        return btn
+    }
+
+    private func showToast(_ message: String) {
+        let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+        present(alert, animated: true)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.4) { alert.dismiss(animated: true) }
+    }
+}
+
+// MARK: - Captured table
+
+extension LogSamplingDecouplingViewController: UITableViewDataSource, UITableViewDelegate {
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        max(Self.captured.count, 1)
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "captured", for: indexPath)
+        cell.selectionStyle = .none
+        var config = UIListContentConfiguration.subtitleCell()
+        if Self.captured.isEmpty {
+            config.text = "(no spans yet — apply a config and trigger events)"
+            config.textProperties.color = .secondaryLabel
+            config.textProperties.font = .preferredFont(forTextStyle: .footnote)
+        } else {
+            let row = Self.captured[indexPath.row]
+            config.text = row.eventType
+            config.secondaryText = "\(row.timeString)  ·  \(row.name)"
+            config.textProperties.font = .monospacedSystemFont(ofSize: 13, weight: .medium)
+            config.secondaryTextProperties.font = .preferredFont(forTextStyle: .caption2)
+            config.secondaryTextProperties.color = .secondaryLabel
+        }
+        cell.contentConfiguration = config
+        return cell
+    }
+}

--- a/Example/DemoAppSwift/LogSamplingDecouplingViewController.swift
+++ b/Example/DemoAppSwift/LogSamplingDecouplingViewController.swift
@@ -61,6 +61,9 @@ final class LogSamplingDecouplingViewController: UIViewController {
     private lazy var sendCustomSpanButton: UIButton = makeButton("Send Custom Span",
                                                                   icon: "point.3.connected.trianglepath.dotted",
                                                                   action: #selector(didTapSendCustomSpan))
+    private lazy var sendCustomMeasurementButton: UIButton = makeButton("Send Custom Measurement",
+                                                                         icon: "ruler",
+                                                                         action: #selector(didTapSendCustomMeasurement))
     private lazy var clearButton: UIButton = makeButton("Clear captured",
                                                         icon: "trash",
                                                         action: #selector(didTapClear))
@@ -121,6 +124,13 @@ final class LogSamplingDecouplingViewController: UIViewController {
         contentStack.addArrangedSubview(statusLabel)
         contentStack.addArrangedSubview(applyButton)
 
+        let applyNote = UILabel()
+        applyNote.text = "Apply rebuilds the SDK on EU2 with all instrumentations on; overrides the initial CoralogixRumManager config."
+        applyNote.font = .preferredFont(forTextStyle: .caption2)
+        applyNote.textColor = .tertiaryLabel
+        applyNote.numberOfLines = 0
+        contentStack.addArrangedSubview(applyNote)
+
         contentStack.addArrangedSubview(makeSectionHeader("Applied config"))
         appliedConfigLabel.font = .monospacedSystemFont(ofSize: 12, weight: .regular)
         appliedConfigLabel.textColor = .secondaryLabel
@@ -138,6 +148,7 @@ final class LogSamplingDecouplingViewController: UIViewController {
         triggers2.distribution = .fillEqually
         contentStack.addArrangedSubview(triggers)
         contentStack.addArrangedSubview(triggers2)
+        contentStack.addArrangedSubview(sendCustomMeasurementButton)
 
         contentStack.addArrangedSubview(makeSectionHeader("Captured (tracesExporter)"))
         contentStack.addArrangedSubview(clearButton)
@@ -211,7 +222,7 @@ final class LogSamplingDecouplingViewController: UIViewController {
                     for scopeSpan in resourceSpan.scopeSpans {
                         for span in scopeSpan.spans {
                             rows.append(CapturedSpan(
-                                eventType: Self.eventType(in: span) ?? "(no event_type)",
+                                eventType: span.eventType ?? "(no event_type)",
                                 name: span.name,
                                 receivedAt: now
                             ))
@@ -265,18 +276,17 @@ final class LogSamplingDecouplingViewController: UIViewController {
         showToast("Custom span emitted")
     }
 
+    @objc private func didTapSendCustomMeasurement() {
+        CoralogixRumManager.shared.sdk.sendCustomMeasurement(name: "sampling-demo.measurement", value: 42.0)
+        showToast("sendCustomMeasurement() called")
+    }
+
     @objc private func didTapClear() {
         Self.captured.removeAll()
         capturedTable.reloadData()
     }
 
     // MARK: - Helpers
-
-    private static func eventType(in span: OtlpSpan) -> String? {
-        guard let kv = span.attributes.first(where: { $0.key == CoralogixInternal.Keys.eventType.rawValue }) else { return nil }
-        if case .stringValue(let value) = kv.value { return value }
-        return nil
-    }
 
     private func updateStatusLabel() {
         let rate = Self.currentSampleRate
@@ -309,7 +319,7 @@ final class LogSamplingDecouplingViewController: UIViewController {
 
     private func updateButtonsEnabled() {
         let on = Self.isApplied
-        for btn in [sendLogButton, sendErrorButton, sendNetworkButton, sendCustomSpanButton] {
+        for btn in [sendLogButton, sendErrorButton, sendNetworkButton, sendCustomSpanButton, sendCustomMeasurementButton] {
             btn.isEnabled = on
             btn.alpha = on ? 1 : 0.4
         }
@@ -322,7 +332,7 @@ final class LogSamplingDecouplingViewController: UIViewController {
 
     // MARK: - View builders
 
-    private func makeSectionHeader(_ title: String) -> UILabel {
+    private func makeSectionHeader(_ title: String) -> UIView {
         let l = UILabel()
         l.text = title
         l.font = .preferredFont(forTextStyle: .headline)
@@ -351,6 +361,8 @@ final class LogSamplingDecouplingViewController: UIViewController {
         btn.setTitle(" " + title, for: .normal)
         btn.setImage(UIImage(systemName: icon), for: .normal)
         btn.titleLabel?.font = .preferredFont(forTextStyle: .body)
+        // contentEdgeInsets is deprecated in iOS 15 (replaced by UIButton.Configuration),
+        // but the demo app's deployment target is iOS 13 so the modern API isn't available.
         btn.contentEdgeInsets = UIEdgeInsets(top: 10, left: 12, bottom: 10, right: 12)
         btn.backgroundColor = UIColor.systemBlue.withAlphaComponent(0.12)
         btn.layer.cornerRadius = 10

--- a/Example/DemoAppSwift/LogSamplingDecouplingViewController.swift
+++ b/Example/DemoAppSwift/LogSamplingDecouplingViewController.swift
@@ -208,8 +208,8 @@ final class LogSamplingDecouplingViewController: UIViewController {
     private func updateAppliedConfigLabel() {
         if model.isApplied {
             appliedConfigLabel.text =
-                "rate=\(model.sampleRate)\n" +
-                "exclude=\(model.formattedExclude)\n" +
+                "rate=\(model.appliedSampleRate)\n" +
+                "exclude=\(model.formattedAppliedExclude)\n" +
                 "isInitialized=\(CoralogixRumManager.shared.sdk.isInitialized)"
         } else {
             appliedConfigLabel.text = "(not applied — tap Apply to reinit the SDK)"

--- a/Example/DemoAppSwift/LogSamplingDecouplingViewController.swift
+++ b/Example/DemoAppSwift/LogSamplingDecouplingViewController.swift
@@ -32,6 +32,10 @@ final class LogSamplingDecouplingViewController: UIViewController {
     private static var currentExclude: Set<ExcludableInstrumentation> = [.logs]
     private static var isApplied = false
     private static var captured: [CapturedSpan] = []
+    /// Bumped on every Apply. Each tracesExporter closure captures its token so late
+    /// callbacks from a previous run (e.g., flushed by BatchSpanProcessor after
+    /// shutdown but before reinit) can be discarded instead of polluting the list.
+    private static var currentRunToken: Int = 0
 
     private static let allExcludable: [ExcludableInstrumentation] =
         [.logs, .errors, .network, .userInteractions, .mobileVitals, .customSpan, .customMeasurement]
@@ -198,6 +202,14 @@ final class LogSamplingDecouplingViewController: UIViewController {
             return
         }
 
+        // Bump the run token first so any late callback from the previous run (still
+        // possibly in flight on the BatchSpanProcessor's queue) is discarded by the
+        // closure's token guard rather than re-filling the just-cleared list.
+        Self.currentRunToken += 1
+        let runToken = Self.currentRunToken
+        Self.captured.removeAll()
+        capturedTable.reloadData()
+
         CoralogixRumManager.shared.sdk.shutdown()
         let options = CoralogixExporterOptions(
             coralogixDomain: .EU2,
@@ -231,6 +243,7 @@ final class LogSamplingDecouplingViewController: UIViewController {
                 }
                 guard !rows.isEmpty else { return }
                 DispatchQueue.main.async {
+                    guard runToken == Self.currentRunToken else { return }
                     Self.captured.insert(contentsOf: rows.reversed(), at: 0)
                     self?.capturedTable.reloadData()
                 }

--- a/Example/DemoAppSwift/MainViewController.swift
+++ b/Example/DemoAppSwift/MainViewController.swift
@@ -73,6 +73,12 @@ final class MainViewController: UITableViewController {
             subtitle: "Test OTLP trace export callback",
             systemImageName: "arrow.up.doc",
             key: .tracesExporter
+        ),
+        .init(
+            title: "Log Sampling Decoupling",
+            subtitle: "Pick rate + exclude set, fire events, watch what survives",
+            systemImageName: "slider.horizontal.3",
+            key: .logSamplingDecoupling
         )
     ]
 
@@ -265,6 +271,8 @@ final class MainViewController: UITableViewController {
             vc = MaskViewController()
         case .tracesExporter:
             vc = TracesExporterViewController()
+        case .logSamplingDecoupling:
+            vc = LogSamplingDecouplingViewController()
         default:
             showToast("Not implemented for this menu item")
             return

--- a/Example/DemoAppSwiftUI/ContentView.swift
+++ b/Example/DemoAppSwiftUI/ContentView.swift
@@ -73,6 +73,12 @@ struct ContentView: View {
                 subtitle: "Test OTLP trace export callback",
                 icon: "arrow.up.doc",
                 destination: AnyView(TracesExporterView())
+            ),
+            MenuItem(
+                title: "Log Sampling Decoupling",
+                subtitle: "Pick rate + exclude set, fire events, watch what survives",
+                icon: "slider.horizontal.3",
+                destination: AnyView(LogSamplingDecouplingView())
             )
         ]
     }

--- a/Example/DemoAppSwiftUI/LogSamplingDecouplingView.swift
+++ b/Example/DemoAppSwiftUI/LogSamplingDecouplingView.swift
@@ -1,0 +1,266 @@
+//
+//  LogSamplingDecouplingView.swift
+//  DemoAppSwiftUI
+//
+//  SwiftUI counterpart of LogSamplingDecouplingViewController. Pick a sample
+//  rate + exclude set, reinitialize the SDK, fire events, and watch which
+//  event_types survive the sampling filter via the tracesExporter callback.
+//
+
+import SwiftUI
+import Coralogix
+import CoralogixInternal
+
+private struct CapturedSpan: Identifiable {
+    let id = UUID()
+    let eventType: String
+    let name: String
+    let receivedAt: Date
+
+    var timeString: String {
+        let f = DateFormatter()
+        f.dateFormat = "HH:mm:ss"
+        return f.string(from: receivedAt)
+    }
+}
+
+private enum LogSamplingState {
+    static var sampleRate: Int = 0
+    static var exclude: Set<ExcludableInstrumentation> = [.logs]
+    static var isApplied = false
+    static var captured: [CapturedSpan] = []
+}
+
+struct LogSamplingDecouplingView: View {
+
+    private static let allExcludable: [ExcludableInstrumentation] =
+        [.logs, .errors, .network, .userInteractions, .mobileVitals, .customSpan, .customMeasurement]
+
+    @State private var sampleRate: Int = LogSamplingState.sampleRate
+    @State private var exclude: Set<ExcludableInstrumentation> = LogSamplingState.exclude
+    @State private var isApplied: Bool = LogSamplingState.isApplied
+    @State private var captured: [CapturedSpan] = LogSamplingState.captured
+    @State private var toastMessage: String?
+
+    var body: some View {
+        Form {
+            Section("sessionSampleRate") {
+                Picker("Sample rate", selection: $sampleRate) {
+                    Text("0%").tag(0)
+                    Text("50%").tag(50)
+                    Text("100%").tag(100)
+                }
+                .pickerStyle(.segmented)
+                .onChange(of: sampleRate) { LogSamplingState.sampleRate = $0 }
+            }
+
+            Section("excludeFromSampling") {
+                ForEach(Self.allExcludable, id: \.self) { excludable in
+                    Toggle(".\(excludable.rawValue)",
+                           isOn: bindingForExclude(excludable))
+                }
+            }
+
+            Section {
+                statusText
+                Button {
+                    apply()
+                } label: {
+                    Label("Apply (reinit SDK)", systemImage: "arrow.clockwise.circle")
+                }
+            }
+
+            Section("Applied config") {
+                if isApplied {
+                    Text(appliedConfigText)
+                        .font(.system(.footnote, design: .monospaced))
+                        .foregroundColor(.secondary)
+                } else {
+                    Text("(not applied — tap Apply to reinit the SDK)")
+                        .font(.footnote)
+                        .foregroundColor(.secondary)
+                }
+            }
+
+            Section("Trigger events") {
+                Button { triggerLog() } label: { Label("Send Log", systemImage: "text.bubble") }
+                Button { triggerError() } label: { Label("Send Error", systemImage: "exclamationmark.triangle") }
+                Button { triggerNetwork() } label: { Label("Send Network", systemImage: "network") }
+                Button { triggerCustomSpan() } label: { Label("Send Custom Span", systemImage: "point.3.connected.trianglepath.dotted") }
+            }
+            .disabled(!isApplied)
+
+            Section {
+                HStack {
+                    Text("Captured (tracesExporter)")
+                        .font(.headline)
+                    Spacer()
+                    Button {
+                        LogSamplingState.captured.removeAll()
+                        captured = []
+                    } label: {
+                        Image(systemName: "trash").foregroundColor(.red)
+                    }
+                    .disabled(captured.isEmpty)
+                }
+
+                if captured.isEmpty {
+                    Text("(no spans yet — apply a config and trigger events)")
+                        .font(.footnote)
+                        .foregroundColor(.secondary)
+                } else {
+                    ForEach(captured) { row in
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(row.eventType)
+                                .font(.system(.callout, design: .monospaced))
+                            Text("\(row.timeString)  ·  \(row.name)")
+                                .font(.caption2)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                }
+            }
+        }
+        .navigationTitle("Log Sampling Decoupling")
+        .navigationBarTitleDisplayMode(.inline)
+        .trackCXView(name: "Log Sampling Decoupling")
+        .toast(message: $toastMessage)
+    }
+
+    // MARK: - Computed views / state
+
+    private var statusText: some View {
+        Group {
+            if sampleRate == 0 && exclude.isEmpty {
+                Text("⚠️ rate=0 + exclude=[] would short-circuit init (legacy contract). Apply will refuse this combination.")
+                    .foregroundColor(.orange)
+            } else if sampleRate == 100 {
+                Text("ℹ️ Sampled in: every event passes regardless of excludeFromSampling.")
+                    .foregroundColor(.secondary)
+            } else if sampleRate == 0 {
+                Text("ℹ️ Sampled out (rate=0): only event_types in excludeFromSampling will be exported.")
+                    .foregroundColor(.secondary)
+            } else {
+                Text("ℹ️ ~\(sampleRate)% of fresh sessions roll sampled-in. Reinit (or relaunch) to roll a new session.")
+                    .foregroundColor(.secondary)
+            }
+        }
+        .font(.footnote)
+    }
+
+    private var appliedConfigText: String {
+        "rate=\(LogSamplingState.sampleRate)\n" +
+        "exclude=\(formatExclude(LogSamplingState.exclude))\n" +
+        "isInitialized=\(CoralogixRumManager.shared.sdk.isInitialized)"
+    }
+
+    private func bindingForExclude(_ excludable: ExcludableInstrumentation) -> Binding<Bool> {
+        Binding(
+            get: { exclude.contains(excludable) },
+            set: { isOn in
+                if isOn { exclude.insert(excludable) } else { exclude.remove(excludable) }
+                LogSamplingState.exclude = exclude
+            }
+        )
+    }
+
+    // MARK: - Actions
+
+    private func apply() {
+        if sampleRate == 0 && exclude.isEmpty {
+            toastMessage = "sampleRate=0 + exclude=[] would skip init. Pick a rate or an exclude."
+            return
+        }
+
+        CoralogixRumManager.shared.sdk.shutdown()
+        let options = CoralogixExporterOptions(
+            coralogixDomain: .EU2,
+            userContext: UserContext(userId: "sampling-test",
+                                     userName: "Sampling Tester",
+                                     userEmail: "sampling@example.com",
+                                     userMetadata: ["test": "logSamplingDecoupling"]),
+            environment: "PROD",
+            application: "DemoApp-iOS-LogSamplingDecoupling",
+            version: "1",
+            publicKey: Envs.PUBLIC_KEY.rawValue,
+            sessionSampleRate: sampleRate,
+            excludeFromSampling: exclude,
+            instrumentations: [.mobileVitals: true, .custom: true, .errors: true,
+                               .userActions: true, .network: true, .anr: true, .lifeCycle: true],
+            collectIPData: true,
+            traceParentInHeader: ["enable": true],
+            tracesExporter: { data in
+                let now = Date()
+                var rows: [CapturedSpan] = []
+                for resourceSpan in data.tracesData.resourceSpans {
+                    for scopeSpan in resourceSpan.scopeSpans {
+                        for span in scopeSpan.spans {
+                            rows.append(CapturedSpan(
+                                eventType: eventType(in: span) ?? "(no event_type)",
+                                name: span.name,
+                                receivedAt: now
+                            ))
+                        }
+                    }
+                }
+                guard !rows.isEmpty else { return }
+                DispatchQueue.main.async {
+                    LogSamplingState.captured.insert(contentsOf: rows.reversed(), at: 0)
+                    captured = LogSamplingState.captured
+                }
+            },
+            debug: true
+        )
+        CoralogixRumManager.shared.reinitialize(with: options)
+        LogSamplingState.sampleRate = sampleRate
+        LogSamplingState.exclude = exclude
+        LogSamplingState.isApplied = true
+        isApplied = true
+        toastMessage = "SDK reinitialized — rate=\(sampleRate), exclude=\(formatExclude(exclude))"
+    }
+
+    private func triggerLog() {
+        CoralogixRumManager.shared.sdk.log(severity: .info,
+                                           message: "Sampling demo log",
+                                           data: ["source": "LogSamplingDecouplingView"])
+        toastMessage = "log() called"
+    }
+
+    private func triggerError() {
+        CoralogixRumManager.shared.sdk.reportError(message: "Sampling demo error", data: nil)
+        toastMessage = "reportError() called"
+    }
+
+    private func triggerNetwork() {
+        NetworkSim.sendSuccesfullRequest()
+        toastMessage = "Network request sent"
+    }
+
+    private func triggerCustomSpan() {
+        let rum = CoralogixRumManager.shared.sdk
+        guard rum.isInitialized else { toastMessage = "SDK not initialized"; return }
+        guard let tracer = rum.getCustomTracer() else { toastMessage = "Failed to get custom tracer"; return }
+        guard let global = tracer.startGlobalSpan(name: "sampling-demo.global",
+                                                   labels: ["source": "LogSamplingDecouplingView"]) else {
+            toastMessage = "startGlobalSpan returned nil"
+            return
+        }
+        let child = global.startCustomSpan(name: "sampling-demo.child")
+        child.endSpan()
+        global.endSpan()
+        toastMessage = "Custom span emitted"
+    }
+
+    // MARK: - Helpers
+
+    private func formatExclude(_ set: Set<ExcludableInstrumentation>) -> String {
+        if set.isEmpty { return "[]" }
+        return "[" + set.map { ".\($0.rawValue)" }.sorted().joined(separator: ", ") + "]"
+    }
+}
+
+private func eventType(in span: OtlpSpan) -> String? {
+    guard let kv = span.attributes.first(where: { $0.key == CoralogixInternal.Keys.eventType.rawValue }) else { return nil }
+    if case .stringValue(let value) = kv.value { return value }
+    return nil
+}

--- a/Example/DemoAppSwiftUI/LogSamplingDecouplingView.swift
+++ b/Example/DemoAppSwiftUI/LogSamplingDecouplingView.swift
@@ -29,6 +29,10 @@ private enum LogSamplingState {
     static var exclude: Set<ExcludableInstrumentation> = [.logs]
     static var isApplied = false
     static var captured: [CapturedSpan] = []
+    /// Bumped on every Apply. Each tracesExporter closure captures its token so late
+    /// callbacks from a previous run (e.g., flushed by BatchSpanProcessor after
+    /// shutdown but before reinit) can be discarded instead of polluting the list.
+    static var runToken: Int = 0
 }
 
 struct LogSamplingDecouplingView: View {
@@ -186,6 +190,14 @@ struct LogSamplingDecouplingView: View {
             return
         }
 
+        // Bump the run token first so any late callback from the previous run (still
+        // possibly in flight on the BatchSpanProcessor's queue) is discarded by the
+        // closure's token guard rather than re-filling the just-cleared list.
+        LogSamplingState.runToken += 1
+        let runToken = LogSamplingState.runToken
+        LogSamplingState.captured.removeAll()
+        refreshTick = UUID()
+
         CoralogixRumManager.shared.sdk.shutdown()
         let options = CoralogixExporterOptions(
             coralogixDomain: .EU2,
@@ -219,6 +231,7 @@ struct LogSamplingDecouplingView: View {
                 }
                 guard !rows.isEmpty else { return }
                 DispatchQueue.main.async {
+                    guard runToken == LogSamplingState.runToken else { return }
                     LogSamplingState.captured.insert(contentsOf: rows.reversed(), at: 0)
                     refreshTick = UUID()
                 }

--- a/Example/DemoAppSwiftUI/LogSamplingDecouplingView.swift
+++ b/Example/DemoAppSwiftUI/LogSamplingDecouplingView.swift
@@ -241,9 +241,20 @@ struct LogSamplingDecouplingView: View {
         CoralogixRumManager.shared.reinitialize(with: options)
         LogSamplingState.sampleRate = sampleRate
         LogSamplingState.exclude = exclude
-        LogSamplingState.isApplied = true
-        isApplied = true
-        toastMessage = "SDK reinitialized — rate=\(sampleRate), exclude=\(formatExclude(exclude))"
+
+        // Gate the success path on the SDK's real initialization state. Today the only
+        // known no-init path (rate=0 + exclude=[]) is already guarded above, but the
+        // contract could grow more skip paths — surfacing the failure here keeps the
+        // demo honest if that happens.
+        if CoralogixRumManager.shared.sdk.isInitialized {
+            LogSamplingState.isApplied = true
+            isApplied = true
+            toastMessage = "SDK reinitialized — rate=\(sampleRate), exclude=\(formatExclude(exclude))"
+        } else {
+            LogSamplingState.isApplied = false
+            isApplied = false
+            toastMessage = "❌ SDK failed to initialize for rate=\(sampleRate), exclude=\(formatExclude(exclude))"
+        }
     }
 
     private func triggerLog() {

--- a/Example/DemoAppSwiftUI/LogSamplingDecouplingView.swift
+++ b/Example/DemoAppSwiftUI/LogSamplingDecouplingView.swift
@@ -47,7 +47,7 @@ struct LogSamplingDecouplingView: View {
 
             Section("Applied config") {
                 if model.isApplied {
-                    Text("rate=\(model.appliedSampleRate)\nexclude=\(model.formattedAppliedExclude)\nisInitialized=\(CoralogixRumManager.shared.sdk.isInitialized)")
+                    Text(model.appliedConfigDescription)
                         .font(.system(.footnote, design: .monospaced))
                         .foregroundColor(.secondary)
                 } else {

--- a/Example/DemoAppSwiftUI/LogSamplingDecouplingView.swift
+++ b/Example/DemoAppSwiftUI/LogSamplingDecouplingView.swift
@@ -2,8 +2,8 @@
 //  LogSamplingDecouplingView.swift
 //  DemoAppSwiftUI
 //
-//  SwiftUI counterpart of LogSamplingDecouplingViewController. Pick a sample
-//  rate + exclude set, reinitialize the SDK, fire events, and watch which
+//  SwiftUI presenter on top of LogSamplingDemoModel — pick a sessionSampleRate +
+//  excludeFromSampling set, reinitialize the SDK, fire events, and watch which
 //  event_types survive the sampling filter via the tracesExporter callback.
 //
 
@@ -11,45 +11,15 @@ import SwiftUI
 import Coralogix
 import CoralogixInternal
 
-private struct CapturedSpan: Identifiable {
-    let id = UUID()
-    let eventType: String
-    let name: String
-    let receivedAt: Date
-
-    var timeString: String {
-        let f = DateFormatter()
-        f.dateFormat = "HH:mm:ss"
-        return f.string(from: receivedAt)
-    }
-}
-
-private enum LogSamplingState {
-    static var sampleRate: Int = 0
-    static var exclude: Set<ExcludableInstrumentation> = [.logs]
-    static var isApplied = false
-    static var captured: [CapturedSpan] = []
-    /// Bumped on every Apply. Each tracesExporter closure captures its token so late
-    /// callbacks from a previous run (e.g., flushed by BatchSpanProcessor after
-    /// shutdown but before reinit) can be discarded instead of polluting the list.
-    static var runToken: Int = 0
-}
-
 struct LogSamplingDecouplingView: View {
 
-    private static let allExcludable: [ExcludableInstrumentation] =
-        [.logs, .errors, .network, .userInteractions, .mobileVitals, .customSpan, .customMeasurement]
-
-    @State private var sampleRate: Int = LogSamplingState.sampleRate
-    @State private var exclude: Set<ExcludableInstrumentation> = LogSamplingState.exclude
-    @State private var isApplied: Bool = LogSamplingState.isApplied
-    @State private var refreshTick = UUID()
+    @ObservedObject private var model = LogSamplingDemoModel.shared
     @State private var toastMessage: String?
 
     var body: some View {
         Form {
             Section("sessionSampleRate") {
-                Picker("Sample rate", selection: sampleRateBinding) {
+                Picker("Sample rate", selection: $model.sampleRate) {
                     Text("0%").tag(0)
                     Text("50%").tag(50)
                     Text("100%").tag(100)
@@ -58,16 +28,15 @@ struct LogSamplingDecouplingView: View {
             }
 
             Section("excludeFromSampling") {
-                ForEach(Self.allExcludable, id: \.self) { excludable in
-                    Toggle(".\(excludable.rawValue)",
-                           isOn: bindingForExclude(excludable))
+                ForEach(LogSamplingDemoModel.allExcludable, id: \.self) { excludable in
+                    Toggle(".\(excludable.rawValue)", isOn: bindingForExclude(excludable))
                 }
             }
 
             Section {
                 statusText
                 Button {
-                    apply()
+                    toastMessage = model.apply()
                 } label: {
                     Label("Apply (reinit SDK)", systemImage: "arrow.clockwise.circle")
                 }
@@ -77,8 +46,8 @@ struct LogSamplingDecouplingView: View {
             }
 
             Section("Applied config") {
-                if isApplied {
-                    Text(appliedConfigText)
+                if model.isApplied {
+                    Text("rate=\(model.sampleRate)\nexclude=\(model.formattedExclude)\nisInitialized=\(CoralogixRumManager.shared.sdk.isInitialized)")
                         .font(.system(.footnote, design: .monospaced))
                         .foregroundColor(.secondary)
                 } else {
@@ -89,13 +58,13 @@ struct LogSamplingDecouplingView: View {
             }
 
             Section("Trigger events") {
-                Button { triggerLog() } label: { Label("Send Log", systemImage: "text.bubble") }
-                Button { triggerError() } label: { Label("Send Error", systemImage: "exclamationmark.triangle") }
-                Button { triggerNetwork() } label: { Label("Send Network", systemImage: "network") }
-                Button { triggerCustomSpan() } label: { Label("Send Custom Span", systemImage: "point.3.connected.trianglepath.dotted") }
-                Button { triggerCustomMeasurement() } label: { Label("Send Custom Measurement", systemImage: "ruler") }
+                Button { toastMessage = model.triggerLog() } label: { Label("Send Log", systemImage: "text.bubble") }
+                Button { toastMessage = model.triggerError() } label: { Label("Send Error", systemImage: "exclamationmark.triangle") }
+                Button { toastMessage = model.triggerNetwork() } label: { Label("Send Network", systemImage: "network") }
+                Button { toastMessage = model.triggerCustomSpan() } label: { Label("Send Custom Span", systemImage: "point.3.connected.trianglepath.dotted") }
+                Button { toastMessage = model.triggerCustomMeasurement() } label: { Label("Send Custom Measurement", systemImage: "ruler") }
             }
-            .disabled(!isApplied)
+            .disabled(!model.isApplied)
 
             Section {
                 HStack {
@@ -103,20 +72,19 @@ struct LogSamplingDecouplingView: View {
                         .font(.headline)
                     Spacer()
                     Button {
-                        LogSamplingState.captured.removeAll()
-                        refreshTick = UUID()
+                        model.clearCaptured()
                     } label: {
                         Image(systemName: "trash").foregroundColor(.red)
                     }
-                    .disabled(LogSamplingState.captured.isEmpty)
+                    .disabled(model.captured.isEmpty)
                 }
 
-                if LogSamplingState.captured.isEmpty {
+                if model.captured.isEmpty {
                     Text("(no spans yet — apply a config and trigger events)")
                         .font(.footnote)
                         .foregroundColor(.secondary)
                 } else {
-                    ForEach(LogSamplingState.captured) { row in
+                    ForEach(model.captured) { row in
                         VStack(alignment: .leading, spacing: 2) {
                             Text(row.eventType)
                                 .font(.system(.callout, design: .monospaced))
@@ -127,7 +95,6 @@ struct LogSamplingDecouplingView: View {
                     }
                 }
             }
-            .id(refreshTick)
         }
         .navigationTitle("Log Sampling Decoupling")
         .navigationBarTitleDisplayMode(.inline)
@@ -135,169 +102,32 @@ struct LogSamplingDecouplingView: View {
         .toast(message: $toastMessage)
     }
 
-    // MARK: - Computed views / state
-
+    @SwiftUI.ViewBuilder
     private var statusText: some View {
         Group {
-            if sampleRate == 0 && exclude.isEmpty {
+            if model.sampleRate == 0 && model.exclude.isEmpty {
                 Text("⚠️ rate=0 + exclude=[] would short-circuit init (legacy contract). Apply will refuse this combination.")
                     .foregroundColor(.orange)
-            } else if sampleRate == 100 {
+            } else if model.sampleRate == 100 {
                 Text("ℹ️ Sampled in: every event passes regardless of excludeFromSampling.")
                     .foregroundColor(.secondary)
-            } else if sampleRate == 0 {
+            } else if model.sampleRate == 0 {
                 Text("ℹ️ Sampled out (rate=0): only event_types in excludeFromSampling will be exported.")
                     .foregroundColor(.secondary)
             } else {
-                Text("ℹ️ ~\(sampleRate)% of fresh sessions roll sampled-in. Reinit (or relaunch) to roll a new session.")
+                Text("ℹ️ ~\(model.sampleRate)% of fresh sessions roll sampled-in. Reinit (or relaunch) to roll a new session.")
                     .foregroundColor(.secondary)
             }
         }
         .font(.footnote)
     }
 
-    private var appliedConfigText: String {
-        "rate=\(LogSamplingState.sampleRate)\n" +
-        "exclude=\(formatExclude(LogSamplingState.exclude))\n" +
-        "isInitialized=\(CoralogixRumManager.shared.sdk.isInitialized)"
-    }
-
-    private var sampleRateBinding: Binding<Int> {
-        Binding(
-            get: { sampleRate },
-            set: { newValue in
-                sampleRate = newValue
-                LogSamplingState.sampleRate = newValue
-            }
-        )
-    }
-
     private func bindingForExclude(_ excludable: ExcludableInstrumentation) -> Binding<Bool> {
         Binding(
-            get: { exclude.contains(excludable) },
+            get: { model.exclude.contains(excludable) },
             set: { isOn in
-                if isOn { exclude.insert(excludable) } else { exclude.remove(excludable) }
-                LogSamplingState.exclude = exclude
+                if isOn { model.exclude.insert(excludable) } else { model.exclude.remove(excludable) }
             }
         )
-    }
-
-    // MARK: - Actions
-
-    private func apply() {
-        if sampleRate == 0 && exclude.isEmpty {
-            toastMessage = "sampleRate=0 + exclude=[] would skip init. Pick a rate or an exclude."
-            return
-        }
-
-        // Bump the run token first so any late callback from the previous run (still
-        // possibly in flight on the BatchSpanProcessor's queue) is discarded by the
-        // closure's token guard rather than re-filling the just-cleared list.
-        LogSamplingState.runToken += 1
-        let runToken = LogSamplingState.runToken
-        LogSamplingState.captured.removeAll()
-        refreshTick = UUID()
-
-        CoralogixRumManager.shared.sdk.shutdown()
-        let options = CoralogixExporterOptions(
-            coralogixDomain: .EU2,
-            userContext: UserContext(userId: "sampling-test",
-                                     userName: "Sampling Tester",
-                                     userEmail: "sampling@example.com",
-                                     userMetadata: ["test": "logSamplingDecoupling"]),
-            environment: "PROD",
-            application: "DemoApp-iOS-LogSamplingDecoupling",
-            version: "1",
-            publicKey: Envs.PUBLIC_KEY.rawValue,
-            sessionSampleRate: sampleRate,
-            excludeFromSampling: exclude,
-            instrumentations: [.mobileVitals: true, .custom: true, .errors: true,
-                               .userActions: true, .network: true, .anr: true, .lifeCycle: true],
-            collectIPData: true,
-            traceParentInHeader: ["enable": true],
-            tracesExporter: { data in
-                let now = Date()
-                var rows: [CapturedSpan] = []
-                for resourceSpan in data.tracesData.resourceSpans {
-                    for scopeSpan in resourceSpan.scopeSpans {
-                        for span in scopeSpan.spans {
-                            rows.append(CapturedSpan(
-                                eventType: span.eventType ?? "(no event_type)",
-                                name: span.name,
-                                receivedAt: now
-                            ))
-                        }
-                    }
-                }
-                guard !rows.isEmpty else { return }
-                DispatchQueue.main.async {
-                    guard runToken == LogSamplingState.runToken else { return }
-                    LogSamplingState.captured.insert(contentsOf: rows.reversed(), at: 0)
-                    refreshTick = UUID()
-                }
-            },
-            debug: true
-        )
-        CoralogixRumManager.shared.reinitialize(with: options)
-        LogSamplingState.sampleRate = sampleRate
-        LogSamplingState.exclude = exclude
-
-        // Gate the success path on the SDK's real initialization state. Today the only
-        // known no-init path (rate=0 + exclude=[]) is already guarded above, but the
-        // contract could grow more skip paths — surfacing the failure here keeps the
-        // demo honest if that happens.
-        if CoralogixRumManager.shared.sdk.isInitialized {
-            LogSamplingState.isApplied = true
-            isApplied = true
-            toastMessage = "SDK reinitialized — rate=\(sampleRate), exclude=\(formatExclude(exclude))"
-        } else {
-            LogSamplingState.isApplied = false
-            isApplied = false
-            toastMessage = "❌ SDK failed to initialize for rate=\(sampleRate), exclude=\(formatExclude(exclude))"
-        }
-    }
-
-    private func triggerLog() {
-        CoralogixRumManager.shared.sdk.log(severity: .info,
-                                           message: "Sampling demo log",
-                                           data: ["source": "LogSamplingDecouplingView"])
-        toastMessage = "log() called"
-    }
-
-    private func triggerError() {
-        CoralogixRumManager.shared.sdk.reportError(message: "Sampling demo error", data: nil)
-        toastMessage = "reportError() called"
-    }
-
-    private func triggerNetwork() {
-        NetworkSim.sendSuccesfullRequest()
-        toastMessage = "Network request sent"
-    }
-
-    private func triggerCustomSpan() {
-        let rum = CoralogixRumManager.shared.sdk
-        guard rum.isInitialized else { toastMessage = "SDK not initialized"; return }
-        guard let tracer = rum.getCustomTracer() else { toastMessage = "Failed to get custom tracer"; return }
-        guard let global = tracer.startGlobalSpan(name: "sampling-demo.global",
-                                                   labels: ["source": "LogSamplingDecouplingView"]) else {
-            toastMessage = "startGlobalSpan returned nil"
-            return
-        }
-        let child = global.startCustomSpan(name: "sampling-demo.child")
-        child.endSpan()
-        global.endSpan()
-        toastMessage = "Custom span emitted"
-    }
-
-    private func triggerCustomMeasurement() {
-        CoralogixRumManager.shared.sdk.sendCustomMeasurement(name: "sampling-demo.measurement", value: 42.0)
-        toastMessage = "sendCustomMeasurement() called"
-    }
-
-    // MARK: - Helpers
-
-    private func formatExclude(_ set: Set<ExcludableInstrumentation>) -> String {
-        if set.isEmpty { return "[]" }
-        return "[" + set.map { ".\($0.rawValue)" }.sorted().joined(separator: ", ") + "]"
     }
 }

--- a/Example/DemoAppSwiftUI/LogSamplingDecouplingView.swift
+++ b/Example/DemoAppSwiftUI/LogSamplingDecouplingView.swift
@@ -45,13 +45,12 @@ struct LogSamplingDecouplingView: View {
     var body: some View {
         Form {
             Section("sessionSampleRate") {
-                Picker("Sample rate", selection: $sampleRate) {
+                Picker("Sample rate", selection: sampleRateBinding) {
                     Text("0%").tag(0)
                     Text("50%").tag(50)
                     Text("100%").tag(100)
                 }
                 .pickerStyle(.segmented)
-                .onChange(of: sampleRate) { LogSamplingState.sampleRate = $0 }
             }
 
             Section("excludeFromSampling") {
@@ -68,6 +67,9 @@ struct LogSamplingDecouplingView: View {
                 } label: {
                     Label("Apply (reinit SDK)", systemImage: "arrow.clockwise.circle")
                 }
+                Text("Apply rebuilds the SDK on EU2 with all instrumentations on; overrides the initial CoralogixRumManager config.")
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
             }
 
             Section("Applied config") {
@@ -87,6 +89,7 @@ struct LogSamplingDecouplingView: View {
                 Button { triggerError() } label: { Label("Send Error", systemImage: "exclamationmark.triangle") }
                 Button { triggerNetwork() } label: { Label("Send Network", systemImage: "network") }
                 Button { triggerCustomSpan() } label: { Label("Send Custom Span", systemImage: "point.3.connected.trianglepath.dotted") }
+                Button { triggerCustomMeasurement() } label: { Label("Send Custom Measurement", systemImage: "ruler") }
             }
             .disabled(!isApplied)
 
@@ -155,6 +158,16 @@ struct LogSamplingDecouplingView: View {
         "isInitialized=\(CoralogixRumManager.shared.sdk.isInitialized)"
     }
 
+    private var sampleRateBinding: Binding<Int> {
+        Binding(
+            get: { sampleRate },
+            set: { newValue in
+                sampleRate = newValue
+                LogSamplingState.sampleRate = newValue
+            }
+        )
+    }
+
     private func bindingForExclude(_ excludable: ExcludableInstrumentation) -> Binding<Bool> {
         Binding(
             get: { exclude.contains(excludable) },
@@ -197,7 +210,7 @@ struct LogSamplingDecouplingView: View {
                     for scopeSpan in resourceSpan.scopeSpans {
                         for span in scopeSpan.spans {
                             rows.append(CapturedSpan(
-                                eventType: eventType(in: span) ?? "(no event_type)",
+                                eventType: span.eventType ?? "(no event_type)",
                                 name: span.name,
                                 receivedAt: now
                             ))
@@ -252,16 +265,15 @@ struct LogSamplingDecouplingView: View {
         toastMessage = "Custom span emitted"
     }
 
+    private func triggerCustomMeasurement() {
+        CoralogixRumManager.shared.sdk.sendCustomMeasurement(name: "sampling-demo.measurement", value: 42.0)
+        toastMessage = "sendCustomMeasurement() called"
+    }
+
     // MARK: - Helpers
 
     private func formatExclude(_ set: Set<ExcludableInstrumentation>) -> String {
         if set.isEmpty { return "[]" }
         return "[" + set.map { ".\($0.rawValue)" }.sorted().joined(separator: ", ") + "]"
     }
-}
-
-private func eventType(in span: OtlpSpan) -> String? {
-    guard let kv = span.attributes.first(where: { $0.key == CoralogixInternal.Keys.eventType.rawValue }) else { return nil }
-    if case .stringValue(let value) = kv.value { return value }
-    return nil
 }

--- a/Example/DemoAppSwiftUI/LogSamplingDecouplingView.swift
+++ b/Example/DemoAppSwiftUI/LogSamplingDecouplingView.swift
@@ -47,7 +47,7 @@ struct LogSamplingDecouplingView: View {
 
             Section("Applied config") {
                 if model.isApplied {
-                    Text("rate=\(model.sampleRate)\nexclude=\(model.formattedExclude)\nisInitialized=\(CoralogixRumManager.shared.sdk.isInitialized)")
+                    Text("rate=\(model.appliedSampleRate)\nexclude=\(model.formattedAppliedExclude)\nisInitialized=\(CoralogixRumManager.shared.sdk.isInitialized)")
                         .font(.system(.footnote, design: .monospaced))
                         .foregroundColor(.secondary)
                 } else {

--- a/Example/DemoAppSwiftUI/LogSamplingDecouplingView.swift
+++ b/Example/DemoAppSwiftUI/LogSamplingDecouplingView.swift
@@ -39,7 +39,7 @@ struct LogSamplingDecouplingView: View {
     @State private var sampleRate: Int = LogSamplingState.sampleRate
     @State private var exclude: Set<ExcludableInstrumentation> = LogSamplingState.exclude
     @State private var isApplied: Bool = LogSamplingState.isApplied
-    @State private var captured: [CapturedSpan] = LogSamplingState.captured
+    @State private var refreshTick = UUID()
     @State private var toastMessage: String?
 
     var body: some View {
@@ -97,19 +97,19 @@ struct LogSamplingDecouplingView: View {
                     Spacer()
                     Button {
                         LogSamplingState.captured.removeAll()
-                        captured = []
+                        refreshTick = UUID()
                     } label: {
                         Image(systemName: "trash").foregroundColor(.red)
                     }
-                    .disabled(captured.isEmpty)
+                    .disabled(LogSamplingState.captured.isEmpty)
                 }
 
-                if captured.isEmpty {
+                if LogSamplingState.captured.isEmpty {
                     Text("(no spans yet — apply a config and trigger events)")
                         .font(.footnote)
                         .foregroundColor(.secondary)
                 } else {
-                    ForEach(captured) { row in
+                    ForEach(LogSamplingState.captured) { row in
                         VStack(alignment: .leading, spacing: 2) {
                             Text(row.eventType)
                                 .font(.system(.callout, design: .monospaced))
@@ -120,6 +120,7 @@ struct LogSamplingDecouplingView: View {
                     }
                 }
             }
+            .id(refreshTick)
         }
         .navigationTitle("Log Sampling Decoupling")
         .navigationBarTitleDisplayMode(.inline)
@@ -206,7 +207,7 @@ struct LogSamplingDecouplingView: View {
                 guard !rows.isEmpty else { return }
                 DispatchQueue.main.async {
                     LogSamplingState.captured.insert(contentsOf: rows.reversed(), at: 0)
-                    captured = LogSamplingState.captured
+                    refreshTick = UUID()
                 }
             },
             debug: true

--- a/Example/Shared/Keys.swift
+++ b/Example/Shared/Keys.swift
@@ -66,4 +66,5 @@ enum Keys: String {
     case requestWithHeaderCapture = "Request with header/payload capture"
     case customSpans = "Custom Spans"
     case tracesExporter = "Traces Exporter"
+    case logSamplingDecoupling = "Log Sampling Decoupling"
 }

--- a/Example/Shared/LogSamplingDemoModel.swift
+++ b/Example/Shared/LogSamplingDemoModel.swift
@@ -176,6 +176,13 @@ final class LogSamplingDemoModel: ObservableObject {
     }
 
     func clearCaptured() {
+        // Bumping runToken first invalidates any tracesExporter callbacks already in
+        // flight on BatchSpanProcessor's queue; their main-queue insert will hit the
+        // token guard and drop the row instead of repopulating the just-cleared list.
+        // Side effect: this also stops the current SDK's *future* spans from being
+        // captured (the closure's captured token is now stale). To resume capture,
+        // tap Apply again.
+        runToken += 1
         captured.removeAll()
     }
 }

--- a/Example/Shared/LogSamplingDemoModel.swift
+++ b/Example/Shared/LogSamplingDemoModel.swift
@@ -55,6 +55,15 @@ final class LogSamplingDemoModel: ObservableObject {
 
     var formattedAppliedExclude: String { Self.formatExclude(appliedExclude) }
 
+    /// Human-readable summary of the currently-applied SDK config. Used by both demo
+    /// screens; centralizing the format keeps the two views from drifting if the
+    /// summary needs another field later.
+    var appliedConfigDescription: String {
+        "rate=\(appliedSampleRate)\n" +
+        "exclude=\(formattedAppliedExclude)\n" +
+        "isInitialized=\(CoralogixRumManager.shared.sdk.isInitialized)"
+    }
+
     private static func formatExclude(_ set: Set<ExcludableInstrumentation>) -> String {
         if set.isEmpty { return "[]" }
         return "[" + set.map { ".\($0.rawValue)" }.sorted().joined(separator: ", ") + "]"

--- a/Example/Shared/LogSamplingDemoModel.swift
+++ b/Example/Shared/LogSamplingDemoModel.swift
@@ -1,0 +1,157 @@
+//
+//  LogSamplingDemoModel.swift
+//  DemoApp
+//
+//  Shared view-model behind both LogSamplingDecoupling screens (UIKit + SwiftUI).
+//  Owns the user-selected sampling config, the captured tracesExporter spans, and
+//  the SDK reinit flow. SwiftUI consumes this via @ObservedObject; UIKit subscribes
+//  to objectWillChange via Combine to drive tableView reloads.
+//
+
+import Foundation
+import Combine
+import Coralogix
+import CoralogixInternal
+
+struct CapturedSpan: Identifiable {
+    let id = UUID()
+    let eventType: String
+    let name: String
+    let receivedAt: Date
+
+    var timeString: String {
+        let f = DateFormatter()
+        f.dateFormat = "HH:mm:ss"
+        return f.string(from: receivedAt)
+    }
+}
+
+final class LogSamplingDemoModel: ObservableObject {
+    static let shared = LogSamplingDemoModel()
+
+    @Published var sampleRate: Int = 0
+    @Published var exclude: Set<ExcludableInstrumentation> = [.logs]
+    @Published var isApplied: Bool = false
+    @Published var captured: [CapturedSpan] = []
+
+    /// Bumped on every Apply. Each tracesExporter closure captures its token so late
+    /// callbacks from a previous run (still possibly in flight on the BatchSpanProcessor's
+    /// queue between shutdown and reinit) can be discarded by the closure's token guard
+    /// rather than re-filling the just-cleared list.
+    private var runToken: Int = 0
+
+    private init() {}
+
+    static let allExcludable: [ExcludableInstrumentation] =
+        [.logs, .errors, .network, .userInteractions, .mobileVitals, .customSpan, .customMeasurement]
+
+    var formattedExclude: String {
+        if exclude.isEmpty { return "[]" }
+        return "[" + exclude.map { ".\($0.rawValue)" }.sorted().joined(separator: ", ") + "]"
+    }
+
+    /// Reinitializes the SDK with the current sampleRate + exclude.
+    /// Returns a user-facing status message suitable for a toast.
+    @discardableResult
+    func apply() -> String {
+        if sampleRate == 0 && exclude.isEmpty {
+            return "sampleRate=0 + exclude=[] would skip init. Pick a rate or an exclude."
+        }
+
+        runToken += 1
+        let runToken = self.runToken
+        captured.removeAll()
+
+        CoralogixRumManager.shared.sdk.shutdown()
+        let options = CoralogixExporterOptions(
+            coralogixDomain: .EU2,
+            userContext: UserContext(userId: "sampling-test",
+                                     userName: "Sampling Tester",
+                                     userEmail: "sampling@example.com",
+                                     userMetadata: ["test": "logSamplingDecoupling"]),
+            environment: "PROD",
+            application: "DemoApp-iOS-LogSamplingDecoupling",
+            version: "1",
+            publicKey: Envs.PUBLIC_KEY.rawValue,
+            sessionSampleRate: sampleRate,
+            excludeFromSampling: exclude,
+            instrumentations: [.mobileVitals: true, .custom: true, .errors: true,
+                               .userActions: true, .network: true, .anr: true, .lifeCycle: true],
+            collectIPData: true,
+            traceParentInHeader: ["enable": true],
+            tracesExporter: { [weak self] data in
+                let now = Date()
+                var rows: [CapturedSpan] = []
+                for resourceSpan in data.tracesData.resourceSpans {
+                    for scopeSpan in resourceSpan.scopeSpans {
+                        for span in scopeSpan.spans {
+                            rows.append(CapturedSpan(
+                                eventType: span.eventType ?? "(no event_type)",
+                                name: span.name,
+                                receivedAt: now
+                            ))
+                        }
+                    }
+                }
+                guard !rows.isEmpty else { return }
+                DispatchQueue.main.async {
+                    guard let self = self, runToken == self.runToken else { return }
+                    self.captured.insert(contentsOf: rows.reversed(), at: 0)
+                }
+            },
+            debug: true
+        )
+        CoralogixRumManager.shared.reinitialize(with: options)
+
+        let didApply = CoralogixRumManager.shared.sdk.isInitialized
+        isApplied = didApply
+        return didApply
+            ? "SDK reinitialized — rate=\(sampleRate), exclude=\(formattedExclude)"
+            : "❌ SDK failed to initialize for rate=\(sampleRate), exclude=\(formattedExclude)"
+    }
+
+    @discardableResult
+    func triggerLog() -> String {
+        CoralogixRumManager.shared.sdk.log(severity: .info,
+                                            message: "Sampling demo log",
+                                            data: ["source": "LogSamplingDemoModel"])
+        return "log() called"
+    }
+
+    @discardableResult
+    func triggerError() -> String {
+        CoralogixRumManager.shared.sdk.reportError(message: "Sampling demo error", data: nil)
+        return "reportError() called"
+    }
+
+    @discardableResult
+    func triggerNetwork() -> String {
+        NetworkSim.sendSuccesfullRequest()
+        return "Network request sent"
+    }
+
+    @discardableResult
+    func triggerCustomSpan() -> String {
+        let rum = CoralogixRumManager.shared.sdk
+        guard rum.isInitialized else { return "SDK not initialized" }
+        guard let tracer = rum.getCustomTracer() else { return "Failed to get custom tracer" }
+        guard let global = tracer.startGlobalSpan(name: "sampling-demo.global",
+                                                   labels: ["source": "LogSamplingDemoModel"]) else {
+            return "startGlobalSpan returned nil"
+        }
+        let child = global.startCustomSpan(name: "sampling-demo.child")
+        child.endSpan()
+        global.endSpan()
+        return "Custom span emitted"
+    }
+
+    @discardableResult
+    func triggerCustomMeasurement() -> String {
+        CoralogixRumManager.shared.sdk.sendCustomMeasurement(name: "sampling-demo.measurement", value: 42.0)
+        return "sendCustomMeasurement() called"
+    }
+
+    func clearCaptured() {
+        captured.removeAll()
+    }
+}

--- a/Example/Shared/LogSamplingDemoModel.swift
+++ b/Example/Shared/LogSamplingDemoModel.swift
@@ -29,8 +29,16 @@ struct CapturedSpan: Identifiable {
 final class LogSamplingDemoModel: ObservableObject {
     static let shared = LogSamplingDemoModel()
 
+    /// Editable selection bound to the UI controls. Reads here drift as the user toggles
+    /// the picker/switches and do NOT reflect what the SDK is currently configured with.
     @Published var sampleRate: Int = 0
     @Published var exclude: Set<ExcludableInstrumentation> = [.logs]
+
+    /// Snapshot of the values that were in effect on the last successful Apply. Use these
+    /// (not the editable fields above) when displaying "what the SDK is configured with".
+    @Published var appliedSampleRate: Int = 0
+    @Published var appliedExclude: Set<ExcludableInstrumentation> = []
+
     @Published var isApplied: Bool = false
     @Published var captured: [CapturedSpan] = []
 
@@ -45,9 +53,11 @@ final class LogSamplingDemoModel: ObservableObject {
     static let allExcludable: [ExcludableInstrumentation] =
         [.logs, .errors, .network, .userInteractions, .mobileVitals, .customSpan, .customMeasurement]
 
-    var formattedExclude: String {
-        if exclude.isEmpty { return "[]" }
-        return "[" + exclude.map { ".\($0.rawValue)" }.sorted().joined(separator: ", ") + "]"
+    var formattedAppliedExclude: String { Self.formatExclude(appliedExclude) }
+
+    private static func formatExclude(_ set: Set<ExcludableInstrumentation>) -> String {
+        if set.isEmpty { return "[]" }
+        return "[" + set.map { ".\($0.rawValue)" }.sorted().joined(separator: ", ") + "]"
     }
 
     /// Reinitializes the SDK with the current sampleRate + exclude.
@@ -58,9 +68,15 @@ final class LogSamplingDemoModel: ObservableObject {
             return "sampleRate=0 + exclude=[] would skip init. Pick a rate or an exclude."
         }
 
+        // Snapshot the values being attempted so toast strings and the success-side
+        // state-write all use the same numbers, even if the user mutates the editable
+        // fields later (the closure below is captured by reference into the SDK).
+        let attemptedSampleRate = sampleRate
+        let attemptedExclude = exclude
+        let attemptedFormatted = Self.formatExclude(attemptedExclude)
+
         runToken += 1
         let runToken = self.runToken
-        captured.removeAll()
 
         CoralogixRumManager.shared.sdk.shutdown()
         let options = CoralogixExporterOptions(
@@ -73,8 +89,8 @@ final class LogSamplingDemoModel: ObservableObject {
             application: "DemoApp-iOS-LogSamplingDecoupling",
             version: "1",
             publicKey: Envs.PUBLIC_KEY.rawValue,
-            sessionSampleRate: sampleRate,
-            excludeFromSampling: exclude,
+            sessionSampleRate: attemptedSampleRate,
+            excludeFromSampling: attemptedExclude,
             instrumentations: [.mobileVitals: true, .custom: true, .errors: true,
                                .userActions: true, .network: true, .anr: true, .lifeCycle: true],
             collectIPData: true,
@@ -105,9 +121,17 @@ final class LogSamplingDemoModel: ObservableObject {
 
         let didApply = CoralogixRumManager.shared.sdk.isInitialized
         isApplied = didApply
+        if didApply {
+            // Promote the attempted config into the "applied" snapshot only after the SDK
+            // confirms it initialized; clearing captured here (vs. before shutdown) keeps
+            // the previous run's rows visible if Apply fails.
+            appliedSampleRate = attemptedSampleRate
+            appliedExclude = attemptedExclude
+            captured.removeAll()
+        }
         return didApply
-            ? "SDK reinitialized — rate=\(sampleRate), exclude=\(formattedExclude)"
-            : "❌ SDK failed to initialize for rate=\(sampleRate), exclude=\(formattedExclude)"
+            ? "SDK reinitialized — rate=\(attemptedSampleRate), exclude=\(attemptedFormatted)"
+            : "❌ SDK failed to initialize for rate=\(attemptedSampleRate), exclude=\(attemptedFormatted)"
     }
 
     @discardableResult

--- a/Example/Shared/OtlpSpan+EventType.swift
+++ b/Example/Shared/OtlpSpan+EventType.swift
@@ -1,0 +1,21 @@
+//
+//  OtlpSpan+EventType.swift
+//  DemoApp
+//
+//  Convenience accessor used by demo screens that capture spans through the
+//  tracesExporter callback. The Coralogix `event_type` is a string attribute
+//  on every emitted span; surfacing it as a property keeps capture-display
+//  code readable.
+//
+
+import Coralogix
+import CoralogixInternal
+
+extension OtlpSpan {
+    /// The `event_type` attribute Coralogix tags every span with, when present.
+    var eventType: String? {
+        guard let kv = attributes.first(where: { $0.key == CoralogixInternal.Keys.eventType.rawValue }) else { return nil }
+        if case .stringValue(let value) = kv.value { return value }
+        return nil
+    }
+}

--- a/Tests/CoralogixRumTests/LogSamplingDecouplingTests.swift
+++ b/Tests/CoralogixRumTests/LogSamplingDecouplingTests.swift
@@ -41,12 +41,12 @@ final class LogSamplingDecouplingTests: XCTestCase {
 
     // MARK: - Case 2: sampleRate=0, exclude=[.logs] ⇒ logs export, others drop
 
-    func testCase2_sampleRateZero_excludeLogs_logsExportOthersDrop() {
+    func testCase2_sampleRateZero_excludeLogs_logsExportOthersDrop() throws {
         let capture = Capture()
         let rum = CoralogixRum(options: makeOptions(sampleRate: 0, exclude: [.logs], capture: capture))
         defer { rum.shutdown() }
 
-        let exporter = requireExporter(rum)
+        let exporter = try requireExporter(rum)
         exporter.spanUploader = MockSpanUploader()
 
         _ = exporter.export(spans: [
@@ -61,12 +61,12 @@ final class LogSamplingDecouplingTests: XCTestCase {
 
     // MARK: - Case 3: sampleRate=100, exclude=[.logs] ⇒ all spans export
 
-    func testCase3_sampleRateHundred_excludeLogs_allSpansExport() {
+    func testCase3_sampleRateHundred_excludeLogs_allSpansExport() throws {
         let capture = Capture()
         let rum = CoralogixRum(options: makeOptions(sampleRate: 100, exclude: [.logs], capture: capture))
         defer { rum.shutdown() }
 
-        let exporter = requireExporter(rum)
+        let exporter = try requireExporter(rum)
         exporter.spanUploader = MockSpanUploader()
 
         _ = exporter.export(spans: [
@@ -82,7 +82,7 @@ final class LogSamplingDecouplingTests: XCTestCase {
 
     // MARK: - Case 4: session rotation re-rolls sampling (and the reroll callback actually runs)
 
-    func testCase4_sessionRotation_sampleRateZero_rerollFlipsBackToFalse() {
+    func testCase4_sessionRotation_sampleRateZero_rerollFlipsBackToFalse() throws {
         // Rationale: with sampleRate=0 the deterministic outcome is `false`. Manually flip
         // the flag to `true`, rotate the session, and watch the reroll callback flip it
         // back. Asserting "the value didn't change" alone would also be true if the callback
@@ -90,7 +90,7 @@ final class LogSamplingDecouplingTests: XCTestCase {
         let rum = CoralogixRum(options: makeOptions(sampleRate: 0, exclude: [.logs]))
         defer { rum.shutdown() }
 
-        let exporter = requireExporter(rum)
+        let exporter = try requireExporter(rum)
         XCTAssertEqual(exporter.isCurrentSessionSampledIn(), false,
                        "Initial roll at sampleRate=0 must be sampled-out.")
 
@@ -104,11 +104,11 @@ final class LogSamplingDecouplingTests: XCTestCase {
                        "Rotation must invoke the reroll callback; sampleRate=0 deterministically re-rolls to false.")
     }
 
-    func testCase4_sessionRotation_sampleRateHundred_rerollFlipsBackToTrue() {
+    func testCase4_sessionRotation_sampleRateHundred_rerollFlipsBackToTrue() throws {
         let rum = CoralogixRum(options: makeOptions(sampleRate: 100, exclude: []))
         defer { rum.shutdown() }
 
-        let exporter = requireExporter(rum)
+        let exporter = try requireExporter(rum)
         XCTAssertEqual(exporter.isCurrentSessionSampledIn(), true,
                        "Initial roll at sampleRate=100 must be sampled-in.")
 
@@ -124,14 +124,14 @@ final class LogSamplingDecouplingTests: XCTestCase {
 
     // MARK: - Case 5: multiple categories ⇒ only those pass
 
-    func testCase5_sampleRateZero_excludeLogsAndErrors_onlyThoseTwoPass() {
+    func testCase5_sampleRateZero_excludeLogsAndErrors_onlyThoseTwoPass() throws {
         let capture = Capture()
         let rum = CoralogixRum(options: makeOptions(sampleRate: 0,
                                                     exclude: [.logs, .errors],
                                                     capture: capture))
         defer { rum.shutdown() }
 
-        let exporter = requireExporter(rum)
+        let exporter = try requireExporter(rum)
         exporter.spanUploader = MockSpanUploader()
 
         _ = exporter.export(spans: [
@@ -147,12 +147,12 @@ final class LogSamplingDecouplingTests: XCTestCase {
 
     // MARK: - Case 6: thread-safety smoke — rotate on one queue while exporting on another
 
-    func testCase6_sessionRotation_concurrentWithExport_threadSafetySmoke() {
+    func testCase6_sessionRotation_concurrentWithExport_threadSafetySmoke() throws {
         let capture = Capture()
         let rum = CoralogixRum(options: makeOptions(sampleRate: 0, exclude: [.logs], capture: capture))
         defer { rum.shutdown() }
 
-        let exporter = requireExporter(rum)
+        let exporter = try requireExporter(rum)
         exporter.spanUploader = MockSpanUploader()
 
         let iterations = 100
@@ -182,10 +182,15 @@ final class LogSamplingDecouplingTests: XCTestCase {
 
         XCTAssertEqual(exporter.isCurrentSessionSampledIn(), false,
                        "Final roll at sampleRate=0 must remain sampled-out after every reroll.")
-        XCTAssertEqual(capture.eventTypes.count, iterations,
+        // Count only `"log"` entries: other spans the SDK might emit as a side effect of init or
+        // session rotation would be filtered out by sampleRate=0 + exclude=[.logs] anyway, but
+        // counting them here would flake the assertion if any happened to carry event_type=log.
+        let logCount = capture.eventTypes.filter { $0 == "log" }.count
+        XCTAssertEqual(logCount, iterations,
                        "Every log export must survive the filter (logs are in excludeFromSampling).")
-        XCTAssertTrue(capture.eventTypes.allSatisfy { $0 == "log" },
-                      "Captured event_types must all be 'log' — the only event_type pushed.")
+        let nonLog = Set(capture.eventTypes).subtracting(["log"])
+        XCTAssertTrue(nonLog.isEmpty,
+                      "No non-log event_types should pass the filter; saw: \(nonLog.sorted())")
     }
 
     // MARK: - Helpers
@@ -233,15 +238,8 @@ final class LogSamplingDecouplingTests: XCTestCase {
         )
     }
 
-    private func requireExporter(_ rum: CoralogixRum,
-                                 file: StaticString = #file,
-                                 line: UInt = #line) -> CoralogixExporter {
-        guard let exporter = rum.coralogixExporter else {
-            XCTFail("Exporter must exist after init.", file: file, line: line)
-            // Unreachable — XCTFail aborts the test, but the compiler still needs a return.
-            fatalError("unreachable: XCTFail aborts before this line")
-        }
-        return exporter
+    private func requireExporter(_ rum: CoralogixRum) throws -> CoralogixExporter {
+        return try XCTUnwrap(rum.coralogixExporter, "Exporter must exist after init.")
     }
 
     /// Builds a SpanData with the attributes CxSpan needs to encode successfully, plus the

--- a/Tests/CoralogixRumTests/LogSamplingDecouplingTests.swift
+++ b/Tests/CoralogixRumTests/LogSamplingDecouplingTests.swift
@@ -1,0 +1,295 @@
+//
+//  LogSamplingDecouplingTests.swift
+//
+//  End-to-end coverage for the sampling-decoupling pipeline introduced in PIPEV2-3365
+//  (T1: ExcludableInstrumentation; T2: per-session reroll + init-flow decoupling;
+//   T3: per-span sampling filter in CoralogixExporter).
+//
+//  Routes real `SpanData` through `CoralogixExporter.export()` and captures what
+//  survives the sampling filter via the `tracesExporter` callback (which fires after
+//  the sampling/URL/error filters but before encode/upload). A MockSpanUploader is
+//  wired in to keep tests offline.
+//
+//  "Deterministic sampler stub": SDKSampler.shouldInitialized() uses
+//  Int.random(in: 0..<100) < sampleRate, which is deterministic at the boundaries
+//  (0 always rolls false, 100 always rolls true). Every case below uses one of those.
+//
+
+import XCTest
+import CoralogixInternal
+@testable import Coralogix
+
+final class LogSamplingDecouplingTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        // Static SDK state can leak between tests if a prior init was not torn down.
+        CoralogixRum.isInitialized = false
+    }
+
+    // MARK: - Case 1: sampleRate=0, exclude=[] ⇒ SDK does not initialize
+
+    func testCase1_sampleRateZero_excludeEmpty_doesNotInitialize() {
+        let rum = CoralogixRum(options: makeOptions(sampleRate: 0, exclude: []))
+        defer { rum.shutdown() }
+
+        XCTAssertFalse(rum.isInitialized,
+                       "Legacy contract: sampleRate=0 + excludeFromSampling=[] must NOT initialize.")
+        XCTAssertNil(rum.coralogixExporter,
+                     "Skipped init must not create an exporter.")
+    }
+
+    // MARK: - Case 2: sampleRate=0, exclude=[.logs] ⇒ logs export, others drop
+
+    func testCase2_sampleRateZero_excludeLogs_logsExportOthersDrop() {
+        let capture = Capture()
+        let rum = CoralogixRum(options: makeOptions(sampleRate: 0, exclude: [.logs], capture: capture))
+        defer { rum.shutdown() }
+
+        let exporter = requireExporter(rum)
+        exporter.spanUploader = MockSpanUploader()
+
+        _ = exporter.export(spans: [
+            makeSpan(eventType: .log),
+            makeSpan(eventType: .error),
+            makeSpan(eventType: .networkRequest)
+        ], explicitTimeout: nil)
+
+        XCTAssertEqual(capture.eventTypes, ["log"],
+                       "Sampled-out + exclude=[.logs] must let only log spans through; errors and network spans drop.")
+    }
+
+    // MARK: - Case 3: sampleRate=100, exclude=[.logs] ⇒ all spans export
+
+    func testCase3_sampleRateHundred_excludeLogs_allSpansExport() {
+        let capture = Capture()
+        let rum = CoralogixRum(options: makeOptions(sampleRate: 100, exclude: [.logs], capture: capture))
+        defer { rum.shutdown() }
+
+        let exporter = requireExporter(rum)
+        exporter.spanUploader = MockSpanUploader()
+
+        _ = exporter.export(spans: [
+            makeSpan(eventType: .log),
+            makeSpan(eventType: .error),
+            makeSpan(eventType: .networkRequest)
+        ], explicitTimeout: nil)
+
+        XCTAssertEqual(Set(capture.eventTypes),
+                       Set(["log", "error", "network-request"]),
+                       "Sampled-in: every span passes regardless of excludeFromSampling.")
+    }
+
+    // MARK: - Case 4: session rotation re-rolls sampling (and the reroll callback actually runs)
+
+    func testCase4_sessionRotation_sampleRateZero_rerollFlipsBackToFalse() {
+        // Rationale: with sampleRate=0 the deterministic outcome is `false`. Manually flip
+        // the flag to `true`, rotate the session, and watch the reroll callback flip it
+        // back. Asserting "the value didn't change" alone would also be true if the callback
+        // never fired — the manual flip closes that gap.
+        let rum = CoralogixRum(options: makeOptions(sampleRate: 0, exclude: [.logs]))
+        defer { rum.shutdown() }
+
+        let exporter = requireExporter(rum)
+        XCTAssertEqual(exporter.isCurrentSessionSampledIn(), false,
+                       "Initial roll at sampleRate=0 must be sampled-out.")
+
+        exporter.updateSessionSampling(sampledIn: true)
+        XCTAssertEqual(exporter.isCurrentSessionSampledIn(), true,
+                       "Manual flip should set the flag to true.")
+
+        rum.sessionManager?.setupSessionMetadata()
+
+        XCTAssertEqual(exporter.isCurrentSessionSampledIn(), false,
+                       "Rotation must invoke the reroll callback; sampleRate=0 deterministically re-rolls to false.")
+    }
+
+    func testCase4_sessionRotation_sampleRateHundred_rerollFlipsBackToTrue() {
+        let rum = CoralogixRum(options: makeOptions(sampleRate: 100, exclude: []))
+        defer { rum.shutdown() }
+
+        let exporter = requireExporter(rum)
+        XCTAssertEqual(exporter.isCurrentSessionSampledIn(), true,
+                       "Initial roll at sampleRate=100 must be sampled-in.")
+
+        exporter.updateSessionSampling(sampledIn: false)
+        XCTAssertEqual(exporter.isCurrentSessionSampledIn(), false,
+                       "Manual flip should set the flag to false.")
+
+        rum.sessionManager?.setupSessionMetadata()
+
+        XCTAssertEqual(exporter.isCurrentSessionSampledIn(), true,
+                       "Rotation must invoke the reroll callback; sampleRate=100 deterministically re-rolls to true.")
+    }
+
+    // MARK: - Case 5: multiple categories ⇒ only those pass
+
+    func testCase5_sampleRateZero_excludeLogsAndErrors_onlyThoseTwoPass() {
+        let capture = Capture()
+        let rum = CoralogixRum(options: makeOptions(sampleRate: 0,
+                                                    exclude: [.logs, .errors],
+                                                    capture: capture))
+        defer { rum.shutdown() }
+
+        let exporter = requireExporter(rum)
+        exporter.spanUploader = MockSpanUploader()
+
+        _ = exporter.export(spans: [
+            makeSpan(eventType: .log),
+            makeSpan(eventType: .error),
+            makeSpan(eventType: .networkRequest),
+            makeSpan(eventType: .mobileVitals)
+        ], explicitTimeout: nil)
+
+        XCTAssertEqual(Set(capture.eventTypes), Set(["log", "error"]),
+                       "Sampled-out + exclude=[.logs, .errors] must let exactly those two categories through.")
+    }
+
+    // MARK: - Case 6: thread-safety smoke — rotate on one queue while exporting on another
+
+    func testCase6_sessionRotation_concurrentWithExport_threadSafetySmoke() {
+        let capture = Capture()
+        let rum = CoralogixRum(options: makeOptions(sampleRate: 0, exclude: [.logs], capture: capture))
+        defer { rum.shutdown() }
+
+        let exporter = requireExporter(rum)
+        exporter.spanUploader = MockSpanUploader()
+
+        let iterations = 100
+        let group = DispatchGroup()
+
+        // Rotation queue: forces a reroll repeatedly.
+        group.enter()
+        DispatchQueue.global(qos: .userInitiated).async {
+            for _ in 0..<iterations {
+                rum.sessionManager?.setupSessionMetadata()
+            }
+            group.leave()
+        }
+
+        // Export queue: pushes 1 log span (excluded ⇒ should always pass) per iteration.
+        group.enter()
+        DispatchQueue.global(qos: .userInitiated).async {
+            let span = self.makeSpan(eventType: .log)
+            for _ in 0..<iterations {
+                _ = exporter.export(spans: [span], explicitTimeout: nil)
+            }
+            group.leave()
+        }
+
+        XCTAssertEqual(group.wait(timeout: .now() + 10), .success,
+                       "Concurrent rotate+export must complete within 10s without deadlock.")
+
+        XCTAssertEqual(exporter.isCurrentSessionSampledIn(), false,
+                       "Final roll at sampleRate=0 must remain sampled-out after every reroll.")
+        XCTAssertEqual(capture.eventTypes.count, iterations,
+                       "Every log export must survive the filter (logs are in excludeFromSampling).")
+        XCTAssertTrue(capture.eventTypes.allSatisfy { $0 == "log" },
+                      "Captured event_types must all be 'log' — the only event_type pushed.")
+    }
+
+    // MARK: - Helpers
+
+    /// Thread-safe append-only collector for event_type strings observed by `tracesExporter`.
+    private final class Capture {
+        private let lock = NSLock()
+        private var values: [String] = []
+
+        func append(_ value: String) {
+            lock.lock()
+            values.append(value)
+            lock.unlock()
+        }
+
+        var eventTypes: [String] {
+            lock.lock()
+            defer { lock.unlock() }
+            return values
+        }
+    }
+
+    private func makeOptions(sampleRate: Int,
+                             exclude: Set<ExcludableInstrumentation>,
+                             capture: Capture? = nil) -> CoralogixExporterOptions {
+        return CoralogixExporterOptions(
+            coralogixDomain: .US2,
+            userContext: nil,
+            environment: "test",
+            application: "TestApp",
+            version: "1.0.0",
+            publicKey: "test-key",
+            ignoreUrls: [],
+            ignoreErrors: [],
+            labels: nil,
+            sessionSampleRate: sampleRate,
+            excludeFromSampling: exclude,
+            instrumentations: nil,
+            tracesExporter: capture.map { capture in
+                { data in
+                    Self.eventTypes(in: data).forEach(capture.append)
+                }
+            },
+            debug: false
+        )
+    }
+
+    private func requireExporter(_ rum: CoralogixRum,
+                                 file: StaticString = #file,
+                                 line: UInt = #line) -> CoralogixExporter {
+        guard let exporter = rum.coralogixExporter else {
+            XCTFail("Exporter must exist after init.", file: file, line: line)
+            // Unreachable — XCTFail aborts the test, but the compiler still needs a return.
+            fatalError("unreachable: XCTFail aborts before this line")
+        }
+        return exporter
+    }
+
+    /// Builds a SpanData with the attributes CxSpan needs to encode successfully, plus the
+    /// `event_type` under test. No `httpUrl` and no `errorMessage`, so URL/error filters pass.
+    private func makeSpan(eventType: CoralogixEventType) -> SpanData {
+        let attributes: [String: AttributeValue] = [
+            Keys.eventType.rawValue: AttributeValue(eventType.rawValue),
+            Keys.severity.rawValue: AttributeValue("3"),
+            Keys.source.rawValue: AttributeValue("console"),
+            Keys.environment.rawValue: AttributeValue("test"),
+            Keys.userId.rawValue: AttributeValue("uid"),
+            Keys.userName.rawValue: AttributeValue("Test User"),
+            Keys.userEmail.rawValue: AttributeValue("test@example.com"),
+            Keys.sessionId.rawValue: AttributeValue("session_001"),
+            Keys.sessionCreationDate.rawValue: AttributeValue("1609459200")
+        ]
+        return SpanData(traceId: TraceId.random(),
+                        spanId: SpanId.random(),
+                        name: "testSpan_\(eventType.rawValue)",
+                        kind: .client,
+                        startTime: Date(),
+                        attributes: attributes,
+                        endTime: Date(),
+                        hasEnded: true)
+    }
+
+    /// Walks the OTLP-shaped capture to extract every `event_type` string attribute.
+    private static func eventTypes(in data: CoralogixTraceExporterData) -> [String] {
+        return data.tracesData.resourceSpans.flatMap { resourceSpan in
+            resourceSpan.scopeSpans.flatMap { scopeSpan in
+                scopeSpan.spans.compactMap { span -> String? in
+                    guard let kv = span.attributes.first(where: { $0.key == Keys.eventType.rawValue }) else {
+                        return nil
+                    }
+                    if case .stringValue(let value) = kv.value { return value }
+                    return nil
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Test Doubles
+
+/// Local copy of the MockSpanUploader pattern from CoralogixExporterTests.swift to keep
+/// this file self-contained and avoid network I/O during export.
+private final class MockSpanUploader: SpanUploading {
+    func upload(_ spans: [[String: Any]], endPoint: String) -> SpanExporterResultCode {
+        return .success
+    }
+}

--- a/Tests/CoralogixRumTests/LogSamplingDecouplingTests.swift
+++ b/Tests/CoralogixRumTests/LogSamplingDecouplingTests.swift
@@ -168,6 +168,8 @@ final class LogSamplingDecouplingTests: XCTestCase {
         }
 
         // Export queue: pushes 1 log span (excluded ⇒ should always pass) per iteration.
+        // Span is built once and reused; export() dedups by spanId *within a single call*,
+        // not across calls, so the duplicate spanId here is harmless.
         group.enter()
         DispatchQueue.global(qos: .userInitiated).async {
             let span = self.makeSpan(eventType: .log)


### PR DESCRIPTION
# User description
## Summary

Closes T4 of [PIPEV2-3365](https://coralogix.atlassian.net/browse/PIPEV2-3365) ([CX-40202](https://coralogix.atlassian.net/browse/CX-40202)) — end-to-end coverage of the sampling-decoupling pipeline (T1+T2+T3) plus a manual-test harness in both demo apps.

- **Unit tests** (`Tests/CoralogixRumTests/LogSamplingDecouplingTests.swift`): all six cases from the ticket, routing real `SpanData` through `CoralogixExporter.export()` and capturing surviving spans via the `tracesExporter` callback. Uses `sampleRate=0`/`100` boundaries as the deterministic sampler stub. A private `MockSpanUploader` keeps tests offline.
- **Demo-app harness** (`Example/DemoAppSwift/LogSamplingDecouplingViewController.swift` + `Example/DemoAppSwiftUI/LogSamplingDecouplingView.swift`): pick a `sessionSampleRate` and `excludeFromSampling` set, reinit the SDK, fire log/error/network/custom-span events, and watch which `event_type`s survive the filter live.

### Cases covered (1:1 with the ticket)

| # | Case | Expectation |
|---|------|-------------|
| 1 | `rate=0, exclude=[]` | SDK does not initialize (legacy contract) |
| 2 | `rate=0, exclude=[.logs]` | only log spans export |
| 3 | `rate=100, exclude=[.logs]` | all spans export (list ignored) |
| 4 | session rotation | reroll runs (manual flip + watch flip back) |
| 5 | `rate=0, exclude=[.logs, .errors]` | only those two pass |
| 6 | concurrent rotate + export | no crash, consistent state |

`SamplerTests`, `SessionSamplingFilterTests`, and `SessionSamplingRerollTests` keep passing unchanged.

## Test plan

- [x] `swift test --filter LogSamplingDecouplingTests` — 7/7 pass
- [x] `swift test --filter SamplerTests` — 2/2 pass (regression check)
- [x] `swift test --filter SessionSamplingFilterTests` — 8/8 pass
- [x] `swift test --filter SessionSamplingRerollTests` — 6/6 pass
- [x] Build `DemoAppSwift` (UIKit) — succeeds, new screen wired into the menu
- [x] Build `DemoAppSwiftUI` — succeeds, new screen wired into the menu
- [ ] Manual smoke in simulator: walk through cases 1/2/3/5 via the new screen and confirm the captured list matches the unit-test expectations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PIPEV2-3365]: https://coralogix.atlassian.net/browse/PIPEV2-3365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CX-40202]: https://coralogix.atlassian.net/browse/CX-40202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Exercise the sampling-decoupling pipeline by routing deterministic <code>SpanData</code> through <code>CoralogixExporter</code> in <code>LogSamplingDecouplingTests</code>, asserting every ticket case from initialization gates to concurrent rerolls. Add UIKit and SwiftUI LogSamplingDecoupling screens powered by <code>LogSamplingDemoModel</code> so reviewers can reinit the SDK with different <code>sessionSampleRate</code>/<code>excludeFromSampling</code> combinations and watch which <code>event_type</code>s survive via the tracesExporter callback.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/197?tool=ast&topic=Demo+harness>Demo harness</a>
        </td><td>Provide a reusable demo harness that reruns the SDK with custom sampling configs, streams captured spans into a shared model, and update the UI tests job to prefer the newer macOS/Xcode/simulator stack needed for the new screens.<details><summary>Modified files (9)</summary><ul><li>.github/workflows/ui-tests.yml</li>
<li>Example/DemoApp.xcodeproj/project.pbxproj</li>
<li>Example/DemoAppSwift/LogSamplingDecouplingViewController.swift</li>
<li>Example/DemoAppSwift/MainViewController.swift</li>
<li>Example/DemoAppSwiftUI/ContentView.swift</li>
<li>Example/DemoAppSwiftUI/LogSamplingDecouplingView.swift</li>
<li>Example/Shared/Keys.swift</li>
<li>Example/Shared/LogSamplingDemoModel.swift</li>
<li>Example/Shared/OtlpSpan+EventType.swift</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>refactor(CX-40202): ce...</td><td>May 07, 2026</td></tr>
<tr><td>NatanCoralogix</td><td>UI test (#85)</td><td>July 29, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/197?tool=ast&topic=Sampling+tests>Sampling tests</a>
        </td><td>Validate the sampling-decoupling pipeline end-to-end with the deterministic sampler stub by routing spans through <code>CoralogixExporter</code> and asserting the six ticket cases, plus session rerolls and concurrent exports.<details><summary>Modified files (1)</summary><ul><li>Tests/CoralogixRumTests/LogSamplingDecouplingTests.swift</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>fix(CX-40202): address...</td><td>May 06, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/coralogix/cx-ios-sdk/197?tool=ast>(Baz)</a>.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive "Log Sampling Decoupling" demo screen to both demo apps with configurable sampling rates and real-time event filtering controls

* **Tests**
  * Added comprehensive tests for sampling and filtering behaviors

* **Chores**
  * Updated CI/CD workflow to use macOS 15 and Xcode 16.4 with enhanced simulator detection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->