### PR TITLE
feat(CX-40572): typed TelemetryEvent model for RUM events

### DIFF
--- a/Coralogix/Sources/Model/TelemetryEvents/ANRErrorEvent.swift
+++ b/Coralogix/Sources/Model/TelemetryEvents/ANRErrorEvent.swift
@@ -1,0 +1,42 @@
+//
+//  ANRErrorEvent.swift
+//
+//
+//  Created by Coralogix DEV TEAM on 18/05/2026.
+//
+
+import Foundation
+import CoralogixInternal
+
+// ANR (Application Not Responding) is delivered on the wire as an `error`
+// event with a fixed `errorType` discriminator ("ANR"). Keeping it as its
+// own struct — separate from ErrorEvent — gives middleware a clear hook
+// without overloading ErrorEvent's larger field set.
+struct ANRErrorEvent: TelemetryEvent {
+    let id: UUID
+    let timestamp: Date
+    let type: EventType
+    let errorMessage: String
+    let errorType: String
+
+    init(
+        id: UUID = UUID(),
+        timestamp: Date = Date(),
+        errorMessage: String = "Application Not Responding",
+        errorType: String = "ANR"
+    ) {
+        self.id = id
+        self.timestamp = timestamp
+        self.type = .error
+        self.errorMessage = errorMessage
+        self.errorType = errorType
+    }
+
+    func toOTelAttributes() -> [String: AttributeValue] {
+        return [
+            Keys.eventType.rawValue:    .string(type.rawValue),
+            Keys.errorMessage.rawValue: .string(errorMessage),
+            Keys.errorType.rawValue:    .string(errorType),
+        ]
+    }
+}

--- a/Coralogix/Sources/Model/TelemetryEvents/ANRErrorEvent.swift
+++ b/Coralogix/Sources/Model/TelemetryEvents/ANRErrorEvent.swift
@@ -22,8 +22,8 @@ struct ANRErrorEvent: TelemetryEvent {
     init(
         id: UUID = UUID(),
         timestamp: Date = Date(),
-        errorMessage: String = Keys.anrErrorMessage.rawValue,
-        errorType: String = Keys.anrErrorType.rawValue
+        errorMessage: String = WireValues.anrErrorMessage.rawValue,
+        errorType: String = WireValues.anrErrorType.rawValue
     ) {
         self.id = id
         self.timestamp = timestamp

--- a/Coralogix/Sources/Model/TelemetryEvents/ANRErrorEvent.swift
+++ b/Coralogix/Sources/Model/TelemetryEvents/ANRErrorEvent.swift
@@ -22,8 +22,8 @@ struct ANRErrorEvent: TelemetryEvent {
     init(
         id: UUID = UUID(),
         timestamp: Date = Date(),
-        errorMessage: String = "Application Not Responding",
-        errorType: String = "ANR"
+        errorMessage: String = Keys.anrErrorMessage.rawValue,
+        errorType: String = Keys.anrErrorType.rawValue
     ) {
         self.id = id
         self.timestamp = timestamp

--- a/Coralogix/Sources/Model/TelemetryEvents/ANRErrorEvent.swift
+++ b/Coralogix/Sources/Model/TelemetryEvents/ANRErrorEvent.swift
@@ -15,7 +15,7 @@ import CoralogixInternal
 struct ANRErrorEvent: TelemetryEvent {
     let id: UUID
     let timestamp: Date
-    let type: EventType
+    var type: EventType { .error }
     let errorMessage: String
     let errorType: String
 
@@ -27,7 +27,6 @@ struct ANRErrorEvent: TelemetryEvent {
     ) {
         self.id = id
         self.timestamp = timestamp
-        self.type = .error
         self.errorMessage = errorMessage
         self.errorType = errorType
     }

--- a/Coralogix/Sources/Model/TelemetryEvents/ErrorEvent.swift
+++ b/Coralogix/Sources/Model/TelemetryEvents/ErrorEvent.swift
@@ -62,6 +62,47 @@ struct ErrorEvent: TelemetryEvent {
         self.stackTraceJson = stackTraceJson
     }
 
+    /// Ergonomic factory that accepts unencoded `userInfo` / `stackTrace`
+    /// dictionaries and performs the JSON encoding internally. Prefer this
+    /// over the raw `init` — it moves the "must be valid JSON" contract from
+    /// the call site into the model, eliminating a class of silent failures
+    /// (`ErrorContext` drops malformed JSON without surfacing the error).
+    static func make(
+        id: UUID = UUID(),
+        timestamp: Date = Date(),
+        domain: String,
+        code: Int? = nil,
+        errorMessage: String,
+        isCrash: Bool = false,
+        errorType: String? = nil,
+        arch: String? = nil,
+        buildId: String? = nil,
+        stackTraceType: String? = nil,
+        userInfo: [String: Any]? = nil,
+        stackTrace: [[String: Any]]? = nil
+    ) -> ErrorEvent {
+        let userInfoJson = userInfo.map { Helper.convertDictionaryToJsonString(dict: $0) }
+        let stackTraceJson = stackTrace.flatMap { frames -> String? in
+            guard JSONSerialization.isValidJSONObject(frames),
+                  let data = try? JSONSerialization.data(withJSONObject: frames, options: []) else { return nil }
+            return String(data: data, encoding: .utf8)
+        }
+        return ErrorEvent(
+            id: id,
+            timestamp: timestamp,
+            domain: domain,
+            code: code,
+            errorMessage: errorMessage,
+            isCrash: isCrash,
+            errorType: errorType,
+            arch: arch,
+            buildId: buildId,
+            stackTraceType: stackTraceType,
+            userInfoJson: userInfoJson,
+            stackTraceJson: stackTraceJson
+        )
+    }
+
     func toOTelAttributes() -> [String: AttributeValue] {
         var attrs: [String: AttributeValue] = [
             Keys.eventType.rawValue:    .string(type.rawValue),

--- a/Coralogix/Sources/Model/TelemetryEvents/ErrorEvent.swift
+++ b/Coralogix/Sources/Model/TelemetryEvents/ErrorEvent.swift
@@ -11,7 +11,7 @@ import CoralogixInternal
 struct ErrorEvent: TelemetryEvent {
     let id: UUID
     let timestamp: Date
-    let type: EventType
+    var type: EventType { .error }
     let domain: String
     let code: Int?
     let errorMessage: String
@@ -50,7 +50,6 @@ struct ErrorEvent: TelemetryEvent {
     ) {
         self.id = id
         self.timestamp = timestamp
-        self.type = .error
         self.domain = domain
         self.code = code
         self.errorMessage = errorMessage

--- a/Coralogix/Sources/Model/TelemetryEvents/ErrorEvent.swift
+++ b/Coralogix/Sources/Model/TelemetryEvents/ErrorEvent.swift
@@ -1,0 +1,82 @@
+//
+//  ErrorEvent.swift
+//
+//
+//  Created by Coralogix DEV TEAM on 18/05/2026.
+//
+
+import Foundation
+import CoralogixInternal
+
+struct ErrorEvent: TelemetryEvent {
+    let id: UUID
+    let timestamp: Date
+    let type: EventType
+    let domain: String
+    let code: Int?
+    let errorMessage: String
+    let isCrash: Bool
+    let errorType: String?
+    let arch: String?
+    let buildId: String?
+    let stackTraceType: String?
+
+    // Encoded as JSON strings on the OTel span (matches what ErrorContext
+    // expects when reading them back out via convertJsonStringToDict /
+    // convertJsonStringToArray).
+    let userInfoJson: String?
+    let stackTraceJson: String?
+
+    // NOTE: crash-path fields (exceptionType, crashTimestamp, processName,
+    // applicationIdentifier, triggeredByThread, baseAddress, threads) are NOT
+    // surfaced here. The crash wire shape differs significantly from a
+    // hand-written error and the AC may surface that as a separate struct
+    // alongside ANRErrorEvent. Keep this struct aligned with the writeError
+    // emission path until the crash variant is specified.
+
+    init(
+        id: UUID = UUID(),
+        timestamp: Date = Date(),
+        domain: String,
+        code: Int? = nil,
+        errorMessage: String,
+        isCrash: Bool = false,
+        errorType: String? = nil,
+        arch: String? = nil,
+        buildId: String? = nil,
+        stackTraceType: String? = nil,
+        userInfoJson: String? = nil,
+        stackTraceJson: String? = nil
+    ) {
+        self.id = id
+        self.timestamp = timestamp
+        self.type = .error
+        self.domain = domain
+        self.code = code
+        self.errorMessage = errorMessage
+        self.isCrash = isCrash
+        self.errorType = errorType
+        self.arch = arch
+        self.buildId = buildId
+        self.stackTraceType = stackTraceType
+        self.userInfoJson = userInfoJson
+        self.stackTraceJson = stackTraceJson
+    }
+
+    func toOTelAttributes() -> [String: AttributeValue] {
+        var attrs: [String: AttributeValue] = [
+            Keys.eventType.rawValue:    .string(type.rawValue),
+            Keys.domain.rawValue:       .string(domain),
+            Keys.errorMessage.rawValue: .string(errorMessage),
+            Keys.isCrash.rawValue:      .bool(isCrash),
+        ]
+        if let code           { attrs[Keys.code.rawValue]           = .int(code) }
+        if let errorType      { attrs[Keys.errorType.rawValue]      = .string(errorType) }
+        if let arch           { attrs[Keys.arch.rawValue]           = .string(arch) }
+        if let buildId        { attrs[Keys.buildId.rawValue]        = .string(buildId) }
+        if let stackTraceType { attrs[Keys.stackTraceType.rawValue] = .string(stackTraceType) }
+        if let userInfoJson   { attrs[Keys.userInfo.rawValue]       = .string(userInfoJson) }
+        if let stackTraceJson { attrs[Keys.stackTrace.rawValue]     = .string(stackTraceJson) }
+        return attrs
+    }
+}

--- a/Coralogix/Sources/Model/TelemetryEvents/ErrorEvent.swift
+++ b/Coralogix/Sources/Model/TelemetryEvents/ErrorEvent.swift
@@ -65,8 +65,14 @@ struct ErrorEvent: TelemetryEvent {
     /// Ergonomic factory that accepts unencoded `userInfo` / `stackTrace`
     /// dictionaries and performs the JSON encoding internally. Prefer this
     /// over the raw `init` — it moves the "must be valid JSON" contract from
-    /// the call site into the model, eliminating a class of silent failures
-    /// (`ErrorContext` drops malformed JSON without surfacing the error).
+    /// the call site into the model.
+    ///
+    /// Failure handling: when encoding fails (e.g. a `Date` or non-finite
+    /// `Double` inside `userInfo`), `Helper.convert{Dictionary,Array}ToJsonString`
+    /// logs via `Log.e(...)` and returns `""`. We normalize `""` back to
+    /// `nil` here so the resulting event omits the attribute on the wire
+    /// instead of emitting an empty string that the downstream parser would
+    /// silently drop again.
     static func make(
         id: UUID = UUID(),
         timestamp: Date = Date(),
@@ -81,12 +87,12 @@ struct ErrorEvent: TelemetryEvent {
         userInfo: [String: Any]? = nil,
         stackTrace: [[String: Any]]? = nil
     ) -> ErrorEvent {
-        let userInfoJson = userInfo.map { Helper.convertDictionaryToJsonString(dict: $0) }
-        let stackTraceJson = stackTrace.flatMap { frames -> String? in
-            guard JSONSerialization.isValidJSONObject(frames),
-                  let data = try? JSONSerialization.data(withJSONObject: frames, options: []) else { return nil }
-            return String(data: data, encoding: .utf8)
-        }
+        let userInfoJson = userInfo
+            .map { Helper.convertDictionaryToJsonString(dict: $0) }
+            .flatMap { $0.isEmpty ? nil : $0 }
+        let stackTraceJson = stackTrace
+            .map { Helper.convertArrayToJsonString(array: $0) }
+            .flatMap { $0.isEmpty ? nil : $0 }
         return ErrorEvent(
             id: id,
             timestamp: timestamp,

--- a/Coralogix/Sources/Model/TelemetryEvents/JSONValue.swift
+++ b/Coralogix/Sources/Model/TelemetryEvents/JSONValue.swift
@@ -1,0 +1,66 @@
+//
+//  JSONValue.swift
+//
+//
+//  Created by Coralogix DEV TEAM on 18/05/2026.
+//
+
+import Foundation
+
+/// A `Codable`, heterogeneous JSON value. Used by `TelemetryEvent` structs that
+/// carry free-form user-supplied sub-dicts (e.g. `UserActionEvent.attributes`).
+/// `[String: Any]` is not `Codable`; this enum is the typed bridge.
+enum JSONValue: Codable, Equatable {
+    case null
+    case bool(Bool)
+    case int(Int)
+    case double(Double)
+    case string(String)
+    case array([JSONValue])
+    case object([String: JSONValue])
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.singleValueContainer()
+        if c.decodeNil() { self = .null; return }
+        if let v = try? c.decode(Bool.self)               { self = .bool(v); return }
+        if let v = try? c.decode(Int.self)                { self = .int(v); return }
+        if let v = try? c.decode(Double.self)             { self = .double(v); return }
+        if let v = try? c.decode(String.self)             { self = .string(v); return }
+        if let v = try? c.decode([JSONValue].self)        { self = .array(v); return }
+        if let v = try? c.decode([String: JSONValue].self) { self = .object(v); return }
+        throw DecodingError.typeMismatch(
+            JSONValue.self,
+            DecodingError.Context(
+                codingPath: decoder.codingPath,
+                debugDescription: "Unsupported JSON value"
+            )
+        )
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.singleValueContainer()
+        switch self {
+        case .null:          try c.encodeNil()
+        case .bool(let v):   try c.encode(v)
+        case .int(let v):    try c.encode(v)
+        case .double(let v): try c.encode(v)
+        case .string(let v): try c.encode(v)
+        case .array(let v):  try c.encode(v)
+        case .object(let v): try c.encode(v)
+        }
+    }
+
+    /// Converts to a `JSONSerialization`-compatible value
+    /// (`NSNull`, `Bool`, `Int`, `Double`, `String`, `[Any]`, `[String: Any]`).
+    func toAny() -> Any {
+        switch self {
+        case .null:          return NSNull()
+        case .bool(let v):   return v
+        case .int(let v):    return v
+        case .double(let v): return v
+        case .string(let v): return v
+        case .array(let v):  return v.map { $0.toAny() }
+        case .object(let v): return v.mapValues { $0.toAny() }
+        }
+    }
+}

--- a/Coralogix/Sources/Model/TelemetryEvents/JSONValue.swift
+++ b/Coralogix/Sources/Model/TelemetryEvents/JSONValue.swift
@@ -10,6 +10,17 @@ import Foundation
 /// A `Codable`, heterogeneous JSON value. Used by `TelemetryEvent` structs that
 /// carry free-form user-supplied sub-dicts (e.g. `UserActionEvent.attributes`).
 /// `[String: Any]` is not `Codable`; this enum is the typed bridge.
+///
+/// Round-trip caveat: JSON itself does not distinguish `2` from `2.0`, so a
+/// whole-number `Double` is not round-trip safe through Codable:
+///   `.double(2.0)`  -> encoded as `2`   -> decoded as `.int(2)`
+///   `.double(2.5)`  -> encoded as `2.5` -> decoded as `.double(2.5)`
+///   `.int(2)`       -> encoded as `2`   -> decoded as `.int(2)`
+/// `Int` is tried first on decode by design — most user-supplied numeric
+/// values are integers (counts, IDs) and demoting them to `Double` would
+/// change the `toAny()` runtime type for the common case. Callers that need
+/// to preserve "this was a Double" semantics for whole values must do so
+/// outside `JSONValue`.
 enum JSONValue: Codable, Equatable {
     case null
     case bool(Bool)

--- a/Coralogix/Sources/Model/TelemetryEvents/MobileVitalsEvent.swift
+++ b/Coralogix/Sources/Model/TelemetryEvents/MobileVitalsEvent.swift
@@ -1,0 +1,38 @@
+//
+//  MobileVitalsEvent.swift
+//
+//
+//  Created by Coralogix DEV TEAM on 18/05/2026.
+//
+
+import Foundation
+import CoralogixInternal
+
+struct MobileVitalsEvent: TelemetryEvent {
+    let id: UUID
+    let timestamp: Date
+    let type: EventType
+    // Payload travels as a JSON-encoded string under `Keys.mobileVitalsType`
+    // (camelCase on the wire — see Keys.swift) and is parsed back into a
+    // dict on the exporter side. Holding the encoded string keeps the
+    // struct honest about what hits the wire.
+    let mobileVitalsType: String
+
+    init(
+        id: UUID = UUID(),
+        timestamp: Date = Date(),
+        mobileVitalsType: String
+    ) {
+        self.id = id
+        self.timestamp = timestamp
+        self.type = .mobileVitals
+        self.mobileVitalsType = mobileVitalsType
+    }
+
+    func toOTelAttributes() -> [String: AttributeValue] {
+        return [
+            Keys.eventType.rawValue: .string(type.rawValue),
+            Keys.mobileVitalsType.rawValue: .string(mobileVitalsType),
+        ]
+    }
+}

--- a/Coralogix/Sources/Model/TelemetryEvents/MobileVitalsEvent.swift
+++ b/Coralogix/Sources/Model/TelemetryEvents/MobileVitalsEvent.swift
@@ -11,7 +11,7 @@ import CoralogixInternal
 struct MobileVitalsEvent: TelemetryEvent {
     let id: UUID
     let timestamp: Date
-    let type: EventType
+    var type: EventType { .mobileVitals }
     // Payload travels as a JSON-encoded string under `Keys.mobileVitalsType`
     // (camelCase on the wire — see Keys.swift) and is parsed back into a
     // dict on the exporter side. Holding the encoded string keeps the
@@ -25,7 +25,6 @@ struct MobileVitalsEvent: TelemetryEvent {
     ) {
         self.id = id
         self.timestamp = timestamp
-        self.type = .mobileVitals
         self.mobileVitalsType = mobileVitalsType
     }
 

--- a/Coralogix/Sources/Model/TelemetryEvents/NetworkRequestEvent.swift
+++ b/Coralogix/Sources/Model/TelemetryEvents/NetworkRequestEvent.swift
@@ -18,6 +18,10 @@ import CoralogixInternal
 /// set span timing from `duration` and span status from `statusText`.
 /// Forgetting either produces wire output that silently omits the field
 /// without failing tests.
+///
+/// `duration` and `statusText` are intentionally non-defaulted on `init` so
+/// every call site has to acknowledge them — preventing the "accept the
+/// default 0/empty and forget the field exists" failure mode.
 struct NetworkRequestEvent: TelemetryEvent {
     let id: UUID
     let timestamp: Date
@@ -54,8 +58,8 @@ struct NetworkRequestEvent: TelemetryEvent {
         fragments: String = "",
         host: String,
         schema: URLScheme,
-        duration: UInt64 = 0,
-        statusText: String = "",
+        duration: UInt64,
+        statusText: String,
         responseContentLength: Int = 0,
         requestHeaders: [String: String]? = nil,
         responseHeaders: [String: String]? = nil,

--- a/Coralogix/Sources/Model/TelemetryEvents/NetworkRequestEvent.swift
+++ b/Coralogix/Sources/Model/TelemetryEvents/NetworkRequestEvent.swift
@@ -11,7 +11,7 @@ import CoralogixInternal
 struct NetworkRequestEvent: TelemetryEvent {
     let id: UUID
     let timestamp: Date
-    let type: EventType
+    var type: EventType { .networkRequest }
     let method: String
     let statusCode: Int
     let url: String
@@ -53,7 +53,6 @@ struct NetworkRequestEvent: TelemetryEvent {
     ) {
         self.id = id
         self.timestamp = timestamp
-        self.type = .networkRequest
         self.method = method
         self.statusCode = statusCode
         self.url = url

--- a/Coralogix/Sources/Model/TelemetryEvents/NetworkRequestEvent.swift
+++ b/Coralogix/Sources/Model/TelemetryEvents/NetworkRequestEvent.swift
@@ -94,13 +94,21 @@ struct NetworkRequestEvent: TelemetryEvent {
             SemanticAttributes.httpStatusCode.rawValue:       .int(statusCode),
             SemanticAttributes.httpResponseBodySize.rawValue: .int(responseContentLength),
         ]
+        // `Helper.convertDictionaryToJsonString` logs via `Log.e(...)` and
+        // returns "" on encoding failure. Omit the attribute on failure
+        // instead of emitting an empty string that the downstream parser
+        // would silently drop again (mirrors `ErrorEvent.make`).
         if let requestHeaders {
             let json = Helper.convertDictionaryToJsonString(dict: requestHeaders)
-            attrs[Keys.requestHeaders.rawValue] = .string(json)
+            if !json.isEmpty {
+                attrs[Keys.requestHeaders.rawValue] = .string(json)
+            }
         }
         if let responseHeaders {
             let json = Helper.convertDictionaryToJsonString(dict: responseHeaders)
-            attrs[Keys.responseHeaders.rawValue] = .string(json)
+            if !json.isEmpty {
+                attrs[Keys.responseHeaders.rawValue] = .string(json)
+            }
         }
         if let requestPayload  { attrs[Keys.requestPayload.rawValue]  = .string(requestPayload) }
         if let responsePayload { attrs[Keys.responsePayload.rawValue] = .string(responsePayload) }

--- a/Coralogix/Sources/Model/TelemetryEvents/NetworkRequestEvent.swift
+++ b/Coralogix/Sources/Model/TelemetryEvents/NetworkRequestEvent.swift
@@ -22,12 +22,12 @@ struct NetworkRequestEvent: TelemetryEvent {
     let id: UUID
     let timestamp: Date
     var type: EventType { .networkRequest }
-    let method: String
+    let method: HTTPMethod
     let statusCode: Int
     let url: String
     let fragments: String
     let host: String
-    let schema: String
+    let schema: URLScheme
 
     /// Span-derived. NOT emitted by `toOTelAttributes()`. The consumer must
     /// translate this into the span's `startTime` / `endTime` at emission.
@@ -48,12 +48,12 @@ struct NetworkRequestEvent: TelemetryEvent {
     init(
         id: UUID = UUID(),
         timestamp: Date = Date(),
-        method: String,
+        method: HTTPMethod,
         statusCode: Int = 0,
         url: String,
         fragments: String = "",
         host: String,
-        schema: String,
+        schema: URLScheme,
         duration: UInt64 = 0,
         statusText: String = "",
         responseContentLength: Int = 0,
@@ -82,11 +82,11 @@ struct NetworkRequestEvent: TelemetryEvent {
     func toOTelAttributes() -> [String: AttributeValue] {
         var attrs: [String: AttributeValue] = [
             Keys.eventType.rawValue:                          .string(type.rawValue),
-            SemanticAttributes.httpMethod.rawValue:           .string(method),
+            SemanticAttributes.httpMethod.rawValue:           .string(method.rawValue),
             SemanticAttributes.httpUrl.rawValue:              .string(url),
             SemanticAttributes.httpTarget.rawValue:           .string(fragments),
             SemanticAttributes.netPeerName.rawValue:          .string(host),
-            SemanticAttributes.httpScheme.rawValue:           .string(schema),
+            SemanticAttributes.httpScheme.rawValue:           .string(schema.rawValue),
             SemanticAttributes.httpStatusCode.rawValue:       .int(statusCode),
             SemanticAttributes.httpResponseBodySize.rawValue: .int(responseContentLength),
         ]

--- a/Coralogix/Sources/Model/TelemetryEvents/NetworkRequestEvent.swift
+++ b/Coralogix/Sources/Model/TelemetryEvents/NetworkRequestEvent.swift
@@ -8,6 +8,16 @@
 import Foundation
 import CoralogixInternal
 
+/// Logical representation of a network-request RUM event.
+///
+/// IMPORTANT: `toOTelAttributes()` does NOT cover the full wire shape on its
+/// own. `duration` and `statusText` reach the backend via OTel span
+/// **infrastructure** (start/end time, span status) — they have no OTel
+/// attribute slot. Any consumer wiring a `NetworkRequestEvent` into a real
+/// span emission path must, in addition to applying `toOTelAttributes()`,
+/// set span timing from `duration` and span status from `statusText`.
+/// Forgetting either produces wire output that silently omits the field
+/// without failing tests.
 struct NetworkRequestEvent: TelemetryEvent {
     let id: UUID
     let timestamp: Date
@@ -18,13 +28,14 @@ struct NetworkRequestEvent: TelemetryEvent {
     let fragments: String
     let host: String
     let schema: String
-    // duration (ms) and statusText flow to the wire via OTel span infrastructure
-    // (startTime/endTime, span status) — NOT as attributes. They live on the
-    // struct so callers can author/inspect a complete event, but the adapter
-    // does not emit them. Future consumers wiring this into a real emission
-    // path must set the span's timing/status separately.
+
+    /// Span-derived. NOT emitted by `toOTelAttributes()`. The consumer must
+    /// translate this into the span's `startTime` / `endTime` at emission.
     let duration: UInt64
+    /// Span-derived. NOT emitted by `toOTelAttributes()`. The consumer must
+    /// translate this into the span's status at emission.
     let statusText: String
+
     let responseContentLength: Int
 
     // Optional capture-rule fields (CX-33233 / CX-33234). Headers travel as

--- a/Coralogix/Sources/Model/TelemetryEvents/NetworkRequestEvent.swift
+++ b/Coralogix/Sources/Model/TelemetryEvents/NetworkRequestEvent.swift
@@ -1,0 +1,95 @@
+//
+//  NetworkRequestEvent.swift
+//
+//
+//  Created by Coralogix DEV TEAM on 18/05/2026.
+//
+
+import Foundation
+import CoralogixInternal
+
+struct NetworkRequestEvent: TelemetryEvent {
+    let id: UUID
+    let timestamp: Date
+    let type: EventType
+    let method: String
+    let statusCode: Int
+    let url: String
+    let fragments: String
+    let host: String
+    let schema: String
+    // duration (ms) and statusText flow to the wire via OTel span infrastructure
+    // (startTime/endTime, span status) — NOT as attributes. They live on the
+    // struct so callers can author/inspect a complete event, but the adapter
+    // does not emit them. Future consumers wiring this into a real emission
+    // path must set the span's timing/status separately.
+    let duration: UInt64
+    let statusText: String
+    let responseContentLength: Int
+
+    // Optional capture-rule fields (CX-33233 / CX-33234). Headers travel as
+    // JSON-encoded strings on the OTel span; payloads as raw strings.
+    let requestHeaders: [String: String]?
+    let responseHeaders: [String: String]?
+    let requestPayload: String?
+    let responsePayload: String?
+
+    init(
+        id: UUID = UUID(),
+        timestamp: Date = Date(),
+        method: String,
+        statusCode: Int = 0,
+        url: String,
+        fragments: String = "",
+        host: String,
+        schema: String,
+        duration: UInt64 = 0,
+        statusText: String = "",
+        responseContentLength: Int = 0,
+        requestHeaders: [String: String]? = nil,
+        responseHeaders: [String: String]? = nil,
+        requestPayload: String? = nil,
+        responsePayload: String? = nil
+    ) {
+        self.id = id
+        self.timestamp = timestamp
+        self.type = .networkRequest
+        self.method = method
+        self.statusCode = statusCode
+        self.url = url
+        self.fragments = fragments
+        self.host = host
+        self.schema = schema
+        self.duration = duration
+        self.statusText = statusText
+        self.responseContentLength = responseContentLength
+        self.requestHeaders = requestHeaders
+        self.responseHeaders = responseHeaders
+        self.requestPayload = requestPayload
+        self.responsePayload = responsePayload
+    }
+
+    func toOTelAttributes() -> [String: AttributeValue] {
+        var attrs: [String: AttributeValue] = [
+            Keys.eventType.rawValue:                          .string(type.rawValue),
+            SemanticAttributes.httpMethod.rawValue:           .string(method),
+            SemanticAttributes.httpUrl.rawValue:              .string(url),
+            SemanticAttributes.httpTarget.rawValue:           .string(fragments),
+            SemanticAttributes.netPeerName.rawValue:          .string(host),
+            SemanticAttributes.httpScheme.rawValue:           .string(schema),
+            SemanticAttributes.httpStatusCode.rawValue:       .int(statusCode),
+            SemanticAttributes.httpResponseBodySize.rawValue: .int(responseContentLength),
+        ]
+        if let requestHeaders {
+            let json = Helper.convertDictionaryToJsonString(dict: requestHeaders)
+            attrs[Keys.requestHeaders.rawValue] = .string(json)
+        }
+        if let responseHeaders {
+            let json = Helper.convertDictionaryToJsonString(dict: responseHeaders)
+            attrs[Keys.responseHeaders.rawValue] = .string(json)
+        }
+        if let requestPayload  { attrs[Keys.requestPayload.rawValue]  = .string(requestPayload) }
+        if let responsePayload { attrs[Keys.responsePayload.rawValue] = .string(responsePayload) }
+        return attrs
+    }
+}

--- a/Coralogix/Sources/Model/TelemetryEvents/TelemetryEvent.swift
+++ b/Coralogix/Sources/Model/TelemetryEvents/TelemetryEvent.swift
@@ -1,0 +1,22 @@
+//
+//  TelemetryEvent.swift
+//
+//
+//  Created by Coralogix DEV TEAM on 17/05/2026.
+//
+
+import Foundation
+import CoralogixInternal
+
+typealias EventType = CoralogixEventType
+
+protocol TelemetryEvent: Codable {
+    var id: UUID { get }
+    var timestamp: Date { get }
+    var type: EventType { get }
+
+    // Every attribute key MUST come from `Keys.<case>.rawValue` — never a
+    // string literal. The wire format (snake_case / camelCase mixing) lives
+    // in `Keys.swift` and this adapter must stay in lockstep with it.
+    func toOTelAttributes() -> [String: AttributeValue]
+}

--- a/Coralogix/Sources/Model/TelemetryEvents/UserActionEvent.swift
+++ b/Coralogix/Sources/Model/TelemetryEvents/UserActionEvent.swift
@@ -1,0 +1,65 @@
+//
+//  UserActionEvent.swift
+//
+//
+//  Created by Coralogix DEV TEAM on 18/05/2026.
+//
+
+import Foundation
+import CoralogixInternal
+
+struct UserActionEvent: TelemetryEvent {
+    let id: UUID
+    let timestamp: Date
+    let type: EventType
+    let eventName: InteractionEventName
+    let targetElement: String
+    let elementClasses: String?
+    let elementId: String?
+    let targetElementInnerText: String?
+    let scrollDirection: ScrollDirection?
+
+    // NOTE: the wire format carries an optional free-form `attributes` sub-dict
+    // (heterogeneous user-supplied values). Modelling that requires a shared
+    // JSONValue helper that NetworkRequestEvent will also need; deferred to
+    // the slice that introduces it. Until then, this struct covers the
+    // structured fields surfaced by InteractionContext.
+
+    init(
+        id: UUID = UUID(),
+        timestamp: Date = Date(),
+        eventName: InteractionEventName,
+        targetElement: String,
+        elementClasses: String? = nil,
+        elementId: String? = nil,
+        targetElementInnerText: String? = nil,
+        scrollDirection: ScrollDirection? = nil
+    ) {
+        self.id = id
+        self.timestamp = timestamp
+        self.type = .userInteraction
+        self.eventName = eventName
+        self.targetElement = targetElement
+        self.elementClasses = elementClasses
+        self.elementId = elementId
+        self.targetElementInnerText = targetElementInnerText
+        self.scrollDirection = scrollDirection
+    }
+
+    func toOTelAttributes() -> [String: AttributeValue] {
+        var tapObject: [String: Any] = [
+            Keys.eventName.rawValue: eventName.rawValue,
+            Keys.targetElement.rawValue: targetElement,
+        ]
+        if let v = elementClasses         { tapObject[Keys.elementClasses.rawValue] = v }
+        if let v = elementId              { tapObject[Keys.elementId.rawValue] = v }
+        if let v = targetElementInnerText { tapObject[Keys.targetElementInnerText.rawValue] = v }
+        if let v = scrollDirection        { tapObject[Keys.scrollDirection.rawValue] = v.rawValue }
+
+        let json = Helper.convertDictionaryToJsonString(dict: tapObject)
+        return [
+            Keys.eventType.rawValue: .string(type.rawValue),
+            Keys.tapObject.rawValue: .string(json),
+        ]
+    }
+}

--- a/Coralogix/Sources/Model/TelemetryEvents/UserActionEvent.swift
+++ b/Coralogix/Sources/Model/TelemetryEvents/UserActionEvent.swift
@@ -18,12 +18,16 @@ struct UserActionEvent: TelemetryEvent {
     let elementId: String?
     let targetElementInnerText: String?
     let scrollDirection: ScrollDirection?
+    /// Free-form user-supplied sub-dict forwarded from hybrid bridges
+    /// (Flutter/RN). Heterogeneous values are modelled via `JSONValue`.
+    let attributes: [String: JSONValue]?
 
-    // NOTE: the wire format carries an optional free-form `attributes` sub-dict
-    // (heterogeneous user-supplied values). Modelling that requires a shared
-    // JSONValue helper that NetworkRequestEvent will also need; deferred to
-    // the slice that introduces it. Until then, this struct covers the
-    // structured fields surfaced by InteractionContext.
+    // NOTE: `positionX` / `positionY` (touch coordinates) are intentionally
+    // not surfaced. `UserActionsInstrumentation.validateHybridInteraction`
+    // writes them into the tap_object dict, but `InteractionContext` never
+    // reads them back — they're a pre-existing gap in the iOS extraction
+    // path and surfacing them here without fixing the extractor would imply
+    // a wire contract that isn't actually delivered.
 
     init(
         id: UUID = UUID(),
@@ -33,7 +37,8 @@ struct UserActionEvent: TelemetryEvent {
         elementClasses: String? = nil,
         elementId: String? = nil,
         targetElementInnerText: String? = nil,
-        scrollDirection: ScrollDirection? = nil
+        scrollDirection: ScrollDirection? = nil,
+        attributes: [String: JSONValue]? = nil
     ) {
         self.id = id
         self.timestamp = timestamp
@@ -43,6 +48,7 @@ struct UserActionEvent: TelemetryEvent {
         self.elementId = elementId
         self.targetElementInnerText = targetElementInnerText
         self.scrollDirection = scrollDirection
+        self.attributes = attributes
     }
 
     func toOTelAttributes() -> [String: AttributeValue] {
@@ -54,6 +60,7 @@ struct UserActionEvent: TelemetryEvent {
         if let v = elementId              { tapObject[Keys.elementId.rawValue] = v }
         if let v = targetElementInnerText { tapObject[Keys.targetElementInnerText.rawValue] = v }
         if let v = scrollDirection        { tapObject[Keys.scrollDirection.rawValue] = v.rawValue }
+        if let v = attributes             { tapObject[Keys.attributes.rawValue] = v.mapValues { $0.toAny() } }
 
         let json = Helper.convertDictionaryToJsonString(dict: tapObject)
         return [

--- a/Coralogix/Sources/Model/TelemetryEvents/UserActionEvent.swift
+++ b/Coralogix/Sources/Model/TelemetryEvents/UserActionEvent.swift
@@ -62,10 +62,17 @@ struct UserActionEvent: TelemetryEvent {
         if let v = scrollDirection        { tapObject[Keys.scrollDirection.rawValue] = v.rawValue }
         if let v = attributes             { tapObject[Keys.attributes.rawValue] = v.mapValues { $0.toAny() } }
 
-        let json = Helper.convertDictionaryToJsonString(dict: tapObject)
-        return [
+        var attrs: [String: AttributeValue] = [
             Keys.eventType.rawValue: .string(type.rawValue),
-            Keys.tapObject.rawValue: .string(json),
         ]
+        // `Helper.convertDictionaryToJsonString` logs via `Log.e(...)` and
+        // returns "" on encoding failure. Omit the attribute on failure
+        // instead of emitting an empty string that the downstream parser
+        // would silently drop again (mirrors `ErrorEvent.make`).
+        let json = Helper.convertDictionaryToJsonString(dict: tapObject)
+        if !json.isEmpty {
+            attrs[Keys.tapObject.rawValue] = .string(json)
+        }
+        return attrs
     }
 }

--- a/Coralogix/Sources/Model/TelemetryEvents/UserActionEvent.swift
+++ b/Coralogix/Sources/Model/TelemetryEvents/UserActionEvent.swift
@@ -11,7 +11,7 @@ import CoralogixInternal
 struct UserActionEvent: TelemetryEvent {
     let id: UUID
     let timestamp: Date
-    let type: EventType
+    var type: EventType { .userInteraction }
     let eventName: InteractionEventName
     let targetElement: String
     let elementClasses: String?
@@ -37,7 +37,6 @@ struct UserActionEvent: TelemetryEvent {
     ) {
         self.id = id
         self.timestamp = timestamp
-        self.type = .userInteraction
         self.eventName = eventName
         self.targetElement = targetElement
         self.elementClasses = elementClasses

--- a/Coralogix/Sources/Model/TelemetryEvents/ViewLifecycleEvent.swift
+++ b/Coralogix/Sources/Model/TelemetryEvents/ViewLifecycleEvent.swift
@@ -1,0 +1,34 @@
+//
+//  ViewLifecycleEvent.swift
+//
+//
+//  Created by Coralogix DEV TEAM on 17/05/2026.
+//
+
+import Foundation
+import CoralogixInternal
+
+struct ViewLifecycleEvent: TelemetryEvent {
+    let id: UUID
+    let timestamp: Date
+    let type: EventType
+    let lifeCycleType: String
+
+    init(
+        id: UUID = UUID(),
+        timestamp: Date = Date(),
+        lifeCycleType: String
+    ) {
+        self.id = id
+        self.timestamp = timestamp
+        self.type = .lifeCycle
+        self.lifeCycleType = lifeCycleType
+    }
+
+    func toOTelAttributes() -> [String: AttributeValue] {
+        return [
+            Keys.eventType.rawValue: .string(type.rawValue),
+            Keys.type.rawValue: .string(lifeCycleType),
+        ]
+    }
+}

--- a/Coralogix/Sources/Model/TelemetryEvents/ViewLifecycleEvent.swift
+++ b/Coralogix/Sources/Model/TelemetryEvents/ViewLifecycleEvent.swift
@@ -11,7 +11,7 @@ import CoralogixInternal
 struct ViewLifecycleEvent: TelemetryEvent {
     let id: UUID
     let timestamp: Date
-    let type: EventType
+    var type: EventType { .lifeCycle }
     let lifeCycleType: String
 
     init(
@@ -21,7 +21,6 @@ struct ViewLifecycleEvent: TelemetryEvent {
     ) {
         self.id = id
         self.timestamp = timestamp
-        self.type = .lifeCycle
         self.lifeCycleType = lifeCycleType
     }
 

--- a/Coralogix/Sources/Utils/MobileVitals/MetricsManager.swift
+++ b/Coralogix/Sources/Utils/MobileVitals/MetricsManager.swift
@@ -145,8 +145,8 @@ public class MetricsManager {
     }
     
     private func handleANREvent() {
-        let errorMessage = Keys.anrErrorMessage.rawValue
-        let errorType = Keys.anrErrorType.rawValue
+        let errorMessage = WireValues.anrErrorMessage.rawValue
+        let errorType = WireValues.anrErrorType.rawValue
         
         // Report ANR as error (not mobile vitals)
         guard let anrErrorClosure = self.anrErrorClosure else {

--- a/Coralogix/Sources/Utils/MobileVitals/MetricsManager.swift
+++ b/Coralogix/Sources/Utils/MobileVitals/MetricsManager.swift
@@ -145,8 +145,8 @@ public class MetricsManager {
     }
     
     private func handleANREvent() {
-        let errorMessage = "Application Not Responding"
-        let errorType = "ANR"
+        let errorMessage = Keys.anrErrorMessage.rawValue
+        let errorType = Keys.anrErrorType.rawValue
         
         // Report ANR as error (not mobile vitals)
         guard let anrErrorClosure = self.anrErrorClosure else {

--- a/CoralogixInternal/Sources/HTTPEnums.swift
+++ b/CoralogixInternal/Sources/HTTPEnums.swift
@@ -1,0 +1,30 @@
+//
+//  HTTPEnums.swift
+//
+//
+//  Created by Coralogix DEV TEAM on 18/05/2026.
+//
+
+import Foundation
+
+/// Standard HTTP request methods. RawValue is lowercase to match what
+/// `URLRequest.httpMethod` and the OTel `http.method` attribute convention
+/// produce in practice; callers may construct via `HTTPMethod(rawValue:)`
+/// from a normalized string.
+public enum HTTPMethod: String, Codable {
+    case get     = "GET"
+    case post    = "POST"
+    case put     = "PUT"
+    case delete  = "DELETE"
+    case patch   = "PATCH"
+    case head    = "HEAD"
+    case options = "OPTIONS"
+    case connect = "CONNECT"
+    case trace   = "TRACE"
+}
+
+/// URL scheme. Matches what `URL.scheme` returns (lowercase).
+public enum URLScheme: String, Codable {
+    case http
+    case https
+}

--- a/CoralogixInternal/Sources/HTTPEnums.swift
+++ b/CoralogixInternal/Sources/HTTPEnums.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-/// Standard HTTP request methods. RawValue is lowercase to match what
+/// Standard HTTP request methods. RawValue is uppercase to match what
 /// `URLRequest.httpMethod` and the OTel `http.method` attribute convention
 /// produce in practice; callers may construct via `HTTPMethod(rawValue:)`
 /// from a normalized string.

--- a/CoralogixInternal/Sources/InteractionEnums.swift
+++ b/CoralogixInternal/Sources/InteractionEnums.swift
@@ -8,14 +8,14 @@
 import Foundation
 
 /// The type of a recorded user interaction.
-public enum InteractionEventName: String {
+public enum InteractionEventName: String, Codable {
     case click
     case scroll
     case swipe // Reserved for future use (UISwipeGestureRecognizer / SwiftUI DragGesture)
 }
 
 /// Direction of a scroll or swipe gesture.
-public enum ScrollDirection: String {
+public enum ScrollDirection: String, Codable {
     case up
     case down
     case left

--- a/CoralogixInternal/Sources/Keys.swift
+++ b/CoralogixInternal/Sources/Keys.swift
@@ -268,7 +268,7 @@ public enum CoralogixLogSeverity: Int {
     case critical = 6
 }
 
-public enum CoralogixEventType: String {
+public enum CoralogixEventType: String, Codable {
     case error
     case networkRequest = "network-request"
     case log

--- a/CoralogixInternal/Sources/Keys.swift
+++ b/CoralogixInternal/Sources/Keys.swift
@@ -166,6 +166,8 @@ public enum Keys: String {
     case mobileVitalsUnits = "units"
     case value
     case anrString = "application_not_responding"
+    case anrErrorMessage = "Application Not Responding"
+    case anrErrorType = "ANR"
     case skipEnrichmentWithIp = "skip_enrichment_with_ip"
     case appDidFinishLaunching
     case appDidBecomeActiveNotification

--- a/CoralogixInternal/Sources/Keys.swift
+++ b/CoralogixInternal/Sources/Keys.swift
@@ -166,8 +166,6 @@ public enum Keys: String {
     case mobileVitalsUnits = "units"
     case value
     case anrString = "application_not_responding"
-    case anrErrorMessage = "Application Not Responding"
-    case anrErrorType = "ANR"
     case skipEnrichmentWithIp = "skip_enrichment_with_ip"
     case appDidFinishLaunching
     case appDidBecomeActiveNotification
@@ -259,6 +257,17 @@ public enum Keys: String {
     case slowFrozen = "slow_frozen"
     case customMeasurementContext = "custom_measurement_context"
     case mobileVitals
+}
+
+/// Wire-format constant **values** (not keys) emitted on spans. Kept
+/// separate from `Keys` so the "keys" enum stays purely a registry of
+/// attribute names — see the CLAUDE.md rule that all attribute keys live
+/// in `Keys.swift`. Values that flow into attribute slots live here.
+public enum WireValues: String {
+    /// `error_message` value emitted for ANR-derived error events.
+    case anrErrorMessage = "Application Not Responding"
+    /// `error_type` discriminator emitted for ANR-derived error events.
+    case anrErrorType = "ANR"
 }
 
 public enum CoralogixLogSeverity: Int {

--- a/Tests/CoralogixRumTests/ANRErrorEventTests.swift
+++ b/Tests/CoralogixRumTests/ANRErrorEventTests.swift
@@ -1,0 +1,76 @@
+//
+//  ANRErrorEventTests.swift
+//
+//
+//  Created by Coralogix DEV TEAM on 18/05/2026.
+//
+
+import XCTest
+import CoralogixInternal
+@testable import Coralogix
+
+final class ANRErrorEventTests: XCTestCase {
+
+    func testEventTypeIsError() {
+        let event = ANRErrorEvent()
+        XCTAssertEqual(event.type, CoralogixEventType.error)
+        XCTAssertEqual(event.type.rawValue, "error")
+    }
+
+    func testDefaultsMatchExistingANRPath() {
+        let event = ANRErrorEvent()
+        XCTAssertEqual(event.errorMessage, "Application Not Responding")
+        XCTAssertEqual(event.errorType, "ANR")
+    }
+
+    func testAdapterEmitsRequiredAttributes() {
+        let event = ANRErrorEvent()
+        let attrs = event.toOTelAttributes()
+
+        XCTAssertEqual(attrs[Keys.eventType.rawValue],    .string("error"))
+        XCTAssertEqual(attrs[Keys.errorMessage.rawValue], .string("Application Not Responding"))
+        XCTAssertEqual(attrs[Keys.errorType.rawValue],    .string("ANR"))
+        XCTAssertEqual(attrs.count, 3)
+    }
+
+    // Parity: feed the adapter output through the existing exporter path
+    // (ErrorContext.init(otel:) -> getDictionary()) and assert the wire dict
+    // matches what the current ANR flow produces.
+    func testDictParityViaExistingContextPath() {
+        let event = ANRErrorEvent()
+
+        let mockSpan = MockSpanData(attributes: event.toOTelAttributes())
+        let context = ErrorContext(otel: mockSpan)
+        let dict = context.getDictionary()
+
+        XCTAssertEqual(dict[Keys.errorMessage.rawValue] as? String, "Application Not Responding")
+        XCTAssertEqual(dict[Keys.errorType.rawValue]    as? String, "ANR")
+        XCTAssertEqual(dict[Keys.isCrash.rawValue]      as? Bool,   false)
+        // Optional/empty fields should NOT appear on the wire.
+        XCTAssertNil(dict[Keys.domain.rawValue])
+        XCTAssertNil(dict[Keys.code.rawValue])
+        XCTAssertNil(dict[Keys.userInfo.rawValue])
+        XCTAssertNil(dict[Keys.originalStackTrace.rawValue])
+        XCTAssertNil(dict[Keys.arch.rawValue])
+        XCTAssertNil(dict[Keys.buildId.rawValue])
+        XCTAssertNil(dict[Keys.stackTraceType.rawValue])
+    }
+
+    func testCodableRoundTrip() throws {
+        let original = ANRErrorEvent(
+            id: UUID(uuidString: "00000000-0000-0000-0000-000000000005")!,
+            timestamp: Date(timeIntervalSince1970: 1_700_000_000),
+            errorMessage: "Hang detected",
+            errorType: "ANR"
+        )
+
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(ANRErrorEvent.self, from: encoded)
+
+        XCTAssertEqual(decoded.id,           original.id)
+        XCTAssertEqual(decoded.timestamp,    original.timestamp)
+        XCTAssertEqual(decoded.type,         original.type)
+        XCTAssertEqual(decoded.errorMessage, original.errorMessage)
+        XCTAssertEqual(decoded.errorType,    original.errorType)
+    }
+}

--- a/Tests/CoralogixRumTests/ErrorEventTests.swift
+++ b/Tests/CoralogixRumTests/ErrorEventTests.swift
@@ -1,0 +1,132 @@
+//
+//  ErrorEventTests.swift
+//
+//
+//  Created by Coralogix DEV TEAM on 18/05/2026.
+//
+
+import XCTest
+import CoralogixInternal
+@testable import Coralogix
+
+final class ErrorEventTests: XCTestCase {
+
+    func testEventTypeIsError() {
+        let event = ErrorEvent(domain: "NSURLErrorDomain", errorMessage: "boom")
+        XCTAssertEqual(event.type, CoralogixEventType.error)
+        XCTAssertEqual(event.type.rawValue, "error")
+    }
+
+    func testAdapterAlwaysEmitsRequiredFields() {
+        let event = ErrorEvent(domain: "io.app.network", errorMessage: "no internet")
+        let attrs = event.toOTelAttributes()
+
+        XCTAssertEqual(attrs[Keys.eventType.rawValue],    .string("error"))
+        XCTAssertEqual(attrs[Keys.domain.rawValue],       .string("io.app.network"))
+        XCTAssertEqual(attrs[Keys.errorMessage.rawValue], .string("no internet"))
+        XCTAssertEqual(attrs[Keys.isCrash.rawValue],      .bool(false))
+    }
+
+    func testAdapterOmitsUnsetOptionals() {
+        let event = ErrorEvent(domain: "d", errorMessage: "m")
+        let attrs = event.toOTelAttributes()
+
+        XCTAssertNil(attrs[Keys.code.rawValue])
+        XCTAssertNil(attrs[Keys.errorType.rawValue])
+        XCTAssertNil(attrs[Keys.arch.rawValue])
+        XCTAssertNil(attrs[Keys.buildId.rawValue])
+        XCTAssertNil(attrs[Keys.stackTraceType.rawValue])
+        XCTAssertNil(attrs[Keys.userInfo.rawValue])
+        XCTAssertNil(attrs[Keys.stackTrace.rawValue])
+    }
+
+    func testAdapterEmitsCodeAsInt() {
+        let event = ErrorEvent(domain: "d", code: 404, errorMessage: "m")
+        XCTAssertEqual(event.toOTelAttributes()[Keys.code.rawValue], .int(404))
+    }
+
+    // Parity: pipe a fully-populated event through the existing exporter path
+    // (ErrorContext.init(otel:) -> getDictionary()) and assert the resulting
+    // wire dict matches the original field set.
+    func testDictParityViaExistingContextPath_fullPopulation() throws {
+        let userInfoJson = Helper.convertDictionaryToJsonString(dict: [
+            "reason": "timeout",
+            "retry": 3
+        ])
+        let stackFrames: [[String: Any]] = [
+            ["function": "main", "file": "AppDelegate.swift", "line": 12]
+        ]
+        let stackJson = try String(
+            data: JSONSerialization.data(withJSONObject: stackFrames, options: []),
+            encoding: .utf8
+        ) ?? "[]"
+
+        let event = ErrorEvent(
+            domain: "io.app.network",
+            code: 504,
+            errorMessage: "gateway timeout",
+            isCrash: false,
+            errorType: "HTTPError",
+            arch: "arm64",
+            buildId: "abc123",
+            stackTraceType: "swift",
+            userInfoJson: userInfoJson,
+            stackTraceJson: stackJson
+        )
+
+        let mockSpan = MockSpanData(attributes: event.toOTelAttributes())
+        let context = ErrorContext(otel: mockSpan)
+        let dict = context.getDictionary()
+
+        XCTAssertEqual(dict[Keys.domain.rawValue]         as? String, "io.app.network")
+        XCTAssertEqual(dict[Keys.code.rawValue]           as? String, "504")
+        XCTAssertEqual(dict[Keys.errorMessage.rawValue]   as? String, "gateway timeout")
+        XCTAssertEqual(dict[Keys.errorType.rawValue]      as? String, "HTTPError")
+        XCTAssertEqual(dict[Keys.arch.rawValue]           as? String, "arm64")
+        XCTAssertEqual(dict[Keys.buildId.rawValue]        as? String, "abc123")
+        XCTAssertEqual(dict[Keys.stackTraceType.rawValue] as? String, "swift")
+        XCTAssertEqual(dict[Keys.isCrash.rawValue]        as? Bool,   false)
+
+        let userInfoDict = try XCTUnwrap(dict[Keys.userInfo.rawValue] as? [String: Any])
+        XCTAssertEqual(userInfoDict["reason"] as? String, "timeout")
+        XCTAssertEqual(userInfoDict["retry"]  as? Int,    3)
+
+        // ErrorContext renames stack_trace -> original_stacktrace on the way out.
+        let stack = try XCTUnwrap(dict[Keys.originalStackTrace.rawValue] as? [[String: Any]])
+        XCTAssertEqual(stack.first?["function"] as? String, "main")
+    }
+
+    func testCodableRoundTrip() throws {
+        let original = ErrorEvent(
+            id: UUID(uuidString: "00000000-0000-0000-0000-000000000004")!,
+            timestamp: Date(timeIntervalSince1970: 1_700_000_000),
+            domain: "d",
+            code: 42,
+            errorMessage: "m",
+            isCrash: true,
+            errorType: "Crash",
+            arch: "arm64",
+            buildId: nil,
+            stackTraceType: "objc",
+            userInfoJson: nil,
+            stackTraceJson: "[]"
+        )
+
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(ErrorEvent.self, from: encoded)
+
+        XCTAssertEqual(decoded.id,             original.id)
+        XCTAssertEqual(decoded.timestamp,      original.timestamp)
+        XCTAssertEqual(decoded.type,           original.type)
+        XCTAssertEqual(decoded.domain,         original.domain)
+        XCTAssertEqual(decoded.code,           original.code)
+        XCTAssertEqual(decoded.errorMessage,   original.errorMessage)
+        XCTAssertEqual(decoded.isCrash,        original.isCrash)
+        XCTAssertEqual(decoded.errorType,      original.errorType)
+        XCTAssertEqual(decoded.arch,           original.arch)
+        XCTAssertNil(decoded.buildId)
+        XCTAssertEqual(decoded.stackTraceType, original.stackTraceType)
+        XCTAssertNil(decoded.userInfoJson)
+        XCTAssertEqual(decoded.stackTraceJson, original.stackTraceJson)
+    }
+}

--- a/Tests/CoralogixRumTests/ErrorEventTests.swift
+++ b/Tests/CoralogixRumTests/ErrorEventTests.swift
@@ -56,10 +56,8 @@ final class ErrorEventTests: XCTestCase {
         let stackFrames: [[String: Any]] = [
             ["function": "main", "file": "AppDelegate.swift", "line": 12]
         ]
-        let stackJson = try String(
-            data: JSONSerialization.data(withJSONObject: stackFrames, options: []),
-            encoding: .utf8
-        ) ?? "[]"
+        let stackData = try JSONSerialization.data(withJSONObject: stackFrames, options: [])
+        let stackJson = try XCTUnwrap(String(data: stackData, encoding: .utf8))
 
         let event = ErrorEvent(
             domain: "io.app.network",
@@ -92,6 +90,28 @@ final class ErrorEventTests: XCTestCase {
         XCTAssertEqual(userInfoDict["retry"]  as? Int,    3)
 
         // ErrorContext renames stack_trace -> original_stacktrace on the way out.
+        let stack = try XCTUnwrap(dict[Keys.originalStackTrace.rawValue] as? [[String: Any]])
+        XCTAssertEqual(stack.first?["function"] as? String, "main")
+    }
+
+    // ErrorEvent.make handles JSON encoding internally; callers pass dicts.
+    func testFactoryEncodesUserInfoAndStackTraceForExistingContextPath() throws {
+        let event = ErrorEvent.make(
+            domain: "io.app.network",
+            code: 504,
+            errorMessage: "gateway timeout",
+            userInfo: ["reason": "timeout", "retry": 3],
+            stackTrace: [["function": "main", "file": "AppDelegate.swift", "line": 12]]
+        )
+
+        let mockSpan = MockSpanData(attributes: event.toOTelAttributes())
+        let context = ErrorContext(otel: mockSpan)
+        let dict = context.getDictionary()
+
+        let userInfoDict = try XCTUnwrap(dict[Keys.userInfo.rawValue] as? [String: Any])
+        XCTAssertEqual(userInfoDict["reason"] as? String, "timeout")
+        XCTAssertEqual(userInfoDict["retry"]  as? Int,    3)
+
         let stack = try XCTUnwrap(dict[Keys.originalStackTrace.rawValue] as? [[String: Any]])
         XCTAssertEqual(stack.first?["function"] as? String, "main")
     }

--- a/Tests/CoralogixRumTests/JSONValueTests.swift
+++ b/Tests/CoralogixRumTests/JSONValueTests.swift
@@ -1,0 +1,120 @@
+//
+//  JSONValueTests.swift
+//
+//
+//  Created by Coralogix DEV TEAM on 18/05/2026.
+//
+
+import XCTest
+@testable import Coralogix
+
+final class JSONValueTests: XCTestCase {
+
+    // MARK: - Codable round-trip (lossless cases)
+
+    func testRoundTrip_null() throws {
+        try assertRoundTrip(.null)
+    }
+
+    func testRoundTrip_bool() throws {
+        try assertRoundTrip(.bool(true))
+        try assertRoundTrip(.bool(false))
+    }
+
+    func testRoundTrip_int() throws {
+        try assertRoundTrip(.int(0))
+        try assertRoundTrip(.int(42))
+        try assertRoundTrip(.int(-17))
+        try assertRoundTrip(.int(Int.max))
+        try assertRoundTrip(.int(Int.min))
+    }
+
+    // Whole-number Doubles are lossy through JSON (see JSONValue type comment);
+    // only fractional doubles round-trip exactly. The lossy case is asserted
+    // separately below.
+    func testRoundTrip_fractionalDouble() throws {
+        try assertRoundTrip(.double(2.5))
+        try assertRoundTrip(.double(-3.14159))
+        try assertRoundTrip(.double(0.1))
+    }
+
+    func testRoundTrip_string() throws {
+        try assertRoundTrip(.string(""))
+        try assertRoundTrip(.string("hello"))
+        try assertRoundTrip(.string("emoji 🎉 + unicode ñ"))
+    }
+
+    func testRoundTrip_array() throws {
+        try assertRoundTrip(.array([]))
+        try assertRoundTrip(.array([.int(1), .string("two"), .bool(true), .null]))
+    }
+
+    func testRoundTrip_object() throws {
+        try assertRoundTrip(.object([:]))
+        try assertRoundTrip(.object([
+            "count":   .int(2),
+            "label":   .string("auth"),
+            "enabled": .bool(true),
+            "ratio":   .double(0.75),
+            "missing": .null,
+        ]))
+    }
+
+    func testRoundTrip_nested() throws {
+        try assertRoundTrip(.object([
+            "user": .object([
+                "id":   .int(7),
+                "tags": .array([.string("admin"), .string("beta")]),
+            ]),
+            "scores": .array([.double(1.5), .double(2.5), .double(3.5)]),
+        ]))
+    }
+
+    // MARK: - Documented caveat: whole-number Double demotes to Int
+
+    // `.double(2.0)` encodes as JSON `2`, which decodes as `.int(2)`. This
+    // test locks in that behaviour so a future "Double first on decode"
+    // change can't silently flip every integer to Double — the type comment
+    // on `JSONValue` explains why `Int`-first is intentional.
+    func testWholeNumberDoubleDecodesAsInt() throws {
+        let encoded = try JSONEncoder().encode(JSONValue.double(2.0))
+        let decoded = try JSONDecoder().decode(JSONValue.self, from: encoded)
+        XCTAssertEqual(decoded, .int(2))
+    }
+
+    // MARK: - toAny() shape
+
+    func testToAny_primitives() {
+        XCTAssertTrue(JSONValue.null.toAny() is NSNull)
+        XCTAssertEqual(JSONValue.bool(true).toAny() as? Bool,       true)
+        XCTAssertEqual(JSONValue.int(7).toAny() as? Int,            7)
+        XCTAssertEqual(JSONValue.double(1.5).toAny() as? Double,    1.5)
+        XCTAssertEqual(JSONValue.string("hi").toAny() as? String,   "hi")
+    }
+
+    func testToAny_nestedIsJSONSerializationCompatible() throws {
+        let value: JSONValue = .object([
+            "list": .array([.int(1), .string("two")]),
+            "flag": .bool(false),
+        ])
+        let any = value.toAny()
+        XCTAssertTrue(JSONSerialization.isValidJSONObject(any))
+        // Spot-check the nested shape made the trip into Foundation types.
+        let dict = try XCTUnwrap(any as? [String: Any])
+        let list = try XCTUnwrap(dict["list"] as? [Any])
+        XCTAssertEqual(list.count, 2)
+        XCTAssertEqual(list[0] as? Int, 1)
+        XCTAssertEqual(list[1] as? String, "two")
+        XCTAssertEqual(dict["flag"] as? Bool, false)
+    }
+
+    // MARK: - Helpers
+
+    private func assertRoundTrip(_ value: JSONValue,
+                                 file: StaticString = #filePath,
+                                 line: UInt = #line) throws {
+        let encoded = try JSONEncoder().encode(value)
+        let decoded = try JSONDecoder().decode(JSONValue.self, from: encoded)
+        XCTAssertEqual(decoded, value, file: file, line: line)
+    }
+}

--- a/Tests/CoralogixRumTests/MobileVitalsEventTests.swift
+++ b/Tests/CoralogixRumTests/MobileVitalsEventTests.swift
@@ -1,0 +1,81 @@
+//
+//  MobileVitalsEventTests.swift
+//
+//
+//  Created by Coralogix DEV TEAM on 18/05/2026.
+//
+
+import XCTest
+import CoralogixInternal
+@testable import Coralogix
+
+final class MobileVitalsEventTests: XCTestCase {
+
+    func testEventTypeIsMobileVitals() {
+        let event = MobileVitalsEvent(mobileVitalsType: "{}")
+        XCTAssertEqual(event.type, CoralogixEventType.mobileVitals)
+        XCTAssertEqual(event.type.rawValue, "mobile-vitals")
+    }
+
+    func testAdapterEmitsEventTypeDiscriminator() {
+        let event = MobileVitalsEvent(mobileVitalsType: "{}")
+        let attrs = event.toOTelAttributes()
+
+        XCTAssertEqual(
+            attrs[Keys.eventType.rawValue],
+            .string(CoralogixEventType.mobileVitals.rawValue)
+        )
+    }
+
+    func testAdapterEmitsPayloadUnderKeysMobileVitalsType() {
+        let payload = Helper.convertDictionaryToJsonString(dict: [
+            "fps": [Keys.mobileVitalsUnits.rawValue: "fps", Keys.value.rawValue: 60]
+        ])
+        let event = MobileVitalsEvent(mobileVitalsType: payload)
+        let attrs = event.toOTelAttributes()
+
+        XCTAssertEqual(
+            attrs[Keys.mobileVitalsType.rawValue],
+            .string(payload)
+        )
+    }
+
+    // Parity: feed the adapter output through the existing exporter path
+    // (MobileVitalsContext.init(otel:) -> getMobileVitalsDictionary()) and
+    // assert the resulting wire dict matches the original payload bit-for-bit.
+    func testDictParityViaExistingContextPath() throws {
+        let originalDict: [String: Any] = [
+            "fps": [
+                Keys.mobileVitalsUnits.rawValue: "fps",
+                Keys.value.rawValue: 60
+            ]
+        ]
+        let payload = Helper.convertDictionaryToJsonString(dict: originalDict)
+        let event = MobileVitalsEvent(mobileVitalsType: payload)
+
+        let mockSpan = MockSpanData(attributes: event.toOTelAttributes())
+        let context = MobileVitalsContext(otel: mockSpan)
+        let dict = context.getMobileVitalsDictionary()
+
+        let fps = try XCTUnwrap(dict["fps"] as? [String: Any])
+        XCTAssertEqual(fps[Keys.mobileVitalsUnits.rawValue] as? String, "fps")
+        XCTAssertEqual(fps[Keys.value.rawValue] as? Int, 60)
+        XCTAssertEqual(dict.count, 1)
+    }
+
+    func testCodableRoundTrip() throws {
+        let original = MobileVitalsEvent(
+            id: UUID(uuidString: "00000000-0000-0000-0000-000000000002")!,
+            timestamp: Date(timeIntervalSince1970: 1_700_000_000),
+            mobileVitalsType: #"{"cpu":{"units":"percent","value":42}}"#
+        )
+
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(MobileVitalsEvent.self, from: encoded)
+
+        XCTAssertEqual(decoded.id, original.id)
+        XCTAssertEqual(decoded.timestamp, original.timestamp)
+        XCTAssertEqual(decoded.type, original.type)
+        XCTAssertEqual(decoded.mobileVitalsType, original.mobileVitalsType)
+    }
+}

--- a/Tests/CoralogixRumTests/NetworkRequestEventTests.swift
+++ b/Tests/CoralogixRumTests/NetworkRequestEventTests.swift
@@ -71,8 +71,7 @@ final class NetworkRequestEventTests: XCTestCase {
     // wire-dict field matches the original.
     func testDictParityViaExistingContextPath_fullPopulation() throws {
         let event = makeEvent(
-            duration: 250,                       // expected wire value
-            statusText: "undefined",             // SpanDataExt always returns "undefined"
+            duration: 250,                       // expected wire value (from span timing below)
             requestHeaders: ["Authorization": "Bearer xyz"],
             responseHeaders: ["Server": "nginx"],
             requestPayload: #"{"q":"hello"}"#,
@@ -96,6 +95,10 @@ final class NetworkRequestEventTests: XCTestCase {
         XCTAssertEqual(dict[Keys.schema.rawValue]                as? String, "https")
         XCTAssertEqual(dict[Keys.duration.rawValue]              as? UInt64, 250)
         XCTAssertEqual(dict[Keys.responseContentLength.rawValue] as? Int,    1234)
+        // statusText is span-status-derived, not an OTel attribute — and
+        // `SpanDataExt.getStatusText()` is hardcoded to `Keys.undefined.rawValue`.
+        // This assertion locks in that existing behaviour; the struct's own
+        // `statusText` field doesn't affect it.
         XCTAssertEqual(dict[Keys.statusText.rawValue]            as? String, Keys.undefined.rawValue)
 
         let reqHeaders = try XCTUnwrap(dict[Keys.requestHeaders.rawValue] as? [String: String])
@@ -141,12 +144,12 @@ final class NetworkRequestEventTests: XCTestCase {
     private func makeEvent(
         id: UUID = UUID(uuidString: "00000000-0000-0000-0000-000000000006")!,
         timestamp: Date = Date(timeIntervalSince1970: 1_700_000_000),
-        method: String = "GET",
+        method: HTTPMethod = .get,
         statusCode: Int = 200,
         url: String = "https://api.example.com/v1/foo?x=1",
         fragments: String = "/v1/foo",
         host: String = "api.example.com",
-        schema: String = "https",
+        schema: URLScheme = .https,
         duration: UInt64 = 0,
         statusText: String = "",
         responseContentLength: Int = 1234,

--- a/Tests/CoralogixRumTests/NetworkRequestEventTests.swift
+++ b/Tests/CoralogixRumTests/NetworkRequestEventTests.swift
@@ -1,0 +1,181 @@
+//
+//  NetworkRequestEventTests.swift
+//
+//
+//  Created by Coralogix DEV TEAM on 18/05/2026.
+//
+
+import XCTest
+import CoralogixInternal
+@testable import Coralogix
+
+final class NetworkRequestEventTests: XCTestCase {
+
+    func testEventTypeIsNetworkRequest() {
+        let event = makeEvent()
+        XCTAssertEqual(event.type, CoralogixEventType.networkRequest)
+        XCTAssertEqual(event.type.rawValue, "network-request")
+    }
+
+    func testAdapterEmitsRequiredHttpAttributes() {
+        let event = makeEvent()
+        let attrs = event.toOTelAttributes()
+
+        XCTAssertEqual(attrs[Keys.eventType.rawValue],                        .string("network-request"))
+        XCTAssertEqual(attrs[SemanticAttributes.httpMethod.rawValue],         .string("GET"))
+        XCTAssertEqual(attrs[SemanticAttributes.httpUrl.rawValue],            .string("https://api.example.com/v1/foo?x=1"))
+        XCTAssertEqual(attrs[SemanticAttributes.httpTarget.rawValue],         .string("/v1/foo"))
+        XCTAssertEqual(attrs[SemanticAttributes.netPeerName.rawValue],        .string("api.example.com"))
+        XCTAssertEqual(attrs[SemanticAttributes.httpScheme.rawValue],         .string("https"))
+        XCTAssertEqual(attrs[SemanticAttributes.httpStatusCode.rawValue],     .int(200))
+        XCTAssertEqual(attrs[SemanticAttributes.httpResponseBodySize.rawValue], .int(1234))
+    }
+
+    // Adapter intentionally omits duration/statusText — they reach the wire
+    // via span timing and span status, not OTel attributes.
+    func testAdapterOmitsDurationAndStatusText() {
+        let event = makeEvent(duration: 9999, statusText: "OK")
+        let attrs = event.toOTelAttributes()
+
+        XCTAssertNil(attrs[Keys.duration.rawValue])
+        XCTAssertNil(attrs[Keys.statusText.rawValue])
+    }
+
+    func testAdapterOmitsUnsetCaptureRuleFields() {
+        let attrs = makeEvent().toOTelAttributes()
+        XCTAssertNil(attrs[Keys.requestHeaders.rawValue])
+        XCTAssertNil(attrs[Keys.responseHeaders.rawValue])
+        XCTAssertNil(attrs[Keys.requestPayload.rawValue])
+        XCTAssertNil(attrs[Keys.responsePayload.rawValue])
+    }
+
+    func testAdapterEmitsHeadersAsJsonStringWhenSet() throws {
+        let event = makeEvent(
+            requestHeaders: ["Content-Type": "application/json"],
+            responseHeaders: ["X-Trace-Id": "abc"]
+        )
+        let attrs = event.toOTelAttributes()
+
+        let reqJson = try XCTUnwrap(extractString(attrs[Keys.requestHeaders.rawValue]))
+        let resJson = try XCTUnwrap(extractString(attrs[Keys.responseHeaders.rawValue]))
+
+        let reqDict = try XCTUnwrap(Helper.convertJsonStringToDict(jsonString: reqJson))
+        XCTAssertEqual(reqDict["Content-Type"] as? String, "application/json")
+
+        let resDict = try XCTUnwrap(Helper.convertJsonStringToDict(jsonString: resJson))
+        XCTAssertEqual(resDict["X-Trace-Id"] as? String, "abc")
+    }
+
+    // Parity: pipe a fully-populated event through the existing exporter path
+    // (NetworkRequestContext.init(otel:) -> getDictionary()) and assert every
+    // wire-dict field matches the original.
+    func testDictParityViaExistingContextPath_fullPopulation() throws {
+        let event = makeEvent(
+            duration: 250,                       // expected wire value
+            statusText: "undefined",             // SpanDataExt always returns "undefined"
+            requestHeaders: ["Authorization": "Bearer xyz"],
+            responseHeaders: ["Server": "nginx"],
+            requestPayload: #"{"q":"hello"}"#,
+            responsePayload: #"{"ok":true}"#
+        )
+
+        // 250ms duration: start=0, end=0.250s
+        let mockSpan = MockSpanData(
+            attributes: event.toOTelAttributes(),
+            startTime: Date(timeIntervalSince1970: 0),
+            endTime: Date(timeIntervalSince1970: 0.250)
+        )
+        let context = NetworkRequestContext(otel: mockSpan)
+        let dict = context.getDictionary()
+
+        XCTAssertEqual(dict[Keys.method.rawValue]                as? String, "GET")
+        XCTAssertEqual(dict[Keys.statusCode.rawValue]            as? Int,    200)
+        XCTAssertEqual(dict[Keys.url.rawValue]                   as? String, "https://api.example.com/v1/foo?x=1")
+        XCTAssertEqual(dict[Keys.fragments.rawValue]             as? String, "/v1/foo")
+        XCTAssertEqual(dict[Keys.host.rawValue]                  as? String, "api.example.com")
+        XCTAssertEqual(dict[Keys.schema.rawValue]                as? String, "https")
+        XCTAssertEqual(dict[Keys.duration.rawValue]              as? UInt64, 250)
+        XCTAssertEqual(dict[Keys.responseContentLength.rawValue] as? Int,    1234)
+        XCTAssertEqual(dict[Keys.statusText.rawValue]            as? String, Keys.undefined.rawValue)
+
+        let reqHeaders = try XCTUnwrap(dict[Keys.requestHeaders.rawValue] as? [String: String])
+        XCTAssertEqual(reqHeaders["Authorization"], "Bearer xyz")
+
+        let resHeaders = try XCTUnwrap(dict[Keys.responseHeaders.rawValue] as? [String: String])
+        XCTAssertEqual(resHeaders["Server"], "nginx")
+
+        XCTAssertEqual(dict[Keys.requestPayload.rawValue]  as? String, #"{"q":"hello"}"#)
+        XCTAssertEqual(dict[Keys.responsePayload.rawValue] as? String, #"{"ok":true}"#)
+    }
+
+    func testCodableRoundTrip() throws {
+        let original = makeEvent(
+            requestHeaders: ["A": "1"],
+            responseHeaders: ["B": "2"],
+            requestPayload: "req",
+            responsePayload: "res"
+        )
+
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(NetworkRequestEvent.self, from: encoded)
+
+        XCTAssertEqual(decoded.id,                    original.id)
+        XCTAssertEqual(decoded.type,                  original.type)
+        XCTAssertEqual(decoded.method,                original.method)
+        XCTAssertEqual(decoded.statusCode,            original.statusCode)
+        XCTAssertEqual(decoded.url,                   original.url)
+        XCTAssertEqual(decoded.fragments,             original.fragments)
+        XCTAssertEqual(decoded.host,                  original.host)
+        XCTAssertEqual(decoded.schema,                original.schema)
+        XCTAssertEqual(decoded.duration,              original.duration)
+        XCTAssertEqual(decoded.statusText,            original.statusText)
+        XCTAssertEqual(decoded.responseContentLength, original.responseContentLength)
+        XCTAssertEqual(decoded.requestHeaders,        original.requestHeaders)
+        XCTAssertEqual(decoded.responseHeaders,       original.responseHeaders)
+        XCTAssertEqual(decoded.requestPayload,        original.requestPayload)
+        XCTAssertEqual(decoded.responsePayload,       original.responsePayload)
+    }
+
+    // MARK: - Helpers
+
+    private func makeEvent(
+        id: UUID = UUID(uuidString: "00000000-0000-0000-0000-000000000006")!,
+        timestamp: Date = Date(timeIntervalSince1970: 1_700_000_000),
+        method: String = "GET",
+        statusCode: Int = 200,
+        url: String = "https://api.example.com/v1/foo?x=1",
+        fragments: String = "/v1/foo",
+        host: String = "api.example.com",
+        schema: String = "https",
+        duration: UInt64 = 0,
+        statusText: String = "",
+        responseContentLength: Int = 1234,
+        requestHeaders: [String: String]? = nil,
+        responseHeaders: [String: String]? = nil,
+        requestPayload: String? = nil,
+        responsePayload: String? = nil
+    ) -> NetworkRequestEvent {
+        return NetworkRequestEvent(
+            id: id,
+            timestamp: timestamp,
+            method: method,
+            statusCode: statusCode,
+            url: url,
+            fragments: fragments,
+            host: host,
+            schema: schema,
+            duration: duration,
+            statusText: statusText,
+            responseContentLength: responseContentLength,
+            requestHeaders: requestHeaders,
+            responseHeaders: responseHeaders,
+            requestPayload: requestPayload,
+            responsePayload: responsePayload
+        )
+    }
+
+    private func extractString(_ value: AttributeValue?) -> String? {
+        guard case let .string(s) = value else { return nil }
+        return s
+    }
+}

--- a/Tests/CoralogixRumTests/NetworkRequestEventTests.swift
+++ b/Tests/CoralogixRumTests/NetworkRequestEventTests.swift
@@ -123,6 +123,7 @@ final class NetworkRequestEventTests: XCTestCase {
         let decoded = try JSONDecoder().decode(NetworkRequestEvent.self, from: encoded)
 
         XCTAssertEqual(decoded.id,                    original.id)
+        XCTAssertEqual(decoded.timestamp,             original.timestamp)
         XCTAssertEqual(decoded.type,                  original.type)
         XCTAssertEqual(decoded.method,                original.method)
         XCTAssertEqual(decoded.statusCode,            original.statusCode)

--- a/Tests/CoralogixRumTests/UserActionEventTests.swift
+++ b/Tests/CoralogixRumTests/UserActionEventTests.swift
@@ -68,6 +68,29 @@ final class UserActionEventTests: XCTestCase {
         XCTAssertNil(dict[Keys.attributes.rawValue])
     }
 
+    func testDictParityViaExistingContextPath_clickWithAttributes() throws {
+        let event = UserActionEvent(
+            eventName: .click,
+            targetElement: "loginButton",
+            attributes: [
+                "loginMethod": .string("oauth"),
+                "retryCount":  .int(2),
+                "rememberMe":  .bool(true),
+                "tags":        .array([.string("urgent"), .string("auth")])
+            ]
+        )
+
+        let mockSpan = MockSpanData(attributes: event.toOTelAttributes())
+        let context = InteractionContext(otel: mockSpan)
+        let dict = context.getDictionary()
+
+        let attrs = try XCTUnwrap(dict[Keys.attributes.rawValue] as? [String: Any])
+        XCTAssertEqual(attrs["loginMethod"] as? String, "oauth")
+        XCTAssertEqual(attrs["retryCount"]  as? Int,    2)
+        XCTAssertEqual(attrs["rememberMe"]  as? Bool,   true)
+        XCTAssertEqual(attrs["tags"] as? [String], ["urgent", "auth"])
+    }
+
     func testDictParityViaExistingContextPath_scrollWithDirection() {
         let event = UserActionEvent(
             eventName: .scroll,

--- a/Tests/CoralogixRumTests/UserActionEventTests.swift
+++ b/Tests/CoralogixRumTests/UserActionEventTests.swift
@@ -1,0 +1,119 @@
+//
+//  UserActionEventTests.swift
+//
+//
+//  Created by Coralogix DEV TEAM on 18/05/2026.
+//
+
+import XCTest
+import CoralogixInternal
+@testable import Coralogix
+
+final class UserActionEventTests: XCTestCase {
+
+    func testEventTypeIsUserInteraction() {
+        let event = UserActionEvent(eventName: .click, targetElement: "button")
+        XCTAssertEqual(event.type, CoralogixEventType.userInteraction)
+        XCTAssertEqual(event.type.rawValue, "user-interaction")
+    }
+
+    func testAdapterEmitsEventTypeDiscriminator() {
+        let event = UserActionEvent(eventName: .click, targetElement: "button")
+        let attrs = event.toOTelAttributes()
+
+        XCTAssertEqual(
+            attrs[Keys.eventType.rawValue],
+            .string(CoralogixEventType.userInteraction.rawValue)
+        )
+    }
+
+    func testAdapterEmitsTapObjectAsJsonString() throws {
+        let event = UserActionEvent(eventName: .click, targetElement: "loginButton")
+        let attrs = event.toOTelAttributes()
+
+        let tapJson = try XCTUnwrap(
+            extractString(attrs[Keys.tapObject.rawValue]),
+            "tap_object attribute should be a JSON string"
+        )
+
+        let parsed = try XCTUnwrap(
+            Helper.convertJsonStringToDict(jsonString: tapJson)
+        )
+        XCTAssertEqual(parsed[Keys.eventName.rawValue] as? String, "click")
+        XCTAssertEqual(parsed[Keys.targetElement.rawValue] as? String, "loginButton")
+    }
+
+    // Parity: feed the adapter output through the existing exporter path
+    // (InteractionContext.init(otel:) -> getDictionary()) and assert the
+    // resulting wire dict matches the original field set.
+    func testDictParityViaExistingContextPath_clickWithAllOptionals() {
+        let event = UserActionEvent(
+            eventName: .click,
+            targetElement: "loginButton",
+            elementClasses: "UIButton",
+            elementId: "login",
+            targetElementInnerText: "Sign in"
+        )
+
+        let mockSpan = MockSpanData(attributes: event.toOTelAttributes())
+        let context = InteractionContext(otel: mockSpan)
+        let dict = context.getDictionary()
+
+        XCTAssertEqual(dict[Keys.eventName.rawValue] as? String, "click")
+        XCTAssertEqual(dict[Keys.targetElement.rawValue] as? String, "loginButton")
+        XCTAssertEqual(dict[Keys.elementClasses.rawValue] as? String, "UIButton")
+        XCTAssertEqual(dict[Keys.elementId.rawValue] as? String, "login")
+        XCTAssertEqual(dict[Keys.targetElementInnerText.rawValue] as? String, "Sign in")
+        XCTAssertNil(dict[Keys.scrollDirection.rawValue])
+        XCTAssertNil(dict[Keys.attributes.rawValue])
+    }
+
+    func testDictParityViaExistingContextPath_scrollWithDirection() {
+        let event = UserActionEvent(
+            eventName: .scroll,
+            targetElement: "feedList",
+            scrollDirection: .down
+        )
+
+        let mockSpan = MockSpanData(attributes: event.toOTelAttributes())
+        let context = InteractionContext(otel: mockSpan)
+        let dict = context.getDictionary()
+
+        XCTAssertEqual(dict[Keys.eventName.rawValue] as? String, "scroll")
+        XCTAssertEqual(dict[Keys.targetElement.rawValue] as? String, "feedList")
+        XCTAssertEqual(dict[Keys.scrollDirection.rawValue] as? String, "down")
+    }
+
+    func testCodableRoundTrip() throws {
+        let original = UserActionEvent(
+            id: UUID(uuidString: "00000000-0000-0000-0000-000000000003")!,
+            timestamp: Date(timeIntervalSince1970: 1_700_000_000),
+            eventName: .scroll,
+            targetElement: "feedList",
+            elementClasses: "UICollectionView",
+            elementId: "feed",
+            targetElementInnerText: nil,
+            scrollDirection: .up
+        )
+
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(UserActionEvent.self, from: encoded)
+
+        XCTAssertEqual(decoded.id, original.id)
+        XCTAssertEqual(decoded.timestamp, original.timestamp)
+        XCTAssertEqual(decoded.type, original.type)
+        XCTAssertEqual(decoded.eventName, original.eventName)
+        XCTAssertEqual(decoded.targetElement, original.targetElement)
+        XCTAssertEqual(decoded.elementClasses, original.elementClasses)
+        XCTAssertEqual(decoded.elementId, original.elementId)
+        XCTAssertNil(decoded.targetElementInnerText)
+        XCTAssertEqual(decoded.scrollDirection, original.scrollDirection)
+    }
+
+    // MARK: - Helpers
+
+    private func extractString(_ value: AttributeValue?) -> String? {
+        guard case let .string(s) = value else { return nil }
+        return s
+    }
+}

--- a/Tests/CoralogixRumTests/ViewLifecycleEventTests.swift
+++ b/Tests/CoralogixRumTests/ViewLifecycleEventTests.swift
@@ -1,0 +1,73 @@
+//
+//  ViewLifecycleEventTests.swift
+//
+//
+//  Created by Coralogix DEV TEAM on 17/05/2026.
+//
+
+import XCTest
+import CoralogixInternal
+@testable import Coralogix
+
+final class ViewLifecycleEventTests: XCTestCase {
+
+    func testEventTypeAliasMatchesCoralogixEventType() {
+        XCTAssertEqual(EventType.lifeCycle, CoralogixEventType.lifeCycle)
+        XCTAssertEqual(EventType.lifeCycle.rawValue, "life-cycle")
+    }
+
+    func testAdapterEmitsEventTypeDiscriminator() {
+        let event = ViewLifecycleEvent(lifeCycleType: Keys.appDidFinishLaunching.rawValue)
+        let attrs = event.toOTelAttributes()
+
+        XCTAssertEqual(
+            attrs[Keys.eventType.rawValue],
+            .string(CoralogixEventType.lifeCycle.rawValue)
+        )
+    }
+
+    func testAdapterEmitsLifeCycleTypeUnderKeysType() {
+        let event = ViewLifecycleEvent(lifeCycleType: Keys.appDidFinishLaunching.rawValue)
+        let attrs = event.toOTelAttributes()
+
+        XCTAssertEqual(
+            attrs[Keys.type.rawValue],
+            .string(Keys.appDidFinishLaunching.rawValue)
+        )
+    }
+
+    // Parity: feed the adapter output through the existing exporter path
+    // (LifeCycleContext.init(otel:) -> getLifeCycleDictionary()) and assert
+    // the wire dict matches what today's flow produces.
+    func testDictParityViaExistingContextPath() {
+        let event = ViewLifecycleEvent(
+            lifeCycleType: Keys.appDidBecomeActiveNotification.rawValue
+        )
+
+        let mockSpan = MockSpanData(attributes: event.toOTelAttributes())
+        let context = LifeCycleContext(otel: mockSpan)
+        let dict = context.getLifeCycleDictionary()
+
+        XCTAssertEqual(
+            dict[Keys.eventName.rawValue] as? String,
+            Keys.appDidBecomeActiveNotification.rawValue
+        )
+        XCTAssertEqual(dict.count, 1, "life_cycle_context should contain only event_name")
+    }
+
+    func testCodableRoundTrip() throws {
+        let original = ViewLifecycleEvent(
+            id: UUID(uuidString: "00000000-0000-0000-0000-000000000001")!,
+            timestamp: Date(timeIntervalSince1970: 1_700_000_000),
+            lifeCycleType: Keys.appDidEnterBackgroundNotification.rawValue
+        )
+
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(ViewLifecycleEvent.self, from: encoded)
+
+        XCTAssertEqual(decoded.id, original.id)
+        XCTAssertEqual(decoded.timestamp, original.timestamp)
+        XCTAssertEqual(decoded.type, original.type)
+        XCTAssertEqual(decoded.lifeCycleType, original.lifeCycleType)
+    }
+}


### PR DESCRIPTION
# User description
## Summary

- Introduce a `TelemetryEvent` protocol and seven `Codable` event structs (`ANRErrorEvent`, `ErrorEvent`, `MobileVitalsEvent`, `NetworkRequestEvent`, `UserActionEvent`, `ViewLifecycleEvent`) backed by a `JSONValue` Codable bridge for free-form user-supplied attributes. Each event owns a `toOTelAttributes()` adapter that targets the existing wire shape — parity is asserted against the live `*Context` paths (`ErrorContext`, `InteractionContext`, `NetworkRequestContext`, `MobileVitalsContext`, `LifeCycleContext`) using `MockSpanData`.
- Add two new public enums in `CoralogixInternal` (`HTTPMethod`, `URLScheme`) and make `InteractionEventName` / `ScrollDirection` / `CoralogixEventType` `Codable` so they can ride along.
- Split wire **values** out of the `Keys` enum into a sibling `WireValues` enum (the two ANR strings were attribute values, not keys). Update `MetricsManager` and `ANRErrorEvent` call sites.
- Address PR-review findings: documented `JSONValue`'s whole-number-`Double` round-trip caveat (Int-first decode is intentional); `ErrorEvent.make` now routes both `userInfo` and `stackTrace` through `Helper.convert*ToJsonString` and omits the attribute on encoding failure instead of emitting `""`; `NetworkRequestEvent`'s `duration` / `statusText` are now required at `init` so call sites can't accept defaults and silently lose span-derived data.

## Test plan

- [x] `swift build` / `xcodebuild` clean on iOS Simulator
- [x] `CoralogixRumTests/ANRErrorEventTests` — 5 cases pass
- [x] `CoralogixRumTests/ErrorEventTests` — 7 cases pass
- [x] `CoralogixRumTests/MobileVitalsEventTests` — 5 cases pass
- [x] `CoralogixRumTests/NetworkRequestEventTests` — 7 cases pass
- [x] `CoralogixRumTests/UserActionEventTests` — 6 cases pass
- [x] `CoralogixRumTests/ViewLifecycleEventTests` — 4 cases pass
- [x] `CoralogixRumTests/JSONValueTests` — 11 cases pass (Codable round-trip + lossy whole-double caveat + `toAny()` shape)
- [ ] CI green on macOS 14 / Xcode 16.x test matrix

## Notes for reviewers

- No production code path consumes these events yet — they're a pure model/adapter layer ahead of wiring. The parity tests via real `*Context` paths are the contract this branch defends.
- Crash-path fields (`exceptionType`, `crashTimestamp`, etc.) are intentionally **not** surfaced on `ErrorEvent`; the crash wire shape differs and may land as a separate struct.
- `NetworkRequestEvent.duration` / `statusText` do **not** flow through `toOTelAttributes()` — they reach the wire via OTel span infrastructure (start/end time, span status). Any future emission-path consumer must source them separately; this is now enforced at the type level (no defaults) and documented at the top of the struct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ANR (Application Not Responding) error event tracking
  * Added comprehensive error telemetry capturing
  * Added network request event tracking
  * Added user interaction event tracking
  * Added mobile vitals event capturing
  * Added view lifecycle event tracking

* **Tests**
  * Added test suites validating new event types, serialization, OpenTelemetry attribute output, and parity with existing export paths

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coralogix/cx-ios-sdk/pull/205?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Introduce a <code>TelemetryEvent</code> protocol together with Codable structs for each RUM flow, leveraging <code>JSONValue</code> to bridge free-form attributes while adapters emit the existing wire shape. Align event-enum helpers and wire constants so middleware can type-safely build on these models before wiring them into the exporter.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/205?tool=ast&topic=Enums+%26+Wire+Values>Enums & Wire Values</a>
        </td><td>Align HTTP/interaction enums and wire constants with Codable usage plus shared <code>WireValues</code> so downstream code reuses canonical values and <code>MetricsManager</code> stays in sync with the ANR metadata.<details><summary>Modified files (4)</summary><ul><li>Coralogix/Sources/Utils/MobileVitals/MetricsManager.swift</li>
<li>CoralogixInternal/Sources/HTTPEnums.swift</li>
<li>CoralogixInternal/Sources/InteractionEnums.swift</li>
<li>CoralogixInternal/Sources/Keys.swift</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>refactor(CX-40572): sp...</td><td>May 18, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/205?tool=ast&topic=TelemetryEvent+Models>TelemetryEvent Models</a>
        </td><td>Document typed <code>TelemetryEvent</code> structs and the <code>JSONValue</code> bridge so each adapter mirrors the existing exporter wire shape while tests assert parity and Codable round trips for every flow.<details><summary>Modified files (15)</summary><ul><li>Coralogix/Sources/Model/TelemetryEvents/ANRErrorEvent.swift</li>
<li>Coralogix/Sources/Model/TelemetryEvents/ErrorEvent.swift</li>
<li>Coralogix/Sources/Model/TelemetryEvents/JSONValue.swift</li>
<li>Coralogix/Sources/Model/TelemetryEvents/MobileVitalsEvent.swift</li>
<li>Coralogix/Sources/Model/TelemetryEvents/NetworkRequestEvent.swift</li>
<li>Coralogix/Sources/Model/TelemetryEvents/TelemetryEvent.swift</li>
<li>Coralogix/Sources/Model/TelemetryEvents/UserActionEvent.swift</li>
<li>Coralogix/Sources/Model/TelemetryEvents/ViewLifecycleEvent.swift</li>
<li>Tests/CoralogixRumTests/ANRErrorEventTests.swift</li>
<li>Tests/CoralogixRumTests/ErrorEventTests.swift</li>
<li>Tests/CoralogixRumTests/JSONValueTests.swift</li>
<li>Tests/CoralogixRumTests/MobileVitalsEventTests.swift</li>
<li>Tests/CoralogixRumTests/NetworkRequestEventTests.swift</li>
<li>Tests/CoralogixRumTests/UserActionEventTests.swift</li>
<li>Tests/CoralogixRumTests/ViewLifecycleEventTests.swift</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>refactor(CX-40572): sp...</td><td>May 18, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/coralogix/cx-ios-sdk/205?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>