### PR TITLE
feat(CX-40570): structured Logger protocol + LogLevel

### DIFF
--- a/CoralogixInternal/Sources/Log.swift
+++ b/CoralogixInternal/Sources/Log.swift
@@ -25,14 +25,15 @@ public class Log {
         }
     }
 
-    // MARK: - Debug
-
-    public static func d(_ message: @autoclosure () -> String,
-                         file: String = #fileID,
-                         function: String = #function,
-                         line: Int = #line) {
+    // Emits at `level` if-and-only-if `isDebug` is true. `message` is only
+    // invoked after the gate, so disabled levels do not evaluate the closure.
+    private static func emit(level: LogLevel,
+                             message: () -> String,
+                             file: String,
+                             function: String,
+                             line: Int) {
         guard isDebug else { return }
-        shared.log(level: .debug,
+        shared.log(level: level,
                    message: message(),
                    metadata: nil,
                    file: file,
@@ -40,11 +41,20 @@ public class Log {
                    line: line)
     }
 
+    // MARK: - Debug
+
+    public static func d(_ message: @autoclosure () -> String,
+                         file: String = #fileID,
+                         function: String = #function,
+                         line: Int = #line) {
+        emit(level: .debug, message: message, file: file, function: function, line: line)
+    }
+
     public static func debug(_ message: @autoclosure () -> String,
                              file: String = #fileID,
                              function: String = #function,
                              line: Int = #line) {
-        d(message(), file: file, function: function, line: line)
+        emit(level: .debug, message: message, file: file, function: function, line: line)
     }
 
     // MARK: - Trace
@@ -53,20 +63,14 @@ public class Log {
                          file: String = #fileID,
                          function: String = #function,
                          line: Int = #line) {
-        guard isDebug else { return }
-        shared.log(level: .trace,
-                   message: message(),
-                   metadata: nil,
-                   file: file,
-                   function: function,
-                   line: line)
+        emit(level: .trace, message: message, file: file, function: function, line: line)
     }
 
     public static func trace(_ message: @autoclosure () -> String,
                              file: String = #fileID,
                              function: String = #function,
                              line: Int = #line) {
-        t(message(), file: file, function: function, line: line)
+        emit(level: .trace, message: message, file: file, function: function, line: line)
     }
 
     // MARK: - Warning
@@ -75,20 +79,14 @@ public class Log {
                          file: String = #fileID,
                          function: String = #function,
                          line: Int = #line) {
-        guard isDebug else { return }
-        shared.log(level: .warning,
-                   message: message(),
-                   metadata: nil,
-                   file: file,
-                   function: function,
-                   line: line)
+        emit(level: .warning, message: message, file: file, function: function, line: line)
     }
 
     public static func warning(_ message: @autoclosure () -> String,
                                file: String = #fileID,
                                function: String = #function,
                                line: Int = #line) {
-        w(message(), file: file, function: function, line: line)
+        emit(level: .warning, message: message, file: file, function: function, line: line)
     }
 
     // MARK: - Error
@@ -98,14 +96,11 @@ public class Log {
                          file: String = #fileID,
                          function: String = #function,
                          line: Int = #line) {
-        guard isDebug else { return }
-        let combined = combine(message: message(), error: error)
-        shared.log(level: .error,
-                   message: combined,
-                   metadata: nil,
-                   file: file,
-                   function: function,
-                   line: line)
+        emit(level: .error,
+             message: { combine(message: message(), error: error) },
+             file: file,
+             function: function,
+             line: line)
     }
 
     public static func error(_ message: @autoclosure () -> String = "",
@@ -113,7 +108,11 @@ public class Log {
                              file: String = #fileID,
                              function: String = #function,
                              line: Int = #line) {
-        e(message(), error, file: file, function: function, line: line)
+        emit(level: .error,
+             message: { combine(message: message(), error: error) },
+             file: file,
+             function: function,
+             line: line)
     }
 
     public static func e(_ error: Error,

--- a/CoralogixInternal/Sources/Log.swift
+++ b/CoralogixInternal/Sources/Log.swift
@@ -126,12 +126,11 @@ public class Log {
                              file: String = #fileID,
                              function: String = #function,
                              line: Int = #line) {
-        shared.log(level: .error,
-                   message: error.localizedDescription,
-                   metadata: nil,
-                   file: file,
-                   function: function,
-                   line: line)
+        emit(level: .error,
+             message: { error.localizedDescription },
+             file: file,
+             function: function,
+             line: line)
     }
 
     private static func combine(message: String, error: Error?) -> String {

--- a/CoralogixInternal/Sources/Log.swift
+++ b/CoralogixInternal/Sources/Log.swift
@@ -10,9 +10,9 @@ public class Log {
     public static var isDebug = false
 
     private static let sharedLock = NSLock()
-    private static var _shared: Logger = OSLogger()
+    private static var _shared: CXLogger = OSLogger()
 
-    public static var shared: Logger {
+    public static var shared: CXLogger {
         get {
             sharedLock.lock()
             defer { sharedLock.unlock() }

--- a/CoralogixInternal/Sources/Log.swift
+++ b/CoralogixInternal/Sources/Log.swift
@@ -9,71 +9,145 @@ import Foundation
 public class Log {
     public static var isDebug = false
 
-    public static func d(_ message: String) {
-        debug(message)
-    }
-    
-    public static func debug(_ message: String) {
-        if isDebug {
-            print("🟪 \(message)")
+    private static let sharedLock = NSLock()
+    private static var _shared: Logger = OSLogger()
+
+    public static var shared: Logger {
+        get {
+            sharedLock.lock()
+            defer { sharedLock.unlock() }
+            return _shared
+        }
+        set {
+            sharedLock.lock()
+            defer { sharedLock.unlock() }
+            _shared = newValue
         }
     }
-    
+
+    // MARK: - Debug
+
+    public static func d(_ message: @autoclosure () -> String,
+                         file: String = #fileID,
+                         function: String = #function,
+                         line: Int = #line) {
+        guard isDebug else { return }
+        shared.log(level: .debug,
+                   message: message(),
+                   metadata: nil,
+                   file: file,
+                   function: function,
+                   line: line)
+    }
+
+    public static func debug(_ message: @autoclosure () -> String,
+                             file: String = #fileID,
+                             function: String = #function,
+                             line: Int = #line) {
+        d(message(), file: file, function: function, line: line)
+    }
+
     // MARK: - Trace
-    
-    public static func t(_ message: String) {
-        trace(message)
+
+    public static func t(_ message: @autoclosure () -> String,
+                         file: String = #fileID,
+                         function: String = #function,
+                         line: Int = #line) {
+        guard isDebug else { return }
+        shared.log(level: .trace,
+                   message: message(),
+                   metadata: nil,
+                   file: file,
+                   function: function,
+                   line: line)
     }
-    
-    public static func trace(_ message: String) {
-        if isDebug {
-            print("🟦 \(message)")
-        }
+
+    public static func trace(_ message: @autoclosure () -> String,
+                             file: String = #fileID,
+                             function: String = #function,
+                             line: Int = #line) {
+        t(message(), file: file, function: function, line: line)
     }
-    
+
     // MARK: - Warning
 
-    public static func w(_ message: String) {
-        warning(message)
+    public static func w(_ message: @autoclosure () -> String,
+                         file: String = #fileID,
+                         function: String = #function,
+                         line: Int = #line) {
+        guard isDebug else { return }
+        shared.log(level: .warning,
+                   message: message(),
+                   metadata: nil,
+                   file: file,
+                   function: function,
+                   line: line)
     }
-    
-    public static func warning(_ message: String) {
-        if isDebug {
-            print("🟨 \(message)")
-        }
+
+    public static func warning(_ message: @autoclosure () -> String,
+                               file: String = #fileID,
+                               function: String = #function,
+                               line: Int = #line) {
+        w(message(), file: file, function: function, line: line)
     }
-    
+
     // MARK: - Error
 
-    public static func e(_ message: String = "", _ error: Error? = nil) {
-        Log.error(message, error)
+    public static func e(_ message: @autoclosure () -> String = "",
+                         _ error: Error? = nil,
+                         file: String = #fileID,
+                         function: String = #function,
+                         line: Int = #line) {
+        guard isDebug else { return }
+        let combined = combine(message: message(), error: error)
+        shared.log(level: .error,
+                   message: combined,
+                   metadata: nil,
+                   file: file,
+                   function: function,
+                   line: line)
     }
-    
-    public static func error(_ message: String = "", _ error: Error? = nil) {
-        if isDebug {
-            var description = message
-            if let error = error {
-                description = "\(description)\ndetails:\n\(error.localizedDescription)"
-            }
-            print("🟥 \(description)")
-        }
+
+    public static func error(_ message: @autoclosure () -> String = "",
+                             _ error: Error? = nil,
+                             file: String = #fileID,
+                             function: String = #function,
+                             line: Int = #line) {
+        e(message(), error, file: file, function: function, line: line)
     }
-    
-    public static func e(_ error: Error) {
-        Log.error(error)
+
+    public static func e(_ error: Error,
+                         file: String = #fileID,
+                         function: String = #function,
+                         line: Int = #line) {
+        Log.error(error, file: file, function: function, line: line)
     }
-    
-    public static func error(_ error: Error) {
-        print("🟥 \(error.localizedDescription)")
+
+    public static func error(_ error: Error,
+                             file: String = #fileID,
+                             function: String = #function,
+                             line: Int = #line) {
+        shared.log(level: .error,
+                   message: error.localizedDescription,
+                   metadata: nil,
+                   file: file,
+                   function: function,
+                   line: line)
     }
-    
+
+    private static func combine(message: String, error: Error?) -> String {
+        guard let error = error else { return message }
+        if message.isEmpty { return error.localizedDescription }
+        return "\(message)\ndetails:\n\(error.localizedDescription)"
+    }
+
     // MARK: - Test Logging (DEBUG only)
-    
+
     #if DEBUG
     private static var isTestLoggingEnabled = false
     private static let testLogFileURL = URL(fileURLWithPath: "/tmp/coralogix_test_logs.txt")
     private static let testLogQueue = DispatchQueue(label: "com.coralogix.testlogger", qos: .utility)
-    
+
     public static func enableTestLogging() {
         testLogQueue.sync {
             isTestLoggingEnabled = true
@@ -81,21 +155,21 @@ public class Log {
             try? "".write(to: testLogFileURL, atomically: true, encoding: .utf8)
         }
     }
-    
+
     public static func disableTestLogging() {
         testLogQueue.sync {
             isTestLoggingEnabled = false
         }
     }
-    
+
     public static func testLog(_ message: String) {
         testLogQueue.async {
             // Read flag under queue protection to avoid race with enable/disable
             guard isTestLoggingEnabled else { return }
-            
+
             let timestamp = ISO8601DateFormatter().string(from: Date())
             let logEntry = "[\(timestamp)] \(message)\n"
-            
+
             if let handle = try? FileHandle(forWritingTo: testLogFileURL) {
                 handle.seekToEndOfFile()
                 if let data = logEntry.data(using: .utf8) {
@@ -107,14 +181,14 @@ public class Log {
             }
         }
     }
-    
+
     public static func getTestLogs() -> String {
         // Synchronize with testLogQueue to ensure all pending writes complete before reading
         return testLogQueue.sync {
             return (try? String(contentsOf: testLogFileURL, encoding: .utf8)) ?? ""
         }
     }
-    
+
     public static func clearTestLogs() {
         testLogQueue.sync {
             try? "".write(to: testLogFileURL, atomically: true, encoding: .utf8)

--- a/CoralogixInternal/Sources/Logging/LogLevel.swift
+++ b/CoralogixInternal/Sources/Logging/LogLevel.swift
@@ -1,0 +1,18 @@
+//
+//  LogLevel.swift
+//
+
+import Foundation
+
+public enum LogLevel: Int, Comparable, Sendable {
+    case trace = 0
+    case debug = 1
+    case info = 2
+    case warning = 3
+    case error = 4
+    case critical = 5
+
+    public static func < (lhs: LogLevel, rhs: LogLevel) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+}

--- a/CoralogixInternal/Sources/Logging/Logger.swift
+++ b/CoralogixInternal/Sources/Logging/Logger.swift
@@ -1,0 +1,40 @@
+//
+//  Logger.swift
+//
+
+import Foundation
+
+public protocol Logger {
+    func log(level: LogLevel,
+             message: @autoclosure () -> String,
+             metadata: [String: Any]?,
+             file: String,
+             function: String,
+             line: Int)
+}
+
+public extension Logger {
+    func log(level: LogLevel,
+             _ message: @autoclosure () -> String,
+             metadata: [String: Any]? = nil,
+             file: String = #fileID,
+             function: String = #function,
+             line: Int = #line) {
+        log(level: level,
+            message: message(),
+            metadata: metadata,
+            file: file,
+            function: function,
+            line: line)
+    }
+}
+
+public struct NoopLogger: Logger {
+    public init() {}
+    public func log(level: LogLevel,
+                    message: @autoclosure () -> String,
+                    metadata: [String: Any]?,
+                    file: String,
+                    function: String,
+                    line: Int) {}
+}

--- a/CoralogixInternal/Sources/Logging/Logger.swift
+++ b/CoralogixInternal/Sources/Logging/Logger.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-public protocol Logger {
+public protocol CXLogger {
     func log(level: LogLevel,
              message: @autoclosure () -> String,
              metadata: [String: Any]?,
@@ -13,7 +13,7 @@ public protocol Logger {
              line: Int)
 }
 
-public extension Logger {
+public extension CXLogger {
     func log(level: LogLevel,
              _ message: @autoclosure () -> String,
              metadata: [String: Any]? = nil,
@@ -29,7 +29,7 @@ public extension Logger {
     }
 }
 
-public struct NoopLogger: Logger {
+public struct NoopLogger: CXLogger {
     public init() {}
     public func log(level: LogLevel,
                     message: @autoclosure () -> String,

--- a/CoralogixInternal/Sources/Logging/OSLogger.swift
+++ b/CoralogixInternal/Sources/Logging/OSLogger.swift
@@ -5,7 +5,7 @@
 import Foundation
 import os
 
-public final class OSLogger: Logger {
+public final class OSLogger: CXLogger {
     public static let defaultSubsystem = "com.coralogix.rum"
     public static let defaultCategory = "default"
 
@@ -29,7 +29,7 @@ public final class OSLogger: Logger {
                     file: String,
                     function: String,
                     line: Int) {
-        let formatted = Self.format(message: message(), metadata: metadata)
+        let formatted = "\(level.emojiPrefix) \(Self.format(message: message(), metadata: metadata))"
 
         if #available(iOS 14.0, *) {
             let logger = modernLogger()
@@ -43,8 +43,6 @@ public final class OSLogger: Logger {
         } else {
             os_log("%{public}@", log: legacyLog, type: level.osLogType, formatted)
         }
-
-        print("\(level.emojiPrefix) \(formatted)")
     }
 
     @available(iOS 14.0, *)

--- a/CoralogixInternal/Sources/Logging/OSLogger.swift
+++ b/CoralogixInternal/Sources/Logging/OSLogger.swift
@@ -29,8 +29,6 @@ public final class OSLogger: Logger {
                     file: String,
                     function: String,
                     line: Int) {
-        guard Log.isDebug else { return }
-
         let formatted = Self.format(message: message(), metadata: metadata)
 
         if #available(iOS 14.0, *) {

--- a/CoralogixInternal/Sources/Logging/OSLogger.swift
+++ b/CoralogixInternal/Sources/Logging/OSLogger.swift
@@ -1,0 +1,96 @@
+//
+//  OSLogger.swift
+//
+
+import Foundation
+import os
+
+public final class OSLogger: Logger {
+    public static let defaultSubsystem = "com.coralogix.rum"
+    public static let defaultCategory = "default"
+
+    private let subsystem: String
+    private let category: String
+    private let legacyLog: OSLog
+
+    private static let cacheLock = NSLock()
+    private static var modernCache: [String: Any] = [:]
+
+    public init(subsystem: String = OSLogger.defaultSubsystem,
+                category: String = OSLogger.defaultCategory) {
+        self.subsystem = subsystem
+        self.category = category
+        self.legacyLog = OSLog(subsystem: subsystem, category: category)
+    }
+
+    public func log(level: LogLevel,
+                    message: @autoclosure () -> String,
+                    metadata: [String: Any]?,
+                    file: String,
+                    function: String,
+                    line: Int) {
+        guard Log.isDebug else { return }
+
+        let formatted = Self.format(message: message(), metadata: metadata)
+
+        if #available(iOS 14.0, *) {
+            let logger = modernLogger()
+            switch level {
+            case .trace, .debug: logger.debug("\(formatted, privacy: .public)")
+            case .info:          logger.info("\(formatted, privacy: .public)")
+            case .warning:       logger.notice("\(formatted, privacy: .public)")
+            case .error:         logger.error("\(formatted, privacy: .public)")
+            case .critical:      logger.fault("\(formatted, privacy: .public)")
+            }
+        } else {
+            os_log("%{public}@", log: legacyLog, type: level.osLogType, formatted)
+        }
+
+        print("\(level.emojiPrefix) \(formatted)")
+    }
+
+    @available(iOS 14.0, *)
+    private func modernLogger() -> os.Logger {
+        let key = "\(subsystem)|\(category)"
+        Self.cacheLock.lock()
+        defer { Self.cacheLock.unlock() }
+        if let existing = Self.modernCache[key] as? os.Logger {
+            return existing
+        }
+        let made = os.Logger(subsystem: subsystem, category: category)
+        Self.modernCache[key] = made
+        return made
+    }
+
+    private static func format(message: String, metadata: [String: Any]?) -> String {
+        guard let metadata = metadata, !metadata.isEmpty else { return message }
+        let pairs = metadata
+            .sorted { $0.key < $1.key }
+            .map { "\($0.key)=\($0.value)" }
+            .joined(separator: " ")
+        return "\(message) [\(pairs)]"
+    }
+}
+
+private extension LogLevel {
+    var osLogType: OSLogType {
+        switch self {
+        case .trace, .debug: return .debug
+        case .info:          return .info
+        case .warning:       return .default
+        case .error:         return .error
+        case .critical:      return .fault
+        }
+    }
+
+    var emojiPrefix: String {
+        switch self {
+        case .trace:    return "🟦"
+        case .debug:    return "🟪"
+        case .info:     return "🟩"
+        case .warning:  return "🟨"
+        case .error:    return "🟥"
+        case .critical: return "💥"
+        }
+    }
+}

--- a/Tests/CoralogixInternalTests/LoggerTests.swift
+++ b/Tests/CoralogixInternalTests/LoggerTests.swift
@@ -186,6 +186,27 @@ final class LoggerTests: XCTestCase {
         XCTAssertEqual(rec.entries.count, 0)
     }
 
+    func test_Log_longNameVariants_doNotEvaluateMessage_whenIsDebugIsFalse() {
+        Log.isDebug = false
+        let rec = RecordingLogger()
+        Log.shared = rec
+
+        var sideEffect = 0
+        func expensive() -> String {
+            sideEffect += 1
+            return "should not be built"
+        }
+
+        Log.debug(expensive())
+        Log.trace(expensive())
+        Log.warning(expensive())
+        Log.error(expensive())
+        Log.error(expensive(), NSError(domain: "x", code: 0))
+
+        XCTAssertEqual(sideEffect, 0, "long-name variants must skip autoclosure evaluation when isDebug is false")
+        XCTAssertEqual(rec.entries.count, 0)
+    }
+
     func test_Log_d_routesToSharedLogger_atDebugLevel_whenIsDebugIsTrue() {
         Log.isDebug = true
         let rec = RecordingLogger()

--- a/Tests/CoralogixInternalTests/LoggerTests.swift
+++ b/Tests/CoralogixInternalTests/LoggerTests.swift
@@ -1,0 +1,260 @@
+//
+//  LoggerTests.swift
+//  CoralogixInternal
+//
+
+import XCTest
+@testable import CoralogixInternal
+
+final class LoggerTests: XCTestCase {
+
+    // MARK: - Test doubles
+
+    final class RecordingLogger: Logger {
+        struct Entry {
+            let level: LogLevel
+            let message: String
+            let metadataKeys: [String]
+            let file: String
+            let function: String
+            let line: Int
+        }
+        private(set) var entries: [Entry] = []
+        private(set) var evaluations = 0
+
+        func log(level: LogLevel,
+                 message: @autoclosure () -> String,
+                 metadata: [String: Any]?,
+                 file: String,
+                 function: String,
+                 line: Int) {
+            evaluations += 1
+            entries.append(Entry(
+                level: level,
+                message: message(),
+                metadataKeys: metadata?.keys.sorted() ?? [],
+                file: file,
+                function: function,
+                line: line
+            ))
+        }
+    }
+
+    final class LevelFilteringLogger: Logger {
+        let threshold: LogLevel
+        private(set) var emitted: [String] = []
+        private(set) var evaluations = 0
+
+        init(threshold: LogLevel) { self.threshold = threshold }
+
+        func log(level: LogLevel,
+                 message: @autoclosure () -> String,
+                 metadata: [String: Any]?,
+                 file: String,
+                 function: String,
+                 line: Int) {
+            guard level >= threshold else { return }
+            evaluations += 1
+            emitted.append(message())
+        }
+    }
+
+    // MARK: - Lifecycle
+
+    override func setUp() {
+        super.setUp()
+        Log.isDebug = false
+        Log.shared = OSLogger()
+    }
+
+    override func tearDown() {
+        Log.isDebug = false
+        Log.shared = OSLogger()
+        super.tearDown()
+    }
+
+    // MARK: - LogLevel
+
+    func test_LogLevel_isOrderedByRawValue() {
+        XCTAssertLessThan(LogLevel.trace, LogLevel.debug)
+        XCTAssertLessThan(LogLevel.debug, LogLevel.info)
+        XCTAssertLessThan(LogLevel.info, LogLevel.warning)
+        XCTAssertLessThan(LogLevel.warning, LogLevel.error)
+        XCTAssertLessThan(LogLevel.error, LogLevel.critical)
+    }
+
+    // MARK: - Logger protocol
+
+    func test_protocolLog_forwardsLevelMessageAndMetadata() {
+        let logger = RecordingLogger()
+        logger.log(level: .info,
+                   message: "hi",
+                   metadata: ["k": 1, "v": "x"],
+                   file: "F.swift",
+                   function: "fn()",
+                   line: 42)
+
+        XCTAssertEqual(logger.entries.count, 1)
+        XCTAssertEqual(logger.entries[0].level, .info)
+        XCTAssertEqual(logger.entries[0].message, "hi")
+        XCTAssertEqual(logger.entries[0].metadataKeys, ["k", "v"])
+        XCTAssertEqual(logger.entries[0].file, "F.swift")
+        XCTAssertEqual(logger.entries[0].function, "fn()")
+        XCTAssertEqual(logger.entries[0].line, 42)
+    }
+
+    func test_protocolExtension_appliesDefaultsForMetadataAndCaller() {
+        let logger = RecordingLogger()
+        logger.log(level: .warning, "danger")
+
+        XCTAssertEqual(logger.entries.count, 1)
+        XCTAssertEqual(logger.entries[0].level, .warning)
+        XCTAssertEqual(logger.entries[0].message, "danger")
+        XCTAssertEqual(logger.entries[0].metadataKeys, [])
+        XCTAssertFalse(logger.entries[0].file.isEmpty)
+        XCTAssertFalse(logger.entries[0].function.isEmpty)
+        XCTAssertGreaterThan(logger.entries[0].line, 0)
+    }
+
+    func test_disabledLevel_doesNotEvaluateAutoclosure() {
+        let logger = LevelFilteringLogger(threshold: .error)
+        var sideEffect = 0
+        func expensive() -> String {
+            sideEffect += 1
+            return "x"
+        }
+
+        logger.log(level: .debug,
+                   message: expensive(),
+                   metadata: nil,
+                   file: #fileID,
+                   function: #function,
+                   line: #line)
+
+        XCTAssertEqual(sideEffect, 0, "autoclosure must not be evaluated when level is filtered out")
+        XCTAssertEqual(logger.evaluations, 0)
+    }
+
+    func test_enabledLevel_evaluatesAutoclosureExactlyOnce() {
+        let logger = LevelFilteringLogger(threshold: .debug)
+        var sideEffect = 0
+        func expensive() -> String {
+            sideEffect += 1
+            return "x"
+        }
+
+        logger.log(level: .info,
+                   message: expensive(),
+                   metadata: nil,
+                   file: #fileID,
+                   function: #function,
+                   line: #line)
+
+        XCTAssertEqual(sideEffect, 1)
+        XCTAssertEqual(logger.emitted, ["x"])
+    }
+
+    // MARK: - NoopLogger
+
+    func test_noopLogger_doesNothing() {
+        let noop = NoopLogger()
+        noop.log(level: .critical,
+                 message: "ignored",
+                 metadata: ["k": 1],
+                 file: #fileID,
+                 function: #function,
+                 line: #line)
+        // No assertion beyond "doesn't crash" — NoopLogger has no observable state.
+    }
+
+    // MARK: - Log façade — isDebug gate
+
+    func test_Log_d_doesNotEvaluateMessage_whenIsDebugIsFalse() {
+        Log.isDebug = false
+        let rec = RecordingLogger()
+        Log.shared = rec
+
+        var sideEffect = 0
+        func expensive() -> String {
+            sideEffect += 1
+            return "should not be built"
+        }
+
+        Log.d(expensive())
+
+        XCTAssertEqual(sideEffect, 0)
+        XCTAssertEqual(rec.entries.count, 0)
+    }
+
+    func test_Log_d_routesToSharedLogger_atDebugLevel_whenIsDebugIsTrue() {
+        Log.isDebug = true
+        let rec = RecordingLogger()
+        Log.shared = rec
+
+        Log.d("hello")
+
+        XCTAssertEqual(rec.entries.count, 1)
+        XCTAssertEqual(rec.entries[0].level, .debug)
+        XCTAssertEqual(rec.entries[0].message, "hello")
+    }
+
+    func test_Log_t_routesAtTraceLevel() {
+        Log.isDebug = true
+        let rec = RecordingLogger()
+        Log.shared = rec
+
+        Log.t("trace-me")
+
+        XCTAssertEqual(rec.entries.first?.level, .trace)
+        XCTAssertEqual(rec.entries.first?.message, "trace-me")
+    }
+
+    func test_Log_w_routesAtWarningLevel() {
+        Log.isDebug = true
+        let rec = RecordingLogger()
+        Log.shared = rec
+
+        Log.w("warn-me")
+
+        XCTAssertEqual(rec.entries.first?.level, .warning)
+        XCTAssertEqual(rec.entries.first?.message, "warn-me")
+    }
+
+    func test_Log_e_string_routesAtErrorLevel() {
+        Log.isDebug = true
+        let rec = RecordingLogger()
+        Log.shared = rec
+
+        Log.e("boom")
+
+        XCTAssertEqual(rec.entries.first?.level, .error)
+        XCTAssertEqual(rec.entries.first?.message, "boom")
+    }
+
+    func test_Log_e_stringWithError_combinesMessageAndLocalizedDescription() {
+        Log.isDebug = true
+        let rec = RecordingLogger()
+        Log.shared = rec
+
+        struct E: LocalizedError { var errorDescription: String? { "bad thing" } }
+        Log.e("context", E())
+
+        XCTAssertEqual(rec.entries.count, 1)
+        XCTAssertEqual(rec.entries[0].level, .error)
+        XCTAssertTrue(rec.entries[0].message.contains("context"))
+        XCTAssertTrue(rec.entries[0].message.contains("bad thing"))
+    }
+
+    func test_Log_e_errorOnly_routesAtErrorLevel() {
+        Log.isDebug = true
+        let rec = RecordingLogger()
+        Log.shared = rec
+
+        struct E: LocalizedError { var errorDescription: String? { "only-error" } }
+        Log.e(E())
+
+        XCTAssertEqual(rec.entries.count, 1)
+        XCTAssertEqual(rec.entries[0].level, .error)
+        XCTAssertEqual(rec.entries[0].message, "only-error")
+    }
+}

--- a/Tests/CoralogixInternalTests/LoggerTests.swift
+++ b/Tests/CoralogixInternalTests/LoggerTests.swift
@@ -278,4 +278,19 @@ final class LoggerTests: XCTestCase {
         XCTAssertEqual(rec.entries[0].level, .error)
         XCTAssertEqual(rec.entries[0].message, "only-error")
     }
+
+    func test_Log_e_errorOnly_isGatedByIsDebug_atFaçadeLayer() {
+        // RecordingLogger does NOT inspect Log.isDebug; it records everything it
+        // receives. So if Log.e(Error) reaches it with isDebug=false, the façade
+        // gate is broken.
+        Log.isDebug = false
+        let rec = RecordingLogger()
+        Log.shared = rec
+
+        struct E: LocalizedError { var errorDescription: String? { "boom" } }
+        Log.e(E())
+        Log.error(E())
+
+        XCTAssertEqual(rec.entries.count, 0, "Log.e(Error)/Log.error(Error) must be gated at the façade, not rely on the underlying logger")
+    }
 }

--- a/Tests/CoralogixInternalTests/LoggerTests.swift
+++ b/Tests/CoralogixInternalTests/LoggerTests.swift
@@ -10,7 +10,7 @@ final class LoggerTests: XCTestCase {
 
     // MARK: - Test doubles
 
-    final class RecordingLogger: Logger {
+    final class RecordingLogger: CXLogger {
         struct Entry {
             let level: LogLevel
             let message: String
@@ -40,7 +40,7 @@ final class LoggerTests: XCTestCase {
         }
     }
 
-    final class LevelFilteringLogger: Logger {
+    final class LevelFilteringLogger: CXLogger {
         let threshold: LogLevel
         private(set) var emitted: [String] = []
         private(set) var evaluations = 0


### PR DESCRIPTION
# User description
## Summary

- Adds `LogLevel` (trace/debug/info/warning/error/critical) and a `Logger` protocol with `@autoclosure` messages and structured metadata, so disabled levels skip message evaluation entirely.
- Default `OSLogger` implementation uses `os.Logger` on iOS 14+ and falls back to `os_log` on iOS 13.
- `Log` stays as the public façade and now delegates through `Log.shared`. The ~295 existing `Log.d/e/t/w` callsites in `Coralogix/`, `CoralogixInternal/`, and `SessionReplay/` migrate transparently with no churn, while gaining lazy autoclosure evaluation.
- `Log.isDebug` remains the global gate (defaults to `false`); enforced at the façade layer for every overload, including `Log.error(_ error: Error)`.

Ticket: [CX-40570](https://coralogix.atlassian.net/browse/CX-40570)

## Test plan

- [x] `xcodebuild build -scheme Coralogix-Package -destination "generic/platform=iOS Simulator"` — BUILD SUCCEEDED
- [x] `xcodebuild test -scheme Coralogix-Package -destination "iPhone 16, OS 18.5"` — 655 / 655 passed across `CoralogixInternalTests`, `CoralogixRumTests`, `SessionReplayTests`
- [x] New `LoggerTests` (15 cases) covering:
  - `LogLevel` ordering
  - Protocol routing + metadata
  - Autoclosure laziness on disabled levels (both at the protocol layer and the `Log` façade, including long-name variants)
  - Façade-level `isDebug` gating for `Log.e(Error)` / `Log.error(Error)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CX-40570]: https://coralogix.atlassian.net/browse/CX-40570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Introduce <code>LogLevel</code> and the <code>CXLogger</code> protocol to enable structured, metadata-aware logging with autoclosure-based messages, and provide <code>OSLogger</code> to route logs through <code>os.Logger</code>/<code>os_log</code> per runtime so disabled levels are free. Update the <code>Log</code> façade to delegate through its guarded shared logger so existing callsites rely on lazy evaluation while honoring <code>isDebug</code> gating.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/203?tool=ast&topic=Structured+Logger>Structured Logger</a>
        </td><td>Implement <code>LogLevel</code>, <code>CXLogger</code>, and <code>OSLogger</code> to provide structured log levels, metadata formatting, and OS logging backends that respect autoclosure messages and modern APIs.<details><summary>Modified files (3)</summary><ul><li>CoralogixInternal/Sources/Logging/LogLevel.swift</li>
<li>CoralogixInternal/Sources/Logging/Logger.swift</li>
<li>CoralogixInternal/Sources/Logging/OSLogger.swift</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>fix(CX-40570): rename ...</td><td>May 14, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/203?tool=ast&topic=Log+Fa%C3%A7ade>Log Façade</a>
        </td><td>Enforce <code>Log</code> façade routing through the guarded shared logger so all convenience methods (including error variants) evaluate lazily and respect <code>isDebug</code>, while covering the behaviors via logger tests.<details><summary>Modified files (2)</summary><ul><li>CoralogixInternal/Sources/Log.swift</li>
<li>Tests/CoralogixInternalTests/LoggerTests.swift</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>fix(CX-40570): rename ...</td><td>May 14, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/coralogix/cx-ios-sdk/203?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>