### PR TITLE
feat(CX-40571): Clock abstraction (SystemClock + MockClock)

### DIFF
--- a/Coralogix/Sources/Utils/MobileVitals/ANRDetector.swift
+++ b/Coralogix/Sources/Utils/MobileVitals/ANRDetector.swift
@@ -18,15 +18,17 @@ internal class ANRDetector {
     // Maximum allowed main thread block time (e.g., 5 seconds)
     let maxBlockTime: TimeInterval
 
-    private var lastCheckTimestamp: CFAbsoluteTime = CFAbsoluteTimeGetCurrent()
+    private let clock: CoralogixInternal.Clock
+    private var lastCheckTimestamp: Date
 
     // ANR handling closure (useful for testing)
     var handleANRClosure: (() -> Void)?
-    
-    init(checkInterval: TimeInterval = 1.0, maxBlockTime: TimeInterval = 5.0) {
+
+    init(checkInterval: TimeInterval = 1.0, maxBlockTime: TimeInterval = 5.0, clock: CoralogixInternal.Clock = SystemClock()) {
         self.checkInterval = checkInterval
         self.maxBlockTime = maxBlockTime
-        self.lastCheckTimestamp = CFAbsoluteTimeGetCurrent()
+        self.clock = clock
+        self.lastCheckTimestamp = clock.now()
     }
 
     func startMonitoring() {
@@ -38,8 +40,8 @@ internal class ANRDetector {
         timer = nil
     }
 
-    @objc private func checkForANR() {
-        let currentTime = CFAbsoluteTimeGetCurrent()
+    @objc internal func checkForANR() {
+        let currentTime = clock.now()
         isMainThreadResponsive = false
 
         DispatchQueue.main.async { [weak self] in
@@ -48,16 +50,15 @@ internal class ANRDetector {
             self.lastCheckTimestamp = currentTime
         }
 
-        if !isMainThreadResponsive && (currentTime - lastCheckTimestamp) > maxBlockTime {
+        if !isMainThreadResponsive && currentTime.timeIntervalSince(lastCheckTimestamp) > maxBlockTime {
             handleANR()
         }
     }
 
     public func handleANR() {
         handleANRClosure?()
-        
-        let currentTime = CFAbsoluteTimeGetCurrent()
-        let duration = currentTime - lastCheckTimestamp
+
+        let duration = clock.now().timeIntervalSince(lastCheckTimestamp)
         Log.d("[Metric] ANR detected: Main thread unresponsive for \(String(format: "%.2f", duration)) seconds")
     }
 }

--- a/CoralogixInternal/Sources/Clock.swift
+++ b/CoralogixInternal/Sources/Clock.swift
@@ -1,0 +1,22 @@
+//
+//  Clock.swift
+//
+//
+//  Created by Coralogix DEV TEAM on 14/05/2026.
+//
+
+import Foundation
+
+/// Abstraction over wall-clock time so time-dependent code can be exercised
+/// deterministically in tests without `Thread.sleep`.
+public protocol Clock {
+    func now() -> Date
+}
+
+public struct SystemClock: Clock {
+    public init() {}
+
+    public func now() -> Date {
+        Date()
+    }
+}

--- a/Tests/CoralogixRumTests/MobileVitalsTests/ANRDetectorTests.swift
+++ b/Tests/CoralogixRumTests/MobileVitalsTests/ANRDetectorTests.swift
@@ -125,15 +125,33 @@ final class ANRDetectorTests: XCTestCase {
     func testHandleANRCallsClosureAndLogs() {
         // This test focuses on the `handleANR` method itself,
         // not necessarily triggered by the timer mechanism, but by directly calling it.
-        
+
         expectation = XCTestExpectation(description: "ANR handler closure should be called")
-        
+
         anrDetector.handleANRClosure = {
             self.expectation.fulfill()
         }
-       
+
         anrDetector.handleANR()
-        
+
         wait(for: [expectation], timeout: 1.0) // Short timeout as it's a direct call
+    }
+
+    func testCheckForANRFiresWhenMockClockAdvancesBeyondMaxBlockTime() {
+        // Deterministic check of the time-comparison branch using MockClock —
+        // no Thread.sleep, no real Timer. The async block on main is queued but
+        // cannot run while this synchronous test body holds the main thread, so
+        // the first checkForANR sees `isMainThreadResponsive = false` and the
+        // advanced delta > maxBlockTime, which is exactly the ANR condition.
+        let clock = MockClock()
+        let detector = ANRDetector(checkInterval: 1.0, maxBlockTime: 0.5, clock: clock)
+
+        var anrCalled = false
+        detector.handleANRClosure = { anrCalled = true }
+
+        clock.advance(by: 1.0)
+        detector.checkForANR()
+
+        XCTAssertTrue(anrCalled, "ANR should fire when clock advances beyond maxBlockTime")
     }
 }

--- a/Tests/CoralogixRumTests/MobileVitalsTests/MockClock.swift
+++ b/Tests/CoralogixRumTests/MobileVitalsTests/MockClock.swift
@@ -1,0 +1,25 @@
+//
+//  MockClock.swift
+//
+//
+//  Created by Coralogix DEV TEAM on 14/05/2026.
+//
+
+import Foundation
+import CoralogixInternal
+
+final class MockClock: CoralogixInternal.Clock {
+    private var current: Date
+
+    init(start: Date = Date(timeIntervalSince1970: 0)) {
+        self.current = start
+    }
+
+    func now() -> Date {
+        current
+    }
+
+    func advance(by interval: TimeInterval) {
+        current = current.addingTimeInterval(interval)
+    }
+}


### PR DESCRIPTION
# User description
## Summary
- Introduces `protocol Clock { func now() -> Date }` in `CoralogixInternal` plus a production `SystemClock`, so time-dependent code can be exercised deterministically without `Thread.sleep`.
- Wires `Clock` into `ANRDetector` as the initial consumer — default `SystemClock()` keeps existing behavior, `MetricsManager` is untouched.
- Adds test-only `MockClock` with `advance(by:)` and one new deterministic ANR test alongside the existing sleep-based tests (those still cover the real timer + main-thread path).

Note on naming: `Clock` is qualified as `CoralogixInternal.Clock` at use sites to disambiguate from Swift stdlib's `Clock` protocol (iOS 16+). The AC-mandated name is preserved at the protocol definition.

Jira: [CX-40571](https://coralogix.atlassian.net/browse/CX-40571)

## Test plan
- [x] `xcodebuild test` on iPhone 16 / iOS 18.5 — all 3 bundles green (`CoralogixRumTests` 580 tests, `CoralogixInternalTests`, `SessionReplayTests`); zero regressions
- [x] New deterministic test (`testCheckForANRFiresWhenMockClockAdvancesBeyondMaxBlockTime`) passes in 0.001s with no sleep
- [x] All 7 pre-existing ANR tests still pass with the injected clock defaulting to `SystemClock()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CX-40571]: https://coralogix.atlassian.net/browse/CX-40571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Introduce <code>CoralogixInternal.Clock</code> along with <code>SystemClock</code> so time-dependent systems can rely on deterministic time sources without sleeping. Wire <code>ANRDetector</code> to accept a clock and keep metrics behavior unchanged while enabling deterministic ANR tests.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/204?tool=ast&topic=ANR+detection>ANR detection</a>
        </td><td>Wire <code>ANRDetector</code> to use the injected clock for comparisons, update its delta handling, and add a deterministic ANR test that advances <code>MockClock</code>.<details><summary>Modified files (2)</summary><ul><li>Coralogix/Sources/Utils/MobileVitals/ANRDetector.swift</li>
<li>Tests/CoralogixRumTests/MobileVitalsTests/ANRDetectorTests.swift</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>feat(CX-40571): Clock ...</td><td>May 14, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/204?tool=ast&topic=Clock+abstraction>Clock abstraction</a>
        </td><td>Introduce <code>CoralogixInternal.Clock</code> along with <code>SystemClock</code> and test-only <code>MockClock</code> so production and tests can derive consistent time values without <code>Thread.sleep</code>.<details><summary>Modified files (2)</summary><ul><li>CoralogixInternal/Sources/Clock.swift</li>
<li>Tests/CoralogixRumTests/MobileVitalsTests/MockClock.swift</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>feat(CX-40571): Clock ...</td><td>May 14, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/coralogix/cx-ios-sdk/204?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * ANR detection system refactored to improve testability through abstracted time handling

* **Tests**
  * Expanded test coverage for ANR detection with deterministic clock-based testing scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coralogix/cx-ios-sdk/pull/204)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->