### PR TITLE
ci: unblock master — macos-15 + Xcode 16.4 + destination-regex fix

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   ui-tests:
     name: Run DemoApp UI Tests
-    runs-on: macos-14
+    runs-on: macos-15
     timeout-minutes: 30
     permissions:
       contents: read
@@ -26,7 +26,15 @@ jobs:
 
       - name: Select Xcode (via DEVELOPER_DIR)
         run: |
-          if [ -d "/Applications/Xcode_16.2.app" ]; then
+          # Prefer Xcode 16.4 (default on macos-15) — Xcode 16.2 swiftc has
+          # been failing to compile firebase-ios-sdk's Package.swift under
+          # `-swift-version 6` (manifest resolution error). 16.3/16.2/16.1/16.0
+          # kept as fallbacks.
+          if [ -d "/Applications/Xcode_16.4.app" ]; then
+            echo "DEVELOPER_DIR=/Applications/Xcode_16.4.app/Contents/Developer" >> $GITHUB_ENV
+          elif [ -d "/Applications/Xcode_16.3.app" ]; then
+            echo "DEVELOPER_DIR=/Applications/Xcode_16.3.app/Contents/Developer" >> $GITHUB_ENV
+          elif [ -d "/Applications/Xcode_16.2.app" ]; then
             echo "DEVELOPER_DIR=/Applications/Xcode_16.2.app/Contents/Developer" >> $GITHUB_ENV
           elif [ -d "/Applications/Xcode_16.1.app" ]; then
             echo "DEVELOPER_DIR=/Applications/Xcode_16.1.app/Contents/Developer" >> $GITHUB_ENV
@@ -132,22 +140,27 @@ jobs:
           OUT=$(xcodebuild -showdestinations -workspace DemoApp.xcworkspace -scheme DemoAppSwift)
           echo "$OUT"
 
-          # Prefer iPhone 16 or newer with iOS 18.0+ (we override deployment target in CI)
-          LINE=$(echo "$OUT" | grep -E "platform:iOS Simulator, id:.*name:iPhone (1[6-9]|[2-9][0-9])" | grep -E "OS:1[89]\.[0-9]" | head -1 || true)
-          
-          # If not found, try any iPhone with iOS 18.0+
+          # Xcode 16.4 (macos-15) emits `platform:iOS Simulator, arch:arm64, id:...`
+          # whereas 16.2 emitted `platform:iOS Simulator, id:...` directly. Use
+          # `.*id:` so the regex tolerates intervening fields either way.
+          SIM_PREFIX="platform:iOS Simulator,.*id:"
+
+          # Prefer iPhone 16 or newer with iOS 18.x (we override deployment target in CI)
+          LINE=$(echo "$OUT" | grep -E "${SIM_PREFIX}.*name:iPhone (1[6-9]|[2-9][0-9])" | grep -E "OS:1[89]\.[0-9]" | head -1 || true)
+
+          # If not found, try any iPhone with iOS 18.x
           if [ -z "$LINE" ]; then
-            LINE=$(echo "$OUT" | grep -E "platform:iOS Simulator, id:.*name:iPhone" | grep -E "OS:1[89]\.[0-9]" | head -1 || true)
+            LINE=$(echo "$OUT" | grep -E "${SIM_PREFIX}.*name:iPhone" | grep -E "OS:1[89]\.[0-9]" | head -1 || true)
           fi
-          
-          # If still not found, try any iPhone with iOS 17.0+ (fallback)
+
+          # If still not found, accept iOS 17.x or the newer 26.x runtimes
           if [ -z "$LINE" ]; then
-            LINE=$(echo "$OUT" | grep -E "platform:iOS Simulator, id:.*name:iPhone" | grep -E "OS:1[7-9]\.[0-9]" | head -1 || true)
+            LINE=$(echo "$OUT" | grep -E "${SIM_PREFIX}.*name:iPhone" | grep -E "OS:(1[7-9]|2[6-9])\." | head -1 || true)
           fi
-          
+
           # Last resort: any iPhone simulator
           if [ -z "$LINE" ]; then
-            LINE=$(echo "$OUT" | grep -E "platform:iOS Simulator, id:.*name:iPhone" | head -1 || true)
+            LINE=$(echo "$OUT" | grep -E "${SIM_PREFIX}.*name:iPhone" | head -1 || true)
           fi
           
           if [ -z "$LINE" ]; then


### PR DESCRIPTION
# User description
## Summary

Master CI is broken because `xcodebuild` on Xcode 16.2 fails to compile firebase-ios-sdk's `Package.swift` under `-swift-version 6` (manifest resolution error). The `Run UI Tests` workflow fails fast at `xcodebuild -showdestinations`. This PR ships the smallest possible workflow change to get master green again.

Three changes, all in `.github/workflows/ui-tests.yml`:

1. **`runs-on: macos-14` → `runs-on: macos-15`** — newer runner image carries Xcode 16.3 / 16.4 pre-installed.
2. **Prefer Xcode 16.4 in the DEVELOPER_DIR selector**, falling back through 16.3 / 16.2 / 16.1 / 16.0. 16.4 resolves the firebase manifest cleanly. 16.2's swiftc is what's been failing.
3. **Destination-regex tolerance.** Xcode 16.4 on macos-15 emits `platform:iOS Simulator, arch:arm64, id:...` whereas 16.2 emitted `platform:iOS Simulator, id:...` directly. The previous regex hardcoded `, id:` immediately after `Simulator,` and matched nothing on macos-15. All four `LINE=` grep invocations now go through a shared `SIM_PREFIX=\"platform:iOS Simulator,.*id:\"`. The iOS-version fallback tier was also widened to accept the newer 26.x runtimes.

## Provenance

The fix originated in branch `tech-debt/ui-test-speedup-phase1` (PR #196, closed). That branch had broader UI-test speedup scope; this PR pulls only the master-CI-unblock pieces and leaves SPM cache, per-test timeouts, base-class refactors, and `MarshalSpanCapture` behind. Background context: CX-41238.

## Test plan

- [ ] Workflow run on this PR is green
- [ ] Wall-clock comes in around the master baseline (~22-25 min) — first run will be ~25-30 min on a cold cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Upgrade the UI Tests workflow to run on macos-15 and prefer Xcode 16.4/16.3/… when populating <code>DEVELOPER_DIR</code> so the Firebase manifest resolves cleanly under the new Swift version. Harden the destination-selection script by sharing <code>SIM_PREFIX</code> and widening the iOS runtime fallbacks so <code>xcodebuild -showdestinations</code> output on macos-15 still yields a matching simulator.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/198?tool=ast&topic=Destination+parsing>Destination parsing</a>
        </td><td>Share <code>SIM_PREFIX</code> and widen the runtime fallbacks so <code>xcodebuild -showdestinations</code> output on macos-15 matches even with the extra fields in newer simulator descriptions.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/ui-tests.yml</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>ci: unblock master —...</td><td>May 07, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/198?tool=ast&topic=Runner+selection>Runner selection</a>
        </td><td>Prefer macos-15 runners and the highest available Xcode 16.x when setting <code>DEVELOPER_DIR</code> so the UI Tests workflow can compile the Firebase manifest without the older Swift compiler regression.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/ui-tests.yml</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>ci: unblock master —...</td><td>May 07, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/coralogix/cx-ios-sdk/198?tool=ast>(Baz)</a>.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD infrastructure to utilize newer testing environments and improved simulator compatibility detection for enhanced testing reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->