### PR TITLE
feat(CX-43017): expose session_creation_date and hasRecording in cx_rum.session_context tracing attrs

### DIFF
--- a/Coralogix/Sources/Model/InstrumentationData.swift
+++ b/Coralogix/Sources/Model/InstrumentationData.swift
@@ -92,6 +92,8 @@ struct OtelSpan {
         static let versionMetadataAppVersion = "cx_rum.version_metadata.app_version"
         static let labels                    = "cx_rum.labels"
         static let sessionId                 = "cx_rum.session_context.session_id"
+        static let sessionCreationDate       = "cx_rum.session_context.session_creation_date"
+        static let hasRecording              = "cx_rum.session_context.hasRecording"
         static let userId                    = "cx_rum.session_context.user_id"
         static let userName                  = "cx_rum.session_context.user_name"
         static let userEmail                 = "cx_rum.session_context.user_email"
@@ -144,6 +146,8 @@ struct OtelSpan {
         // Session context
         if let session = cxRum.sessionContext {
             attrs[AttrKey.sessionId] = session.sessionId
+            attrs[AttrKey.sessionCreationDate] = session.sessionCreationDate.milliseconds
+            attrs[AttrKey.hasRecording] = session.hasRecording
             if !session.userId.isEmpty    { attrs[AttrKey.userId]    = session.userId }
             if !session.userName.isEmpty  { attrs[AttrKey.userName]  = session.userName }
             if !session.userEmail.isEmpty { attrs[AttrKey.userEmail] = session.userEmail }

--- a/Tests/CoralogixRumTests/InstrumentationDataTests.swift
+++ b/Tests/CoralogixRumTests/InstrumentationDataTests.swift
@@ -182,6 +182,33 @@ final class InstrumentationDataTests: XCTestCase {
         XCTAssertNotNil(attrs["cx_rum.session_context.user_agent"])
     }
 
+    func testBuildRumContextAttributes_hasRecording_reflectsSessionState() {
+        let cxRumOff = makeCxRum(hasRecording: false)
+        XCTAssertEqual(
+            OtelSpan(otel: mockSpan, cxRum: cxRumOff, viewManager: nil).attributes["cx_rum.session_context.hasRecording"] as? Bool,
+            false
+        )
+
+        let cxRumOn = makeCxRum(hasRecording: true)
+        XCTAssertEqual(
+            OtelSpan(otel: mockSpan, cxRum: cxRumOn, viewManager: nil).attributes["cx_rum.session_context.hasRecording"] as? Bool,
+            true
+        )
+    }
+
+    func testBuildRumContextAttributes_sessionCreationDate_isMillisecondInt() {
+        // The mock session span carries sessionCreationDate="1609459200" (seconds).
+        // The cx_rum attribute must be emitted as Int milliseconds (1609459200000),
+        // matching the SessionContext payload encoding and the backend tracing contract.
+        let cxRum = makeCxRum()
+        let attrs = OtelSpan(otel: mockSpan, cxRum: cxRum, viewManager: nil).attributes
+
+        let scd = attrs["cx_rum.session_context.session_creation_date"]
+        XCTAssertNotNil(scd, "cx_rum.session_context.session_creation_date must be present in instrumentation_data attributes")
+        XCTAssertNil(scd as? String, "session_creation_date must not be a String — backend expects an integer ms timestamp")
+        XCTAssertEqual(scd as? Int, 1_609_459_200_000)
+    }
+
     func testBuildRumContextAttributes_eventContext_isPresent() {
         let cxRum = makeCxRum(eventType: .networkRequest, severity: 3, source: "fetch")
         let attrs = OtelSpan(otel: mockSpan, cxRum: cxRum, viewManager: nil).attributes
@@ -373,7 +400,8 @@ final class InstrumentationDataTests: XCTestCase {
         fragments: String = "/api",
         labels: [String: Any]? = nil,
         errorType: String = "",
-        errorMessage: String = ""
+        errorMessage: String = "",
+        hasRecording: Bool = false
     ) -> CxRum {
         let eventSpan = MockSpanData(attributes: [
             Keys.eventType.rawValue: AttributeValue(eventType.rawValue),
@@ -409,7 +437,7 @@ final class InstrumentationDataTests: XCTestCase {
             timeStamp: Date().timeIntervalSince1970,
             networkRequestContext: NetworkRequestContext(otel: networkSpan),
             versionMetadata: VersionMetadata(appName: appName, appVersion: appVersion),
-            sessionContext: SessionContext(otel: sessionSpan, userMetadata: nil),
+            sessionContext: SessionContext(otel: sessionSpan, userMetadata: nil, hasRecording: hasRecording),
             prevSessionContext: nil,
             eventContext: EventContext(otel: eventSpan),
             logContext: LogContext(otel: emptySpan),


### PR DESCRIPTION
# User description
## Summary
- Surface `cx_rum.session_context.session_creation_date` (Int ms) and `cx_rum.session_context.hasRecording` (Bool) inside `instrumentation_data.otelSpan.attributes` so downstream tracing extractors can read them
- Both values already exist on the OTel span / CxRum payload elsewhere — this only extends the tracing allow-list in `InstrumentationData.buildRumContextAttributes()`
- Two new unit tests pin the keys, types, and value propagation; helper `makeCxRum` extended with a `hasRecording` param

## Heads-up — divergence from browser SDK
The web SDK's `cx_rum.session_context.*` allow-list (`libs/browser/src/otel/rum-span-attributes.types.ts`) does **not** currently emit either key. iOS will be ahead. Coordinate with the RUM ingest team before release if the schema is strict, and consider filing on the browser SDK for parity.

## Jira
[CX-43017](https://coralogix.atlassian.net/browse/CX-43017)

## Test plan
- [x] `xcodebuild test -only-testing:CoralogixRumTests/InstrumentationDataTests` — 30 tests pass, including the two new ones:
  - `testBuildRumContextAttributes_sessionCreationDate_isMillisecondInt`
  - `testBuildRumContextAttributes_hasRecording_reflectsSessionState`
- [ ] Reviewer: run a demo app with a `beforeSend` callback or `tracesExporter` and confirm both keys appear under `instrumentation_data.otelSpan.attributes`
- [ ] Reviewer: confirm with RUM ingest team that the new keys are acceptable (schema divergence from browser SDK noted above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CX-43017]: https://coralogix.atlassian.net/browse/CX-43017?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Extend InstrumentationData.buildRumContextAttributes to propagate <code>cx_rum.session_context.session_creation_date</code> milliseconds and <code>cx_rum.session_context.hasRecording</code> into <code>instrumentation_data.otelSpan.attributes</code> so tracing extractors can join on session metadata. Add OtelSpan attribute coverage that checks the emitted values and keep the helper factory aligned with the session recording flag.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/206?tool=ast&topic=Traces+session+attrs>Traces session attrs</a>
        </td><td>Add session_creation_date and hasRecording to the tracing allow-list so InstrumentationData exposes those session_context fields in instrumentation_data.otelSpan.attributes.<details><summary>Modified files (1)</summary><ul><li>Coralogix/Sources/Model/InstrumentationData.swift</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>feat(CX-43017): expose...</td><td>May 19, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/206?tool=ast&topic=Instrumentation+tests>Instrumentation tests</a>
        </td><td>Verify OtelSpan attributes reflect the new keys and types, adding coverage that exercises both the session_creation_date milliseconds encoding and hasRecording flag while extending the CX-RUM helper.<details><summary>Modified files (1)</summary><ul><li>Tests/CoralogixRumTests/InstrumentationDataTests.swift</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>feat(CX-43017): expose...</td><td>May 19, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/coralogix/cx-ios-sdk/206?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * RUM session context now includes recording status and session creation timestamp (emitted as milliseconds) for improved session-level monitoring.

* **Tests**
  * Added tests verifying the new session context attributes, including correct timestamp formatting and recording-flag propagation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coralogix/cx-ios-sdk/pull/206?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->