### PR TITLE
feat(CX-40203): T5 — hybrid SDK path honors excludeFromSampling

### DIFF
--- a/Coralogix/Sources/Utils/MobileVitals/SlowFrozenFramesDetector.swift
+++ b/Coralogix/Sources/Utils/MobileVitals/SlowFrozenFramesDetector.swift
@@ -19,13 +19,13 @@ import UIKit
 /// ## Why 700ms for Frozen Frames?
 /// The 700ms threshold was chosen to align with the SDK's ANR (Application Not Responding)
 /// detection threshold, providing a consistent definition of "unresponsive UI" across all
-/// SDK features. This matches Sentry's production-tested approach and balances sensitivity
-/// with noise reduction.
+/// SDK features. This is an industry-tested threshold that balances sensitivity with
+/// noise reduction.
 ///
-/// Industry comparison:
-/// - Apple WWDC guidelines: 250ms (very sensitive, includes moderate hitches)
-/// - Firebase Performance: 400ms (moderate sensitivity)
-/// - Sentry/Coralogix: 700ms (aligned with ANR, focused on severe freezes)
+/// Industry thresholds span 250ms–700ms:
+/// - 250ms: very sensitive, includes moderate hitches
+/// - 400ms: moderate sensitivity
+/// - 700ms: aligned with ANR, focused on severe freezes
 ///
 /// A frame frozen for 700ms will trigger BOTH:
 /// 1. A frozen frame metric (this detector)
@@ -116,7 +116,7 @@ final class SlowFrozenFramesDetector {
     /// - Parameters:
     ///   - frozenThresholdMs: Frame time (ms) at which a frame is considered frozen.
     ///     Default 700ms aligns with ANR threshold for consistent "unresponsive UI" definition.
-    ///     Industry varies: Apple 250ms, Firebase 400ms, Sentry/Coralogix 700ms.
+    ///     Industry thresholds range from 250ms (sensitive) to 700ms (severe freezes only).
     ///   - reportIntervalMs: Window size for aggregating frame counts. Default 60s.
     ///   - tolerancePercentage: Tolerance for slow frame detection. Default 3% to prevent false positives.
     init(

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ These intervals are optimized for battery efficiency while capturing all importa
 - **Frozen frames**: Frame render time >= 700ms (causes perceivable UI freeze)
 - The 700ms frozen frame threshold aligns with ANR detection, providing consistent "unresponsive UI" definition across the SDK
 - Thresholds automatically adapt to display refresh rate (60Hz standard, 120Hz ProMotion)
-- Industry comparison: Apple recommends 250ms, Firebase uses 400ms, Sentry/Coralogix use 700ms (aligned with ANR)
+- Industry thresholds range from 250ms (very sensitive) to 700ms (severe freezes only); 700ms aligns with ANR
 
 ### Enable Swizzling
 Controls whether the SDK automatically swizzles system methods for instrumentation (e.g. `NSURLSession`, view-controller lifecycle). Enabled by default. Set to `false` only if another library conflicts with Coralogix's swizzling.

--- a/Tests/CoralogixRumTests/HybridAPITests.swift
+++ b/Tests/CoralogixRumTests/HybridAPITests.swift
@@ -415,4 +415,59 @@ final class HybridAPITests: XCTestCase {
         XCTAssertEqual(result?[Keys.eventName.rawValue] as? String, "swipe")
         XCTAssertEqual(result?[Keys.scrollDirection.rawValue] as? String, "left")
     }
+
+    // MARK: - T5 (CX-40203): hybrid path inherits per-span sampling filter
+    //
+    // Pins the ordering of the per-span sampling filter relative to `beforeSendCallBack`
+    // inside `CoralogixExporter.export()`. The filter sits ABOVE the callback so hybrid
+    // platforms (Flutter/RN) automatically get the same filtered set as native upload —
+    // without any bridge-side changes. A future refactor that swaps the filter below the
+    // callback would fail these tests. Shared helpers live in `SamplingTestHelpers.swift`.
+
+    func testFlutterPath_sampleRateZero_excludeLogs_callbackReceivesOnlyLogs() throws {
+        coralogixRum?.shutdown()
+        coralogixRum = nil
+
+        let capture = EventTypeCapture()
+        var opts = makeSamplingOptions(sampleRate: 0, exclude: [.logs])
+        opts.beforeSendCallBack = capture.beforeSendCallback()
+
+        coralogixRum = CoralogixRum(options: opts, sdkFramework: .flutter(version: "1.0.0"))
+
+        let exporter = try XCTUnwrap(coralogixRum.coralogixExporter, "Exporter must exist after init.")
+        exporter.spanUploader = SamplingMockSpanUploader()
+
+        _ = exporter.export(spans: [
+            makeSamplingSpan(eventType: .log),
+            makeSamplingSpan(eventType: .networkRequest)
+        ], explicitTimeout: nil)
+
+        XCTAssertEqual(capture.eventTypes, ["log"],
+                       "Hybrid callback must only receive spans whose event_type matches excludeFromSampling.")
+    }
+
+    /// Positive control: when the session is sampled in, the filter is a no-op and both
+    /// log and network spans reach the callback. Guards the negative test above from
+    /// passing for the wrong reason (e.g., encoding silently dropping network spans).
+    func testFlutterPath_sampleRateHundred_callbackReceivesAllSpans() throws {
+        coralogixRum?.shutdown()
+        coralogixRum = nil
+
+        let capture = EventTypeCapture()
+        var opts = makeSamplingOptions(sampleRate: 100, exclude: [.logs])
+        opts.beforeSendCallBack = capture.beforeSendCallback()
+
+        coralogixRum = CoralogixRum(options: opts, sdkFramework: .flutter(version: "1.0.0"))
+
+        let exporter = try XCTUnwrap(coralogixRum.coralogixExporter, "Exporter must exist after init.")
+        exporter.spanUploader = SamplingMockSpanUploader()
+
+        _ = exporter.export(spans: [
+            makeSamplingSpan(eventType: .log),
+            makeSamplingSpan(eventType: .networkRequest)
+        ], explicitTimeout: nil)
+
+        XCTAssertEqual(Set(capture.eventTypes), Set(["log", "network-request"]),
+                       "Sampled-in: every span should reach the hybrid callback regardless of excludeFromSampling.")
+    }
 }

--- a/Tests/CoralogixRumTests/LogSamplingDecouplingTests.swift
+++ b/Tests/CoralogixRumTests/LogSamplingDecouplingTests.swift
@@ -7,8 +7,9 @@
 //
 //  Routes real `SpanData` through `CoralogixExporter.export()` and captures what
 //  survives the sampling filter via the `tracesExporter` callback (which fires after
-//  the sampling/URL/error filters but before encode/upload). A MockSpanUploader is
-//  wired in to keep tests offline.
+//  the sampling/URL/error filters but before encode/upload). A `SamplingMockSpanUploader`
+//  is wired in to keep tests offline. Shared helpers (`EventTypeCapture`, factories,
+//  mock uploader) live in `SamplingTestHelpers.swift` and are reused by `HybridAPITests`.
 //
 //  "Deterministic sampler stub": SDKSampler.shouldInitialized() uses
 //  Int.random(in: 0..<100) < sampleRate, which is deterministic at the boundaries
@@ -30,7 +31,7 @@ final class LogSamplingDecouplingTests: XCTestCase {
     // MARK: - Case 1: sampleRate=0, exclude=[] ⇒ SDK does not initialize
 
     func testCase1_sampleRateZero_excludeEmpty_doesNotInitialize() {
-        let rum = CoralogixRum(options: makeOptions(sampleRate: 0, exclude: []))
+        let rum = CoralogixRum(options: makeSamplingOptions(sampleRate: 0, exclude: []))
         defer { rum.shutdown() }
 
         XCTAssertFalse(rum.isInitialized,
@@ -42,17 +43,19 @@ final class LogSamplingDecouplingTests: XCTestCase {
     // MARK: - Case 2: sampleRate=0, exclude=[.logs] ⇒ logs export, others drop
 
     func testCase2_sampleRateZero_excludeLogs_logsExportOthersDrop() throws {
-        let capture = Capture()
-        let rum = CoralogixRum(options: makeOptions(sampleRate: 0, exclude: [.logs], capture: capture))
+        let capture = EventTypeCapture()
+        let rum = CoralogixRum(options: makeSamplingOptions(sampleRate: 0,
+                                                            exclude: [.logs],
+                                                            tracesExporter: capture.tracesExporterCallback()))
         defer { rum.shutdown() }
 
         let exporter = try requireExporter(rum)
-        exporter.spanUploader = MockSpanUploader()
+        exporter.spanUploader = SamplingMockSpanUploader()
 
         _ = exporter.export(spans: [
-            makeSpan(eventType: .log),
-            makeSpan(eventType: .error),
-            makeSpan(eventType: .networkRequest)
+            makeSamplingSpan(eventType: .log),
+            makeSamplingSpan(eventType: .error),
+            makeSamplingSpan(eventType: .networkRequest)
         ], explicitTimeout: nil)
 
         XCTAssertEqual(capture.eventTypes, ["log"],
@@ -62,17 +65,19 @@ final class LogSamplingDecouplingTests: XCTestCase {
     // MARK: - Case 3: sampleRate=100, exclude=[.logs] ⇒ all spans export
 
     func testCase3_sampleRateHundred_excludeLogs_allSpansExport() throws {
-        let capture = Capture()
-        let rum = CoralogixRum(options: makeOptions(sampleRate: 100, exclude: [.logs], capture: capture))
+        let capture = EventTypeCapture()
+        let rum = CoralogixRum(options: makeSamplingOptions(sampleRate: 100,
+                                                            exclude: [.logs],
+                                                            tracesExporter: capture.tracesExporterCallback()))
         defer { rum.shutdown() }
 
         let exporter = try requireExporter(rum)
-        exporter.spanUploader = MockSpanUploader()
+        exporter.spanUploader = SamplingMockSpanUploader()
 
         _ = exporter.export(spans: [
-            makeSpan(eventType: .log),
-            makeSpan(eventType: .error),
-            makeSpan(eventType: .networkRequest)
+            makeSamplingSpan(eventType: .log),
+            makeSamplingSpan(eventType: .error),
+            makeSamplingSpan(eventType: .networkRequest)
         ], explicitTimeout: nil)
 
         XCTAssertEqual(Set(capture.eventTypes),
@@ -87,7 +92,7 @@ final class LogSamplingDecouplingTests: XCTestCase {
         // the flag to `true`, rotate the session, and watch the reroll callback flip it
         // back. Asserting "the value didn't change" alone would also be true if the callback
         // never fired — the manual flip closes that gap.
-        let rum = CoralogixRum(options: makeOptions(sampleRate: 0, exclude: [.logs]))
+        let rum = CoralogixRum(options: makeSamplingOptions(sampleRate: 0, exclude: [.logs]))
         defer { rum.shutdown() }
 
         let exporter = try requireExporter(rum)
@@ -105,7 +110,7 @@ final class LogSamplingDecouplingTests: XCTestCase {
     }
 
     func testCase4_sessionRotation_sampleRateHundred_rerollFlipsBackToTrue() throws {
-        let rum = CoralogixRum(options: makeOptions(sampleRate: 100, exclude: []))
+        let rum = CoralogixRum(options: makeSamplingOptions(sampleRate: 100, exclude: []))
         defer { rum.shutdown() }
 
         let exporter = try requireExporter(rum)
@@ -125,20 +130,20 @@ final class LogSamplingDecouplingTests: XCTestCase {
     // MARK: - Case 5: multiple categories ⇒ only those pass
 
     func testCase5_sampleRateZero_excludeLogsAndErrors_onlyThoseTwoPass() throws {
-        let capture = Capture()
-        let rum = CoralogixRum(options: makeOptions(sampleRate: 0,
-                                                    exclude: [.logs, .errors],
-                                                    capture: capture))
+        let capture = EventTypeCapture()
+        let rum = CoralogixRum(options: makeSamplingOptions(sampleRate: 0,
+                                                            exclude: [.logs, .errors],
+                                                            tracesExporter: capture.tracesExporterCallback()))
         defer { rum.shutdown() }
 
         let exporter = try requireExporter(rum)
-        exporter.spanUploader = MockSpanUploader()
+        exporter.spanUploader = SamplingMockSpanUploader()
 
         _ = exporter.export(spans: [
-            makeSpan(eventType: .log),
-            makeSpan(eventType: .error),
-            makeSpan(eventType: .networkRequest),
-            makeSpan(eventType: .mobileVitals)
+            makeSamplingSpan(eventType: .log),
+            makeSamplingSpan(eventType: .error),
+            makeSamplingSpan(eventType: .networkRequest),
+            makeSamplingSpan(eventType: .mobileVitals)
         ], explicitTimeout: nil)
 
         XCTAssertEqual(Set(capture.eventTypes), Set(["log", "error"]),
@@ -148,12 +153,14 @@ final class LogSamplingDecouplingTests: XCTestCase {
     // MARK: - Case 6: thread-safety smoke — rotate on one queue while exporting on another
 
     func testCase6_sessionRotation_concurrentWithExport_threadSafetySmoke() throws {
-        let capture = Capture()
-        let rum = CoralogixRum(options: makeOptions(sampleRate: 0, exclude: [.logs], capture: capture))
+        let capture = EventTypeCapture()
+        let rum = CoralogixRum(options: makeSamplingOptions(sampleRate: 0,
+                                                            exclude: [.logs],
+                                                            tracesExporter: capture.tracesExporterCallback()))
         defer { rum.shutdown() }
 
         let exporter = try requireExporter(rum)
-        exporter.spanUploader = MockSpanUploader()
+        exporter.spanUploader = SamplingMockSpanUploader()
 
         let iterations = 100
         let group = DispatchGroup()
@@ -172,7 +179,7 @@ final class LogSamplingDecouplingTests: XCTestCase {
         // not across calls, so the duplicate spanId here is harmless.
         group.enter()
         DispatchQueue.global(qos: .userInitiated).async {
-            let span = self.makeSpan(eventType: .log)
+            let span = makeSamplingSpan(eventType: .log)
             for _ in 0..<iterations {
                 _ = exporter.export(spans: [span], explicitTimeout: nil)
             }
@@ -197,99 +204,7 @@ final class LogSamplingDecouplingTests: XCTestCase {
 
     // MARK: - Helpers
 
-    /// Thread-safe append-only collector for event_type strings observed by `tracesExporter`.
-    private final class Capture {
-        private let lock = NSLock()
-        private var values: [String] = []
-
-        func append(_ value: String) {
-            lock.lock()
-            values.append(value)
-            lock.unlock()
-        }
-
-        var eventTypes: [String] {
-            lock.lock()
-            defer { lock.unlock() }
-            return values
-        }
-    }
-
-    private func makeOptions(sampleRate: Int,
-                             exclude: Set<ExcludableInstrumentation>,
-                             capture: Capture? = nil) -> CoralogixExporterOptions {
-        return CoralogixExporterOptions(
-            coralogixDomain: .US2,
-            userContext: nil,
-            environment: "test",
-            application: "TestApp",
-            version: "1.0.0",
-            publicKey: "test-key",
-            ignoreUrls: [],
-            ignoreErrors: [],
-            labels: nil,
-            sessionSampleRate: sampleRate,
-            excludeFromSampling: exclude,
-            instrumentations: nil,
-            tracesExporter: capture.map { capture in
-                { data in
-                    Self.eventTypes(in: data).forEach(capture.append)
-                }
-            },
-            debug: false
-        )
-    }
-
     private func requireExporter(_ rum: CoralogixRum) throws -> CoralogixExporter {
         return try XCTUnwrap(rum.coralogixExporter, "Exporter must exist after init.")
-    }
-
-    /// Builds a SpanData with the attributes CxSpan needs to encode successfully, plus the
-    /// `event_type` under test. No `httpUrl` and no `errorMessage`, so URL/error filters pass.
-    private func makeSpan(eventType: CoralogixEventType) -> SpanData {
-        let attributes: [String: AttributeValue] = [
-            Keys.eventType.rawValue: AttributeValue(eventType.rawValue),
-            Keys.severity.rawValue: AttributeValue("3"),
-            Keys.source.rawValue: AttributeValue("console"),
-            Keys.environment.rawValue: AttributeValue("test"),
-            Keys.userId.rawValue: AttributeValue("uid"),
-            Keys.userName.rawValue: AttributeValue("Test User"),
-            Keys.userEmail.rawValue: AttributeValue("test@example.com"),
-            Keys.sessionId.rawValue: AttributeValue("session_001"),
-            Keys.sessionCreationDate.rawValue: AttributeValue("1609459200")
-        ]
-        return SpanData(traceId: TraceId.random(),
-                        spanId: SpanId.random(),
-                        name: "testSpan_\(eventType.rawValue)",
-                        kind: .client,
-                        startTime: Date(),
-                        attributes: attributes,
-                        endTime: Date(),
-                        hasEnded: true)
-    }
-
-    /// Walks the OTLP-shaped capture to extract every `event_type` string attribute.
-    private static func eventTypes(in data: CoralogixTraceExporterData) -> [String] {
-        return data.tracesData.resourceSpans.flatMap { resourceSpan in
-            resourceSpan.scopeSpans.flatMap { scopeSpan in
-                scopeSpan.spans.compactMap { span -> String? in
-                    guard let kv = span.attributes.first(where: { $0.key == Keys.eventType.rawValue }) else {
-                        return nil
-                    }
-                    if case .stringValue(let value) = kv.value { return value }
-                    return nil
-                }
-            }
-        }
-    }
-}
-
-// MARK: - Test Doubles
-
-/// Local copy of the MockSpanUploader pattern from CoralogixExporterTests.swift to keep
-/// this file self-contained and avoid network I/O during export.
-private final class MockSpanUploader: SpanUploading {
-    func upload(_ spans: [[String: Any]], endPoint: String) -> SpanExporterResultCode {
-        return .success
     }
 }

--- a/Tests/CoralogixRumTests/SamplingTestHelpers.swift
+++ b/Tests/CoralogixRumTests/SamplingTestHelpers.swift
@@ -1,0 +1,136 @@
+//
+//  SamplingTestHelpers.swift
+//
+//  Shared helpers for the sampling-decoupling test surface (PIPEV2-3365). Used by
+//  `LogSamplingDecouplingTests` (T4 — native path via `tracesExporter`) and
+//  `HybridAPITests` T5 cases (hybrid path via `beforeSendCallBack`). Both paths
+//  converge on the same per-span filter in `CoralogixExporter.export()`, so they
+//  collect into the same `EventTypeCapture` shape.
+//
+
+import Foundation
+import XCTest
+import CoralogixInternal
+@testable import Coralogix
+
+/// Thread-safe append-only collector for `event_type` strings observed by either the
+/// `tracesExporter` callback (raw OTLP shape) or the `beforeSendCallBack` (encoded CxSpan).
+/// Both observation points sit below the per-span sampling filter in `CoralogixExporter.export()`,
+/// so they yield the same set of strings — tests assert against `eventTypes` regardless of
+/// which surface they wired.
+final class EventTypeCapture {
+    private let lock = NSLock()
+    private var values: [String] = []
+
+    /// Atomically appends a batch of event_type strings. Single lock acquisition per batch
+    /// (not per element), so concurrent observers always see whole-batch boundaries — and
+    /// the export hot path takes the lock at most once per `export()` call.
+    func append(_ types: [String]) {
+        guard !types.isEmpty else { return }
+        lock.lock()
+        values.append(contentsOf: types)
+        lock.unlock()
+    }
+
+    var eventTypes: [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return values
+    }
+
+    /// Returns a closure suitable for `CoralogixExporterOptions.tracesExporter`. Walks the
+    /// OTLP shape (resourceSpans → scopeSpans → spans) and pulls every `event_type` attribute.
+    /// Captures `self` strongly so the test's local `let capture = …` only needs to outlive
+    /// the test method (the rum/exporter retain the closure for the duration of export).
+    func tracesExporterCallback() -> TracesExporterCallback {
+        return { data in
+            let types = data.tracesData.resourceSpans.flatMap { resourceSpan in
+                resourceSpan.scopeSpans.flatMap { scopeSpan in
+                    scopeSpan.spans.compactMap { span -> String? in
+                        guard let kv = span.attributes.first(where: { $0.key == Keys.eventType.rawValue }) else {
+                            return nil
+                        }
+                        if case .stringValue(let value) = kv.value { return value }
+                        return nil
+                    }
+                }
+            }
+            self.append(types)
+        }
+    }
+
+    /// Returns a closure suitable for `CoralogixExporterOptions.beforeSendCallBack`. Walks
+    /// the encoded CxSpan dictionary (`text → cx_rum → event_context → type`) — the shape
+    /// hybrid bridges (Flutter/RN) receive at the platform-channel boundary.
+    func beforeSendCallback() -> ([[String: Any]]) -> Void {
+        return { batch in
+            self.append(batch.compactMap(Self.encodedEventType))
+        }
+    }
+
+    private static func encodedEventType(in dict: [String: Any]) -> String? {
+        guard let text = dict[Keys.text.rawValue] as? [String: Any],
+              let cxRum = text[Keys.cxRum.rawValue] as? [String: Any],
+              let eventContext = cxRum[Keys.eventContext.rawValue] as? [String: Any],
+              let type = eventContext[Keys.type.rawValue] as? String else {
+            return nil
+        }
+        return type
+    }
+}
+
+/// Builds `CoralogixExporterOptions` for sampling tests. `beforeSendCallBack` is a `public var`
+/// on the options (not an init parameter), so hybrid tests assign it post-init at the call site.
+func makeSamplingOptions(sampleRate: Int,
+                         exclude: Set<ExcludableInstrumentation>,
+                         tracesExporter: TracesExporterCallback? = nil) -> CoralogixExporterOptions {
+    return CoralogixExporterOptions(
+        coralogixDomain: .US2,
+        userContext: nil,
+        environment: "test",
+        application: "TestApp",
+        version: "1.0.0",
+        publicKey: "test-key",
+        ignoreUrls: [],
+        ignoreErrors: [],
+        labels: nil,
+        sessionSampleRate: sampleRate,
+        excludeFromSampling: exclude,
+        instrumentations: nil,
+        tracesExporter: tracesExporter,
+        debug: false
+    )
+}
+
+/// Builds a `SpanData` that survives the encoding pipeline (`CxRumBuilder.build()` requires
+/// session attributes) and carries the `event_type` under test. No `httpUrl`, no
+/// `errorMessage`, so the URL and error filters in `export()` are no-ops.
+func makeSamplingSpan(eventType: CoralogixEventType) -> SpanData {
+    let attributes: [String: AttributeValue] = [
+        Keys.eventType.rawValue: AttributeValue(eventType.rawValue),
+        Keys.severity.rawValue: AttributeValue("3"),
+        Keys.source.rawValue: AttributeValue("console"),
+        Keys.environment.rawValue: AttributeValue("test"),
+        Keys.userId.rawValue: AttributeValue("uid"),
+        Keys.userName.rawValue: AttributeValue("Test User"),
+        Keys.userEmail.rawValue: AttributeValue("test@example.com"),
+        Keys.sessionId.rawValue: AttributeValue("session_001"),
+        Keys.sessionCreationDate.rawValue: AttributeValue("1609459200")
+    ]
+    return SpanData(traceId: TraceId.random(),
+                    spanId: SpanId.random(),
+                    name: "testSpan_\(eventType.rawValue)",
+                    kind: .client,
+                    startTime: Date(),
+                    attributes: attributes,
+                    endTime: Date(),
+                    hasEnded: true)
+}
+
+/// Test-only `SpanUploading` that returns `.success` without network I/O. Shared by all
+/// sampling-decoupling tests so we don't keep duplicating per-file mocks.
+final class SamplingMockSpanUploader: SpanUploading {
+    func upload(_ spans: [[String: Any]], endPoint: String) -> SpanExporterResultCode {
+        return .success
+    }
+}


### PR DESCRIPTION
# User description
## Summary

- **T5 hybrid coverage:** Two new tests in `HybridAPITests` pin that the per-span sampling filter in `CoralogixExporter.export()` sits **above** `beforeSendCallBack`, so hybrid platforms (Flutter/RN) inherit the same filtered set as native upload — no bridge-side changes needed. The negative case from the ticket (`.flutter` + `sampleRate: 0` + `excludeFromSampling: [.logs]`) asserts the callback only receives `event_type == "log"`; a symmetric positive control (`sampleRate: 100`) guards against the negative test passing for the wrong reason (e.g., encoding silently dropping network spans).
- **Shared test helpers:** Extracted `EventTypeCapture`, `makeSamplingOptions`, `makeSamplingSpan`, and `SamplingMockSpanUploader` into `SamplingTestHelpers.swift` (single source of truth for both `tracesExporter` and `beforeSendCallBack` observation surfaces). Removes ~115 lines of duplicated private helpers from `LogSamplingDecouplingTests` (T4) and `HybridAPITests` (T5). `EventTypeCapture.append([String])` batches the lock (one acquisition per export, not per element) — perf + whole-batch atomicity win over T4's previous per-element-locked `Capture`.
- **Docs scrub:** Removed competitor names from industry-comparison phrasing in `README.md` and `SlowFrozenFramesDetector.swift`. Thresholds, ANR alignment rationale, and sensitivity tradeoffs preserved; only vendor names dropped.

Ticket: https://coralogix.atlassian.net/browse/CX-40203
Design: `tech-debt/PIPEV2-3365_decouple_log_sampling.md`
Sequence: T1 (#193) → T2 (#194) → T3 (#195) → T4 (#197) → **T5 (this PR)** → T6 (docs)

## Test plan

- [x] `xcodebuild test -scheme Coralogix-Package -destination "platform=iOS Simulator,name=iPhone 16,OS=18.5"` — **566/566** CoralogixRumTests pass locally
- [x] `HybridAPITests` (27 tests including 2 new T5 cases) green
- [x] `LogSamplingDecouplingTests` (7 tests) green after helper extraction — verifies T4 behavior preserved
- [x] `SlowFrozenFramesDetectorTests` (2 tests) green — confirms comment-only edits compile cleanly
- [x] Final grep confirms zero competitor mentions in tracked SDK code
- [ ] CI macOS 14 / Xcode 16.x matrix green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Validate that the hybrid APIs flowing through <code>CoralogixExporter</code> honor the per-span sampling filter above <code>beforeSendCallBack</code>, so Flutter and React Native consumers inherit the same dropped spans as native uploads. Share sampling helpers and doc wording clarifications to keep the decoupling tests aligned while cleaning up the detector narrative.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/201?tool=ast&topic=Sampling+Helpers>Sampling Helpers</a>
        </td><td>Extract shared sampling helpers and doc wording clarifications so native and hybrid tests reuse <code>EventTypeCapture</code>, the sampling span factories, and keep detector descriptions vendor-neutral.<details><summary>Modified files (4)</summary><ul><li>Coralogix/Sources/Utils/MobileVitals/SlowFrozenFramesDetector.swift</li>
<li>README.md</li>
<li>Tests/CoralogixRumTests/LogSamplingDecouplingTests.swift</li>
<li>Tests/CoralogixRumTests/SamplingTestHelpers.swift</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>feat(CX-40203): T5 —...</td><td>May 12, 2026</td></tr>
<tr><td>naftaly@users.noreply....</td><td>Fix typos and enhance ...</td><td>October 26, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/201?tool=ast&topic=Hybrid+Sampling>Hybrid Sampling</a>
        </td><td>Verify that hybrid flows through <code>CoralogixExporter</code> drop excluded spans before <code>beforeSendCallBack</code>, ensuring Flutter/RN callbacks only see sampled-in events.<details><summary>Modified files (1)</summary><ul><li>Tests/CoralogixRumTests/HybridAPITests.swift</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>feat(CX-40203): T5 —...</td><td>May 12, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/coralogix/cx-ios-sdk/201?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Mobile Vitals frozen frame detection thresholds, specifying the industry range spans 250ms–700ms, with 700ms aligned to ANR detection.

* **Tests**
  * Enhanced test coverage for hybrid (Flutter) per-span sampling filtering behavior.
  * Refactored sampling-related tests with shared utilities for improved maintainability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coralogix/cx-ios-sdk/pull/201)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->