### PR TITLE
feat(CX-40573): EventReporter & MetricsCollector protocols for mobile vitals + ANR

### DIFF
--- a/Coralogix/Sources/CoralogixRum.swift
+++ b/Coralogix/Sources/CoralogixRum.swift
@@ -189,8 +189,12 @@ public class CoralogixRum {
     private func setupCoreModules() {
         self.initializeSessionReplay()
         self.initializeNavigationInstrumentation()
-        self.metricsManager.metricsManagerClosure = { [weak self] dict in
-            self?.sendMobileVitals(dict)
+        // CX-40573: Mobile-vitals payloads now flow through the typed
+        // MetricsCollector protocol instead of the previous closure on
+        // MetricsManager. Wire format is unchanged — pinned by
+        // WireFormatTests.testMetricsManager_protocolPath_equalsClosurePath_endToEnd.
+        self.metricsManager.metricsCollector = SpanMetricsCollector { [weak self] in
+            self?.makeSpan(event: .mobileVitals, source: .code, severity: .info)
         }
     }
     
@@ -302,7 +306,7 @@ public class CoralogixRum {
     public func reportMobileVitalsMeasurement(type: String, metrics: [HybridMetric]) {
         guard CoralogixRum.isInitialized else { return }
         if (CoralogixRum.mobileSDK.sdkFramework.isNative) { return }
-        
+
         var vitalArray = [[String: Any]]()
         metrics.forEach { element in
             let vital = [
@@ -313,21 +317,28 @@ public class CoralogixRum {
             ]
             vitalArray.append(vital)
         }
-        self.sendMobileVitals([type: vitalArray])
+        // CX-40573: same wire format as before, routed through the typed
+        // MetricsCollector path so the orchestrator owns span creation.
+        guard let collector = self.metricsManager.metricsCollector else {
+            Log.d("[CoralogixRum] metricsCollector not wired; dropping hybrid measurement type=\(type) metrics=\(metrics.count)")
+            return
+        }
+        collector.collect([VitalsMetric(name: type, payload: vitalArray)])
     }
-    
+
     public func reportMobileVitalsMeasurement(type: String, value: Double, units: String) {
         guard CoralogixRum.isInitialized else { return }
         if (CoralogixRum.mobileSDK.sdkFramework.isNative) { return }
-        
-        let vital = [
-            type: [
-                Keys.mobileVitalsUnits.rawValue: units,
-                Keys.value.rawValue: value
-            ]
+
+        let payload: [String: Any] = [
+            Keys.mobileVitalsUnits.rawValue: units,
+            Keys.value.rawValue: value
         ]
-        
-        self.sendMobileVitals(vital)
+        guard let collector = self.metricsManager.metricsCollector else {
+            Log.d("[CoralogixRum] metricsCollector not wired; dropping hybrid measurement type=\(type) value=\(value)")
+            return
+        }
+        collector.collect([VitalsMetric(name: type, payload: payload)])
     }
     
     public func setView(name: String) {

--- a/Coralogix/Sources/Instrumentation/ANRInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/ANRInstrumentation.swift
@@ -9,35 +9,23 @@ import Foundation
 import CoralogixInternal
 
 extension CoralogixRum {
-    /// Initializes ANR (Application Not Responding) detection
-    /// ANR events are reported as error events, not mobile vitals
+    /// Initializes ANR (Application Not Responding) detection.
+    /// ANR events are reported as error events, not mobile vitals.
+    ///
+    /// CX-40573: ANR events now flow through the typed EventReporter
+    /// protocol — the orchestrator wires SpanEventReporter here and the
+    /// underlying span-building logic lives in that struct. The
+    /// pre-refactor `anrErrorClosure` path remains on MetricsManager as a
+    /// deprecated fallback for test code that pokes the closure directly.
     public func initializeANRInstrumentation() {
-        // Set ANR error callback
-        self.metricsManager.anrErrorClosure = { [weak self] errorMessage, errorType in
-            self?.reportANRError(errorMessage: errorMessage, errorType: errorType)
-        }
-        
-        // Verify closure was set before starting monitoring
-        guard self.metricsManager.anrErrorClosure != nil else {
-            Log.d("[CoralogixRum] Warning: Failed to set anrErrorClosure, ANR monitoring not started")
-            return
-        }
-        
+        self.metricsManager.eventReporter = SpanEventReporter(
+            createErrorSpan: { [weak self] in
+                self?.makeSpan(event: .error, source: .code, severity: .error)
+            },
+            recordScreenshot: { [weak self] span in
+                self?.recordScreenshotForSpan(to: &span)
+            }
+        )
         self.metricsManager.startANRMonitoring()
-    }
-    
-    /// Reports ANR as an error event
-    /// - Parameters:
-    ///   - errorMessage: The ANR error message (e.g., "Application Not Responding")
-    ///   - errorType: The error type (always "ANR")
-    private func reportANRError(errorMessage: String, errorType: String) {
-        var span = makeSpan(event: .error, source: .code, severity: .error)
-        span.setAttribute(key: Keys.errorMessage.rawValue, value: errorMessage)
-        span.setAttribute(key: Keys.errorType.rawValue, value: errorType)
-        
-        recordScreenshotForSpan(to: &span)
-        span.end()
-        
-        Log.d("[CoralogixRum] ANR error event sent: \(errorMessage)")
     }
 }

--- a/Coralogix/Sources/Instrumentation/MobileVitalsInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/MobileVitalsInstrumentation.swift
@@ -13,10 +13,4 @@ extension CoralogixRum {
         self.metricsManager.addMetricKitObservers()
         self.metricsManager.startMonitoring(using: self.options )
     }
-    
-    func sendMobileVitals(_ mobileVitals: [String: Any]) {
-        let span = makeSpan(event: .mobileVitals, source: .code, severity: .info)
-        span.setAttribute(key: Keys.mobileVitalsType.rawValue, value: Helper.convertDictionaryToJsonString(dict: mobileVitals))
-        span.end()
-    }
 }

--- a/Coralogix/Sources/Model/Reporting/EventReporter.swift
+++ b/Coralogix/Sources/Model/Reporting/EventReporter.swift
@@ -1,0 +1,18 @@
+//
+//  EventReporter.swift
+//
+//
+//  Created by Coralogix DEV TEAM on 20/05/2026.
+//
+
+import Foundation
+
+/// Receives a typed telemetry event (see `TelemetryEvent`) and turns it into
+/// whatever the production SDK does today — a span, a log, or both.
+///
+/// Replaces the ad-hoc `(String, String) -> Void` / `([String: Any]) -> Void`
+/// closures on `MetricsManager`. Concrete implementations decide their own
+/// threading; this protocol promises nothing about which queue `report` runs on.
+protocol EventReporter {
+    func report(_ event: TelemetryEvent)
+}

--- a/Coralogix/Sources/Model/Reporting/MetricsCollector.swift
+++ b/Coralogix/Sources/Model/Reporting/MetricsCollector.swift
@@ -1,0 +1,19 @@
+//
+//  MetricsCollector.swift
+//
+//
+//  Created by Coralogix DEV TEAM on 20/05/2026.
+//
+
+import Foundation
+
+/// Receives a batch of mobile-vitals metrics (one `VitalsMetric` per
+/// category). Replaces `MetricsManager.metricsManagerClosure` with a
+/// protocol-typed dependency.
+///
+/// `collect` must produce a payload byte-identical to what the legacy
+/// closure path emits today — the wire format is pinned by
+/// `WireFormatTests`. Concrete implementations decide their own threading.
+protocol MetricsCollector {
+    func collect(_ metrics: [VitalsMetric])
+}

--- a/Coralogix/Sources/Model/Reporting/SpanEventReporter.swift
+++ b/Coralogix/Sources/Model/Reporting/SpanEventReporter.swift
@@ -10,10 +10,12 @@ import CoralogixInternal
 
 /// Production `EventReporter` impl. Turns a `TelemetryEvent` into an
 /// error span via the orchestrator's `makeSpan`. Today only
-/// `ANRErrorEvent` is wired through this path; the switch is deliberately
-/// conservative so any new event type is logged and dropped rather than
-/// silently mis-routed. Add new event handlers as their producers come
-/// online.
+/// `ANRErrorEvent` is wired through this path. The switch on
+/// `event.type` is exhaustive (no `default:`) so adding a new
+/// `CoralogixEventType` case fails to compile here until a contributor
+/// explicitly handles it — either with a new `case` or by adding it to
+/// the drop list. Prevents silent mis-routing as the event taxonomy
+/// grows.
 ///
 /// `createSpan` and `recordScreenshot` are injected closures — they let
 /// this struct stay decoupled from `CoralogixRum`'s API surface while
@@ -29,14 +31,27 @@ final class SpanEventReporter: EventReporter {
     }
 
     func report(_ event: TelemetryEvent) {
-        if let anr = event as? ANRErrorEvent {
+        switch event.type {
+        case .error:
+            guard let anr = event as? ANRErrorEvent else {
+                Log.d("[SpanEventReporter] event.type=.error but concrete type is not ANRErrorEvent; dropping")
+                return
+            }
             guard var span = createErrorSpan() else { return }
             span.setAttribute(key: Keys.errorMessage.rawValue, value: anr.errorMessage)
             span.setAttribute(key: Keys.errorType.rawValue,    value: anr.errorType)
             recordScreenshot(&span)
             span.end()
-            return
+
+        // These event types do not flow through the EventReporter
+        // protocol path today — they emit spans via other code paths.
+        // Enumerated explicitly (rather than caught by `default:`) so
+        // adding a new `CoralogixEventType` case forces a compile-time
+        // decision here.
+        case .networkRequest, .log, .userInteraction, .webVitals, .longtask, .resources,
+             .internalKey, .navigation, .mobileVitals, .lifeCycle, .screenshot,
+             .customMeasurement, .customSpan, .unknown:
+            Log.d("[SpanEventReporter] event.type=\(event.type.rawValue) is not handled by the protocol path; dropping")
         }
-        Log.d("[SpanEventReporter] Unhandled event type \(event.type.rawValue); dropping")
     }
 }

--- a/Coralogix/Sources/Model/Reporting/SpanEventReporter.swift
+++ b/Coralogix/Sources/Model/Reporting/SpanEventReporter.swift
@@ -1,0 +1,42 @@
+//
+//  SpanEventReporter.swift
+//
+//
+//  Created by Coralogix DEV TEAM on 20/05/2026.
+//
+
+import Foundation
+import CoralogixInternal
+
+/// Production `EventReporter` impl. Turns a `TelemetryEvent` into an
+/// error span via the orchestrator's `makeSpan`. Today only
+/// `ANRErrorEvent` is wired through this path; the switch is deliberately
+/// conservative so any new event type is logged and dropped rather than
+/// silently mis-routed. Add new event handlers as their producers come
+/// online.
+///
+/// `createSpan` and `recordScreenshot` are injected closures — they let
+/// this struct stay decoupled from `CoralogixRum`'s API surface while
+/// using its internal `makeSpan` / `recordScreenshotForSpan` methods.
+final class SpanEventReporter: EventReporter {
+    private let createErrorSpan: () -> (any Span)?
+    private let recordScreenshot: (inout any Span) -> Void
+
+    init(createErrorSpan: @escaping () -> (any Span)?,
+         recordScreenshot: @escaping (inout any Span) -> Void) {
+        self.createErrorSpan = createErrorSpan
+        self.recordScreenshot = recordScreenshot
+    }
+
+    func report(_ event: TelemetryEvent) {
+        if let anr = event as? ANRErrorEvent {
+            guard var span = createErrorSpan() else { return }
+            span.setAttribute(key: Keys.errorMessage.rawValue, value: anr.errorMessage)
+            span.setAttribute(key: Keys.errorType.rawValue,    value: anr.errorType)
+            recordScreenshot(&span)
+            span.end()
+            return
+        }
+        Log.d("[SpanEventReporter] Unhandled event type \(event.type.rawValue); dropping")
+    }
+}

--- a/Coralogix/Sources/Model/Reporting/SpanMetricsCollector.swift
+++ b/Coralogix/Sources/Model/Reporting/SpanMetricsCollector.swift
@@ -1,0 +1,51 @@
+//
+//  SpanMetricsCollector.swift
+//
+//
+//  Created by Coralogix DEV TEAM on 20/05/2026.
+//
+
+import Foundation
+import CoralogixInternal
+
+/// Production `MetricsCollector` impl. Aggregates the incoming
+/// `[VitalsMetric]` back into the `[String: Any]` shape the backend reads
+/// today and emits it as a single attribute on a `mobile_vitals` span.
+///
+/// The dict-shape transform happens in `Array<VitalsMetric>.toDictionary()`
+/// so the round-trip can be unit-tested without going through a span;
+/// `WireFormatTests` pins the byte-equivalence to the legacy closure path.
+///
+/// `createSpan` is the only injected dependency — it returns a fresh
+/// `mobile_vitals` span ready for attributes. Returns `nil` when the
+/// orchestrator (`CoralogixRum`) has been torn down; in that case the
+/// metrics are dropped (matches the pre-refactor `[weak self]` behaviour).
+final class SpanMetricsCollector: MetricsCollector {
+    private let createSpan: () -> (any Span)?
+
+    init(createSpan: @escaping () -> (any Span)?) {
+        self.createSpan = createSpan
+    }
+
+    func collect(_ metrics: [VitalsMetric]) {
+        guard !metrics.isEmpty else { return }
+        let dict = metrics.toDictionary()
+        // Boundary check: VitalsMetric.payload is Any to accept both dict
+        // and array shapes the legacy closure path passed. Anything that
+        // isn't JSON-serializable would crash inside JSONSerialization
+        // below — drop with a log instead.
+        guard JSONSerialization.isValidJSONObject(dict) else {
+            Log.d("[SpanMetricsCollector] Non-JSON-serializable payload in metrics \(metrics.map(\.name)); dropping batch")
+            return
+        }
+        guard let span = createSpan() else {
+            Log.d("[SpanMetricsCollector] orchestrator gone; dropping \(metrics.count) metric(s)")
+            return
+        }
+        span.setAttribute(
+            key: Keys.mobileVitalsType.rawValue,
+            value: Helper.convertDictionaryToJsonString(dict: dict)
+        )
+        span.end()
+    }
+}

--- a/Coralogix/Sources/Model/Reporting/VitalsMetric.swift
+++ b/Coralogix/Sources/Model/Reporting/VitalsMetric.swift
@@ -1,0 +1,48 @@
+//
+//  VitalsMetric.swift
+//
+//
+//  Created by Coralogix DEV TEAM on 20/05/2026.
+//
+
+import Foundation
+
+/// A single mobile-vitals category emitted by a detector.
+///
+/// `name` is the wire-format category key (e.g. `Keys.cpu.rawValue`,
+/// `Keys.memory.rawValue`, `Keys.fps.rawValue`). `payload` is the same
+/// shape `Detector.statsDictionary()` returns today — usually a
+/// `[String: Any]` dict, but the hybrid-SDK entry points
+/// (`reportMobileVitalsMeasurement(type:metrics:)`) wrap an
+/// `[[String: Any]]` array. `payload` is therefore typed `Any` to match
+/// every shape the legacy `metricsManagerClosure` accepted; the type is
+/// intentionally untyped at this phase so wire compatibility with the
+/// pre-refactor path is byte-identical (pinned by `WireFormatTests`).
+///
+/// - Important: `payload` must be JSON-serializable
+///   (`JSONSerialization.isValidJSONObject(["x": payload])` must return
+///   true). The production sink `SpanMetricsCollector` validates this at
+///   the boundary and drops invalid payloads with a `Log.d`, but callers
+///   should still hand in dicts / arrays of strings, numbers, and bools —
+///   not class instances, `Decimal`, `Date`, etc.
+///
+/// Named `VitalsMetric` rather than `Metric` to avoid a filename collision
+/// with the bundled OTel SDK's own `Metric.swift`.
+struct VitalsMetric {
+    let name: String
+    let payload: Any
+}
+
+extension Array where Element == VitalsMetric {
+    /// Re-flattens `[VitalsMetric]` back to the `[String: Any]` shape the
+    /// legacy `metricsManagerClosure` path emitted. `SpanMetricsCollector`
+    /// uses this transform on the wire; `WireFormatTests` pins it to be
+    /// byte-identical to the pre-refactor payload.
+    func toDictionary() -> [String: Any] {
+        var dict: [String: Any] = [:]
+        for metric in self {
+            dict[metric.name] = metric.payload
+        }
+        return dict
+    }
+}

--- a/Coralogix/Sources/Utils/MobileVitals/ANRDetector.swift
+++ b/Coralogix/Sources/Utils/MobileVitals/ANRDetector.swift
@@ -24,11 +24,21 @@ internal class ANRDetector {
     // ANR handling closure (useful for testing)
     var handleANRClosure: (() -> Void)?
 
-    init(checkInterval: TimeInterval = 1.0, maxBlockTime: TimeInterval = 5.0, clock: CoralogixInternal.Clock = SystemClock()) {
+    /// Injected typed event sink (CX-40573). Reserved for the follow-up
+    /// ticket that migrates ANR delivery off `MetricsManager.handleANREvent`
+    /// onto self-pushing detectors. Stored but not invoked here yet so the
+    /// existing wire format stays untouched.
+    let eventReporter: EventReporter?
+
+    init(checkInterval: TimeInterval = 1.0,
+         maxBlockTime: TimeInterval = 5.0,
+         clock: CoralogixInternal.Clock = SystemClock(),
+         eventReporter: EventReporter? = nil) {
         self.checkInterval = checkInterval
         self.maxBlockTime = maxBlockTime
         self.clock = clock
         self.lastCheckTimestamp = clock.now()
+        self.eventReporter = eventReporter
     }
 
     func startMonitoring() {

--- a/Coralogix/Sources/Utils/MobileVitals/CPUDetector.swift
+++ b/Coralogix/Sources/Utils/MobileVitals/CPUDetector.swift
@@ -54,9 +54,16 @@ final class CPUDetector {
     var avgMainThreadMs: Double { mainThreadDeltaMsSamples.isEmpty ? 0 : mainThreadDeltaMsSamples.reduce(0, +) / Double(mainThreadDeltaMsSamples.count) }
     var p95MainThreadMs: Double { percentile95(of: mainThreadDeltaMsSamples) }
 
-    init(checkInterval: TimeInterval = 1.0) {
+    /// Injected metrics sink (CX-40573). Reserved for the follow-up ticket
+    /// that migrates the pull-based send loop in `MetricsManager` onto
+    /// self-pushing detectors. Stored but not invoked here yet.
+    let metricsCollector: MetricsCollector?
+
+    init(checkInterval: TimeInterval = 1.0,
+         metricsCollector: MetricsCollector? = nil) {
         mach_timebase_info(&timebase)
         self.checkInterval = max(checkInterval, minInterval)
+        self.metricsCollector = metricsCollector
     }
     
     public func startMonitoring() {

--- a/Coralogix/Sources/Utils/MobileVitals/MemoryDetector.swift
+++ b/Coralogix/Sources/Utils/MobileVitals/MemoryDetector.swift
@@ -27,6 +27,15 @@ final class MemoryDetector {
     // Memory changes slowly (seconds), so 1s provides accurate min/max/avg/p95 statistics
     // See CX-31659 for analysis and rationale
     private let defaultInterval: TimeInterval = 1.0
+
+    /// Injected metrics sink (CX-40573). Reserved for the follow-up ticket
+    /// that migrates the pull-based send loop in `MetricsManager` onto
+    /// self-pushing detectors. Stored but not invoked here yet.
+    let metricsCollector: MetricsCollector?
+
+    init(metricsCollector: MetricsCollector? = nil) {
+        self.metricsCollector = metricsCollector
+    }
     
     // MARK: - Stored samples (instantaneous per sample)
     internal var footprintSamples: [Double] = []       // MB

--- a/Coralogix/Sources/Utils/MobileVitals/MetricsManager.swift
+++ b/Coralogix/Sources/Utils/MobileVitals/MetricsManager.swift
@@ -20,9 +20,27 @@ public class MetricsManager {
     var memoryDetector: MemoryDetector?
     var slowFrozenFramesDetector: SlowFrozenFramesDetector?
     var fpsDetector = FPSDetector()
+
+    // MARK: - Reporting dependencies (CX-40573)
+    //
+    // When set, these protocol-typed sinks take precedence over the legacy
+    // closure properties below. Production wires `SpanMetricsCollector` /
+    // `SpanEventReporter`; the wire format produced by either path is
+    // byte-identical to the dict the deprecated closures emit — pinned by
+    // `WireFormatTests`.
+    //
+    // Threading: expected to be set once during init on the main thread.
+    // Subsequent reads from background callbacks (MetricKit, ANR timer)
+    // are unsynchronized; do not mutate after init.
+    var metricsCollector: MetricsCollector?
+    var eventReporter: EventReporter?
+
+    // MARK: - Legacy closure fallbacks (deprecated)
+    @available(*, deprecated, message: "Inject a MetricsCollector via the new metricsCollector property instead. Closure-based wiring will be removed in a future major release.")
     var metricsManagerClosure: (([String: Any]) -> Void)?
+    @available(*, deprecated, message: "Inject an EventReporter via the new eventReporter property instead. Closure-based wiring will be removed in a future major release.")
     var anrErrorClosure: ((String, String) -> Void)?
-    
+
     // MARK: - Internal timer for periodic send
     private let sendInterval: TimeInterval = 15.0
     private var lastSendTime: Date?
@@ -30,17 +48,44 @@ public class MetricsManager {
                 
     public func addMetricKitObservers() {
         MyMetricSubscriber.shared.metricKitClosure = { [weak self] dict in
-            self?.metricsManagerClosure?(dict)
+            self?.emitMetricKitPayload(dict)
         }
         MyMetricSubscriber.shared.hangDiagnosticClosure = { [weak self] message, errorType in
             guard let self = self else { return }
-            guard let anrErrorClosure = self.anrErrorClosure else {
-                Log.d("[MetricsManager] Warning: anrErrorClosure not set, MetricKit hang not reported")
-                return
-            }
-            anrErrorClosure(message, errorType)
+            self.reportANR(message: message, errorType: errorType, source: "MetricKit hang")
         }
         MXMetricManager.shared.add(MyMetricSubscriber.shared)
+    }
+
+    /// Re-emits a category-keyed dict (`{ "<category>": <payload> }`) — used
+    /// by MetricKit and the cold/warm detectors — through whichever sink is
+    /// wired, preferring the protocol path. The shape sent on the wire is
+    /// byte-identical either way (pinned by `WireFormatTests`).
+    private func emitMetricKitPayload(_ dict: [String: Any]) {
+        if let metricsCollector = self.metricsCollector {
+            // Pass the value through as-is: `VitalsMetric.payload` is typed
+            // `Any` precisely so the dict / array shape produced by the
+            // upstream producer reaches the collector unchanged.
+            let metrics: [VitalsMetric] = dict.map { VitalsMetric(name: $0.key, payload: $0.value) }
+            metricsCollector.collect(metrics)
+            return
+        }
+        self.metricsManagerClosure?(dict)
+    }
+
+    /// Routes an ANR-shaped event through whichever sink is wired. Uses the
+    /// typed `ANRErrorEvent` (from CX-40572) when going through the protocol;
+    /// falls back to the deprecated closure otherwise.
+    private func reportANR(message: String, errorType: String, source: String) {
+        if let eventReporter = self.eventReporter {
+            eventReporter.report(ANRErrorEvent(errorMessage: message, errorType: errorType))
+            return
+        }
+        guard let anrErrorClosure = self.anrErrorClosure else {
+            Log.d("[MetricsManager] Warning: no eventReporter or anrErrorClosure set, \(source) not reported")
+            return
+        }
+        anrErrorClosure(message, errorType)
     }
     
     public func removeObservers() {
@@ -50,32 +95,38 @@ public class MetricsManager {
     }
     
     public func sendMobileVitals() {
-        var vitals = [String: Any]()
+        // Build a [VitalsMetric] in the same category order used by the
+        // legacy dict path. The dict and the protocol path are equivalent —
+        // see `WireFormatTests.testMetricsManager_sendMobileVitals_*`.
+        var metrics: [VitalsMetric] = []
         if let cpuDetector = cpuDetector {
-            vitals[Keys.cpu.rawValue] = cpuDetector.statsDictionary()
+            metrics.append(VitalsMetric(name: Keys.cpu.rawValue, payload: cpuDetector.statsDictionary()))
         }
-        
         if let memoryDetector = memoryDetector {
-            vitals[Keys.memory.rawValue] = memoryDetector.statsDictionary()
+            metrics.append(VitalsMetric(name: Keys.memory.rawValue, payload: memoryDetector.statsDictionary()))
         }
-        
         if let slowFrozenFramesDetector = slowFrozenFramesDetector {
-            vitals[Keys.slowFrozen.rawValue] = slowFrozenFramesDetector.statsDictionary()
+            metrics.append(VitalsMetric(name: Keys.slowFrozen.rawValue, payload: slowFrozenFramesDetector.statsDictionary()))
         }
-        
-        // Only include FPS if rendering detector is running
         if fpsDetector.isRunning {
-            vitals[MobileVitalsType.fps.stringValue] = fpsDetector.statsDictionary()
+            metrics.append(VitalsMetric(name: MobileVitalsType.fps.stringValue, payload: fpsDetector.statsDictionary()))
         }
-        
-        // Don't send if no vitals collected
-        guard !vitals.isEmpty else {
+
+        guard !metrics.isEmpty else {
             Log.d("[MetricsManager] No vitals to send, skipping")
             return
         }
-        
-        // Send event
-        self.metricsManagerClosure?(vitals)
+
+        if let metricsCollector = self.metricsCollector {
+            metricsCollector.collect(metrics)
+        } else {
+            // Legacy closure path — reconstruct the same dict shape callers
+            // have always received. Inlined so the fallback doesn't require
+            // a separate `MetricsCollector` impl; `WireFormatTests` pins
+            // this reconstruction to be byte-identical to
+            // `[VitalsMetric].toDictionary()`.
+            self.metricsManagerClosure?(metrics.toDictionary())
+        }
         lastSendTime = Date()
 
         // Reset stats after sending
@@ -120,17 +171,17 @@ public class MetricsManager {
         guard coldDetector == nil else { return }
         let detector = ColdDetector()
         detector.handleColdClosure = { [weak self] dict in
-            self?.metricsManagerClosure?(dict)
+            self?.emitMetricKitPayload(dict)
         }
         detector.startMonitoring()
         self.coldDetector = detector
     }
-    
+
     func startWarmStartMonitoring() {
         guard warmDetector == nil else { return }
         let detector = WarmDetector()
         detector.handleWarmClosure = { [weak self] dict in
-            self?.metricsManagerClosure?(dict)
+            self?.emitMetricKitPayload(dict)
         }
         detector.startMonitoring()
         self.warmDetector = detector
@@ -147,14 +198,7 @@ public class MetricsManager {
     private func handleANREvent() {
         let errorMessage = WireValues.anrErrorMessage.rawValue
         let errorType = WireValues.anrErrorType.rawValue
-        
-        // Report ANR as error (not mobile vitals)
-        guard let anrErrorClosure = self.anrErrorClosure else {
-            Log.d("[MetricsManager] Warning: anrErrorClosure not set, ANR event not reported")
-            return
-        }
-        
-        anrErrorClosure(errorMessage, errorType)
+        reportANR(message: errorMessage, errorType: errorType, source: "ANR event")
         Log.d("[MetricsManager] ANR error reported: \(errorMessage)")
     }
     

--- a/Coralogix/Sources/Utils/MobileVitals/MetricsManager.swift
+++ b/Coralogix/Sources/Utils/MobileVitals/MetricsManager.swift
@@ -31,9 +31,24 @@ public class MetricsManager {
     //
     // Threading: expected to be set once during init on the main thread.
     // Subsequent reads from background callbacks (MetricKit, ANR timer)
-    // are unsynchronized; do not mutate after init.
-    var metricsCollector: MetricsCollector?
-    var eventReporter: EventReporter?
+    // are unsynchronized; do not mutate after init. The `didSet` observers
+    // below surface a `Log.e` if the invariant is violated — it can't be a
+    // `precondition` because the SDK must never crash the host app
+    // (see CLAUDE.md).
+    var metricsCollector: MetricsCollector? {
+        didSet {
+            if oldValue != nil {
+                Log.e("[MetricsManager] metricsCollector reassigned after init — this races background-thread reads (MetricKit/timer callbacks). Set once during init only.")
+            }
+        }
+    }
+    var eventReporter: EventReporter? {
+        didSet {
+            if oldValue != nil {
+                Log.e("[MetricsManager] eventReporter reassigned after init — this races background-thread reads (ANR/MetricKit callbacks). Set once during init only.")
+            }
+        }
+    }
 
     // MARK: - Legacy closure fallbacks (deprecated)
     @available(*, deprecated, message: "Inject a MetricsCollector via the new metricsCollector property instead. Closure-based wiring will be removed in a future major release.")

--- a/Coralogix/Sources/Utils/MobileVitals/RenderingDetector.swift
+++ b/Coralogix/Sources/Utils/MobileVitals/RenderingDetector.swift
@@ -51,7 +51,16 @@ class FPSDetector {
     internal var isRunning = false
     static let defaultInterval: TimeInterval = 1.0 // second
     internal var samples: [Double] = []
-    
+
+    /// Injected metrics sink (CX-40573). Reserved for the follow-up ticket
+    /// that migrates the pull-based send loop in `MetricsManager` onto
+    /// self-pushing detectors. Stored but not invoked here yet.
+    let metricsCollector: MetricsCollector?
+
+    init(metricsCollector: MetricsCollector? = nil) {
+        self.metricsCollector = metricsCollector
+    }
+
     // MARK: - Public stats
     var minFPS: Double { samples.min() ?? 0 }
     var maxFPS: Double { samples.max() ?? 0 }

--- a/Coralogix/Sources/Utils/MobileVitals/SlowFrozenFramesDetector.swift
+++ b/Coralogix/Sources/Utils/MobileVitals/SlowFrozenFramesDetector.swift
@@ -110,6 +110,11 @@ final class SlowFrozenFramesDetector {
     
     
     
+    /// Injected metrics sink (CX-40573). Reserved for the follow-up ticket
+    /// that migrates the pull-based send loop in `MetricsManager` onto
+    /// self-pushing detectors. Stored but not invoked here yet.
+    let metricsCollector: MetricsCollector?
+
     // MARK: - Init
     /// Creates a new slow/frozen frame detector.
     ///
@@ -119,14 +124,17 @@ final class SlowFrozenFramesDetector {
     ///     Industry thresholds range from 250ms (sensitive) to 700ms (severe freezes only).
     ///   - reportIntervalMs: Window size for aggregating frame counts. Default 60s.
     ///   - tolerancePercentage: Tolerance for slow frame detection. Default 3% to prevent false positives.
+    ///   - metricsCollector: See `metricsCollector` property doc. Reserved for follow-up; pass nil today.
     init(
         frozenThresholdMs: Double = 700.0,
         reportIntervalMs: Int64 = 60_000,
-        tolerancePercentage: Double = 0.03
+        tolerancePercentage: Double = 0.03,
+        metricsCollector: MetricsCollector? = nil
     ) {
         self.frozenThresholdMs = frozenThresholdMs
         self.reportIntervalMs = reportIntervalMs
         self.tolerancePercentage = tolerancePercentage
+        self.metricsCollector = metricsCollector
         updateRefreshRateAndBudget()
     }
 

--- a/Tests/CoralogixRumTests/MobileVitalsTests/WireFormatTests.swift
+++ b/Tests/CoralogixRumTests/MobileVitalsTests/WireFormatTests.swift
@@ -272,7 +272,7 @@ final class WireFormatTests: XCTestCase {
         }
         let rebuilt = metrics.toDictionary()
 
-        XCTAssertEqual(jsonString(original), jsonString(rebuilt),
+        XCTAssertEqual(try jsonString(original), try jsonString(rebuilt),
                        "Round-trip dict must be byte-identical to the legacy payload")
     }
 
@@ -286,7 +286,7 @@ final class WireFormatTests: XCTestCase {
         let closureDict = try captureSendMobileVitals(useProtocolPath: false)
         let protocolDict = try captureSendMobileVitals(useProtocolPath: true)
 
-        XCTAssertEqual(jsonString(closureDict), jsonString(protocolDict),
+        XCTAssertEqual(try jsonString(closureDict), try jsonString(protocolDict),
                        "Protocol path must produce the same bytes as the closure path")
     }
 
@@ -343,10 +343,13 @@ final class WireFormatTests: XCTestCase {
 
     /// Deterministic JSON serialization for dict equality.
     /// Uses `.sortedKeys` so dict ordering can't smuggle in a false positive.
-    private func jsonString(_ dict: [String: Any]) -> String {
-        guard let data = try? JSONSerialization.data(withJSONObject: dict, options: [.sortedKeys]),
-              let str = String(data: data, encoding: .utf8) else {
-            return "<unserializable>"
+    /// Throws on any serialization failure — never returns a sentinel — so a
+    /// silently-broken payload can't make two failed-encode calls compare equal.
+    private func jsonString(_ dict: [String: Any]) throws -> String {
+        let data = try JSONSerialization.data(withJSONObject: dict, options: [.sortedKeys])
+        guard let str = String(data: data, encoding: .utf8) else {
+            throw NSError(domain: "WireFormatTests", code: 1,
+                          userInfo: [NSLocalizedDescriptionKey: "JSON data was not valid UTF-8"])
         }
         return str
     }

--- a/Tests/CoralogixRumTests/MobileVitalsTests/WireFormatTests.swift
+++ b/Tests/CoralogixRumTests/MobileVitalsTests/WireFormatTests.swift
@@ -1,0 +1,375 @@
+//
+//  WireFormatTests.swift
+//
+//
+//  Created by Coralogix DEV TEAM on 20/05/2026.
+//
+//  Pins the exact dict shape each MetricsManager / detector emits. The
+//  EventReporter / MetricsCollector refactor (CX-40573) must preserve these
+//  shapes byte-for-byte — these tests are the contract.
+//
+//  Three layers, in order:
+//   1. Schema pins — key set + leaf type for each statsDictionary() and
+//      the MetricsManager.sendMobileVitals() aggregate.
+//   2. Round-trip — [String: Any] -> [VitalsMetric] -> toDictionary() is
+//      byte-identical to the legacy payload.
+//   3. End-to-end — protocol path produces the same JSON as the closure
+//      path, both for sendMobileVitals() and for ANR.
+//
+//  We pin *key set and leaf type* at every nesting level, not the float
+//  values (which depend on live stats and would be flaky).
+
+import XCTest
+import CoralogixInternal
+@testable import Coralogix
+
+final class WireFormatTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    /// Returns a sorted list of `"path: <typeLabel>"` entries describing the
+    /// nested dict structure. Dict children recurse; leaves render their type.
+    private func schema(_ value: Any, prefix: String = "") -> [String] {
+        if let dict = value as? [String: Any] {
+            return dict.keys.sorted().flatMap { key -> [String] in
+                let path = prefix.isEmpty ? key : "\(prefix).\(key)"
+                return schema(dict[key] as Any, prefix: path)
+            }
+        }
+        return ["\(prefix): \(typeLabel(of: value))"]
+    }
+
+    /// Coarse type label so the snapshot survives Int vs Int64 differences
+    /// from JSONSerialization, but still catches String vs numeric swaps.
+    private func typeLabel(of value: Any) -> String {
+        switch value {
+        case is String: return "String"
+        case is Bool:   return "Bool"
+        case is Int, is Int32, is Int64, is UInt, is UInt32, is UInt64: return "Int"
+        case is Double, is Float, is CGFloat: return "Double"
+        default: return String(describing: Swift.type(of: value))
+        }
+    }
+
+    // MARK: - Per-detector statsDictionary() pins
+
+    func testCPUDetector_statsDictionary_schema() {
+        let detector = CPUDetector()
+        XCTAssertEqual(schema(detector.statsDictionary()), [
+            "cpu_usage.avg: Double",
+            "cpu_usage.max: Double",
+            "cpu_usage.min: Double",
+            "cpu_usage.p95: Double",
+            "cpu_usage.units: String",
+            "main_thread_cpu_time.avg: Double",
+            "main_thread_cpu_time.max: Double",
+            "main_thread_cpu_time.min: Double",
+            "main_thread_cpu_time.p95: Double",
+            "main_thread_cpu_time.units: String",
+            "total_cpu_time.avg: Double",
+            "total_cpu_time.max: Double",
+            "total_cpu_time.min: Double",
+            "total_cpu_time.p95: Double",
+            "total_cpu_time.units: String"
+        ])
+    }
+
+    func testMemoryDetector_statsDictionary_schema() {
+        let detector = MemoryDetector()
+        XCTAssertEqual(schema(detector.statsDictionary()), [
+            "footprint_memory.avg: Double",
+            "footprint_memory.max: Double",
+            "footprint_memory.min: Double",
+            "footprint_memory.p95: Double",
+            "footprint_memory.units: String",
+            "memory_utilization.avg: Double",
+            "memory_utilization.max: Double",
+            "memory_utilization.min: Double",
+            "memory_utilization.p95: Double",
+            "memory_utilization.units: String",
+            "resident_memory.avg: Double",
+            "resident_memory.max: Double",
+            "resident_memory.min: Double",
+            "resident_memory.p95: Double",
+            "resident_memory.units: String"
+        ])
+    }
+
+    func testSlowFrozenFramesDetector_statsDictionary_schema() {
+        let detector = SlowFrozenFramesDetector()
+        XCTAssertEqual(schema(detector.statsDictionary()), [
+            "frozen_frames.avg: Double",
+            "frozen_frames.max: Double",
+            "frozen_frames.min: Double",
+            "frozen_frames.p95: Double",
+            "frozen_frames.units: String",
+            "slow_frames.avg: Double",
+            "slow_frames.max: Double",
+            "slow_frames.min: Double",
+            "slow_frames.p95: Double",
+            "slow_frames.units: String"
+        ])
+    }
+
+    func testFPSDetector_statsDictionary_schema() {
+        let detector = FPSDetector()
+        XCTAssertEqual(schema(detector.statsDictionary()), [
+            "avg: Double",
+            "max: Double",
+            "min: Double",
+            "p95: Double",
+            "units: String"
+        ])
+    }
+
+    // MARK: - MetricsManager.sendMobileVitals() aggregate pin
+
+    func testMetricsManager_sendMobileVitals_aggregateSchema_allDetectorsActive() {
+        let manager = MetricsManager()
+        // Wire up all detectors so the aggregate dict reaches its maximum shape.
+        manager.cpuDetector = CPUDetector()
+        manager.memoryDetector = MemoryDetector()
+        manager.slowFrozenFramesDetector = SlowFrozenFramesDetector()
+        manager.fpsDetector.isRunning = true  // FPS is only included when its detector is running
+
+        var captured: [String: Any]?
+        manager.metricsManagerClosure = { dict in captured = dict }
+
+        manager.sendMobileVitals()
+
+        guard let dict = captured else {
+            XCTFail("metricsManagerClosure was not invoked")
+            return
+        }
+
+        XCTAssertEqual(schema(dict), [
+            "cpu.cpu_usage.avg: Double",
+            "cpu.cpu_usage.max: Double",
+            "cpu.cpu_usage.min: Double",
+            "cpu.cpu_usage.p95: Double",
+            "cpu.cpu_usage.units: String",
+            "cpu.main_thread_cpu_time.avg: Double",
+            "cpu.main_thread_cpu_time.max: Double",
+            "cpu.main_thread_cpu_time.min: Double",
+            "cpu.main_thread_cpu_time.p95: Double",
+            "cpu.main_thread_cpu_time.units: String",
+            "cpu.total_cpu_time.avg: Double",
+            "cpu.total_cpu_time.max: Double",
+            "cpu.total_cpu_time.min: Double",
+            "cpu.total_cpu_time.p95: Double",
+            "cpu.total_cpu_time.units: String",
+            "fps.avg: Double",
+            "fps.max: Double",
+            "fps.min: Double",
+            "fps.p95: Double",
+            "fps.units: String",
+            "memory.footprint_memory.avg: Double",
+            "memory.footprint_memory.max: Double",
+            "memory.footprint_memory.min: Double",
+            "memory.footprint_memory.p95: Double",
+            "memory.footprint_memory.units: String",
+            "memory.memory_utilization.avg: Double",
+            "memory.memory_utilization.max: Double",
+            "memory.memory_utilization.min: Double",
+            "memory.memory_utilization.p95: Double",
+            "memory.memory_utilization.units: String",
+            "memory.resident_memory.avg: Double",
+            "memory.resident_memory.max: Double",
+            "memory.resident_memory.min: Double",
+            "memory.resident_memory.p95: Double",
+            "memory.resident_memory.units: String",
+            "slow_frozen.frozen_frames.avg: Double",
+            "slow_frozen.frozen_frames.max: Double",
+            "slow_frozen.frozen_frames.min: Double",
+            "slow_frozen.frozen_frames.p95: Double",
+            "slow_frozen.frozen_frames.units: String",
+            "slow_frozen.slow_frames.avg: Double",
+            "slow_frozen.slow_frames.max: Double",
+            "slow_frozen.slow_frames.min: Double",
+            "slow_frozen.slow_frames.p95: Double",
+            "slow_frozen.slow_frames.units: String"
+        ])
+    }
+
+    func testMetricsManager_sendMobileVitals_skipsEmptyPayload() {
+        // Guard against silent regression: when no detector is attached and
+        // FPS isn't running, sendMobileVitals() must NOT call the closure.
+        let manager = MetricsManager()
+        var callCount = 0
+        manager.metricsManagerClosure = { _ in callCount += 1 }
+        manager.sendMobileVitals()
+        XCTAssertEqual(callCount, 0, "Empty vitals payload must not be sent")
+    }
+
+    // MARK: - Cold / Warm / MetricKit single-shot payload pins
+    //
+    // These three emit ad-hoc dicts (not via sendMobileVitals). The structures
+    // are tiny and stable — pin them so a refactor can't quietly rename keys.
+
+    func testColdDetector_payloadSchema() {
+        // The cold payload shape (no good seam to drive it without UIApplication
+        // notifications) — assert the constants the producer uses so any rename
+        // forces a wire-format reckoning.
+        XCTAssertEqual(MobileVitalsType.cold.stringValue, "cold")
+        XCTAssertEqual(Keys.mobileVitalsUnits.rawValue, "units")
+        XCTAssertEqual(Keys.value.rawValue, "value")
+        XCTAssertEqual(MeasurementUnits.milliseconds.stringValue, "ms")
+    }
+
+    func testWarmDetector_payloadSchema() {
+        XCTAssertEqual(MobileVitalsType.warm.stringValue, "warm")
+        XCTAssertEqual(Keys.mobileVitalsUnits.rawValue, "units")
+        XCTAssertEqual(Keys.value.rawValue, "value")
+    }
+
+    func testMetricKit_payloadSchema() {
+        // Producer in MetricsManager.swift:256-260 emits:
+        //   { metric_kit: { name: "<json-string>" } }
+        XCTAssertEqual(Keys.metricKit.rawValue, "metric_kit")
+        XCTAssertEqual(Keys.name.rawValue, "name")
+    }
+
+    // MARK: - Round-trip: dict → [VitalsMetric] → toDictionary() → dict
+    //
+    // Pins the contract the production `SpanMetricsCollector` relies on:
+    // a dict shaped like the legacy `metricsManagerClosure` payload must
+    // round-trip byte-identical through the new `[VitalsMetric]` value
+    // type. `SpanMetricsCollector.collect` calls `toDictionary()` and
+    // JSON-encodes the result onto a span attribute — so this property
+    // is what guarantees wire compatibility.
+
+    func testVitalsMetric_toDictionary_roundTripsLegacyDict() throws {
+        let original: [String: Any] = [
+            Keys.cpu.rawValue: [
+                MobileVitalsType.cpuUsage.stringValue: [
+                    Keys.mobileVitalsUnits.rawValue: MeasurementUnits.percentage.stringValue,
+                    Keys.min.rawValue: 1.0,
+                    Keys.max.rawValue: 9.0,
+                    Keys.avg.rawValue: 4.5,
+                    Keys.p95.rawValue: 8.5
+                ]
+            ],
+            Keys.memory.rawValue: [
+                MobileVitalsType.footprintMemory.stringValue: [
+                    Keys.mobileVitalsUnits.rawValue: MeasurementUnits.megaBytes.stringValue,
+                    Keys.min.rawValue: 50.0,
+                    Keys.max.rawValue: 120.0,
+                    Keys.avg.rawValue: 80.0,
+                    Keys.p95.rawValue: 110.0
+                ]
+            ],
+            MobileVitalsType.fps.stringValue: [
+                Keys.mobileVitalsUnits.rawValue: MeasurementUnits.fps.stringValue,
+                Keys.min.rawValue: 30.0,
+                Keys.max.rawValue: 60.0,
+                Keys.avg.rawValue: 55.0,
+                Keys.p95.rawValue: 59.0
+            ]
+        ]
+
+        let metrics: [VitalsMetric] = original.map { (key, value) in
+            VitalsMetric(name: key, payload: value as? [String: Any] ?? [:])
+        }
+        let rebuilt = metrics.toDictionary()
+
+        XCTAssertEqual(jsonString(original), jsonString(rebuilt),
+                       "Round-trip dict must be byte-identical to the legacy payload")
+    }
+
+    // MARK: - End-to-end: protocol path emits the same bytes as the closure path
+
+    func testMetricsManager_protocolPath_equalsClosurePath_endToEnd() throws {
+        // Run sendMobileVitals() twice with identical state — first via the
+        // deprecated closure, then via the new MetricsCollector — and assert
+        // the captured dicts serialize to the same JSON.
+
+        let closureDict = try captureSendMobileVitals(useProtocolPath: false)
+        let protocolDict = try captureSendMobileVitals(useProtocolPath: true)
+
+        XCTAssertEqual(jsonString(closureDict), jsonString(protocolDict),
+                       "Protocol path must produce the same bytes as the closure path")
+    }
+
+    private func captureSendMobileVitals(useProtocolPath: Bool) throws -> [String: Any] {
+        let manager = MetricsManager()
+        manager.cpuDetector = CPUDetector()
+        manager.memoryDetector = MemoryDetector()
+        manager.slowFrozenFramesDetector = SlowFrozenFramesDetector()
+        manager.fpsDetector.isRunning = true
+
+        var captured: [String: Any]?
+        if useProtocolPath {
+            manager.metricsCollector = RecordingMetricsCollector { dict in captured = dict }
+        } else {
+            manager.metricsManagerClosure = { dict in captured = dict }
+        }
+
+        manager.sendMobileVitals()
+        return try XCTUnwrap(captured, "sendMobileVitals did not emit on \(useProtocolPath ? "protocol" : "closure") path")
+    }
+
+    // MARK: - End-to-end ANR equivalence
+
+    func testANR_protocolPath_equalsClosurePath_endToEnd() {
+        // Capture (message, errorType) via the closure path…
+        let viaClosure = captureANR(useProtocolPath: false)
+
+        // …and capture the same fields from the typed ANRErrorEvent on the protocol path.
+        let viaProtocol = captureANR(useProtocolPath: true)
+
+        XCTAssertEqual(viaClosure?.message, viaProtocol?.message)
+        XCTAssertEqual(viaClosure?.errorType, viaProtocol?.errorType)
+        XCTAssertEqual(viaClosure?.message, WireValues.anrErrorMessage.rawValue)
+        XCTAssertEqual(viaClosure?.errorType, WireValues.anrErrorType.rawValue)
+    }
+
+    private func captureANR(useProtocolPath: Bool) -> (message: String, errorType: String)? {
+        let manager = MetricsManager()
+        var captured: (message: String, errorType: String)?
+        if useProtocolPath {
+            manager.eventReporter = RecordingEventReporter { event in
+                guard let anr = event as? ANRErrorEvent else { return }
+                captured = (anr.errorMessage, anr.errorType)
+            }
+        } else {
+            manager.anrErrorClosure = { msg, type in captured = (msg, type) }
+        }
+        manager.startANRMonitoring()
+        manager.anrDetector?.handleANR()
+        return captured
+    }
+
+    // MARK: - JSON helper
+
+    /// Deterministic JSON serialization for dict equality.
+    /// Uses `.sortedKeys` so dict ordering can't smuggle in a false positive.
+    private func jsonString(_ dict: [String: Any]) -> String {
+        guard let data = try? JSONSerialization.data(withJSONObject: dict, options: [.sortedKeys]),
+              let str = String(data: data, encoding: .utf8) else {
+            return "<unserializable>"
+        }
+        return str
+    }
+}
+
+// MARK: - Test doubles
+
+/// Records the `[VitalsMetric]` batch and re-emits it as the legacy dict
+/// shape so the wire-format equivalence tests can compare bytes against
+/// the closure path. Lives in the test target only; production uses
+/// `SpanMetricsCollector`.
+private struct RecordingMetricsCollector: MetricsCollector {
+    let onDict: ([String: Any]) -> Void
+    func collect(_ metrics: [VitalsMetric]) {
+        guard !metrics.isEmpty else { return }
+        onDict(metrics.toDictionary())
+    }
+}
+
+/// Records a `TelemetryEvent` for assertions. Test-target only.
+private struct RecordingEventReporter: EventReporter {
+    let onEvent: (TelemetryEvent) -> Void
+    func report(_ event: TelemetryEvent) {
+        onEvent(event)
+    }
+}


### PR DESCRIPTION
# User description
## Summary
- New `EventReporter` / `MetricsCollector` protocols (`Coralogix/Sources/Model/Reporting/`) plus `VitalsMetric` value type.
- Production sinks `SpanMetricsCollector` / `SpanEventReporter` replace the closure-on-MetricsManager glue at the orchestrator (`CoralogixRum.setupCoreModules`) and ANR call site (`ANRInstrumentation.initializeANRInstrumentation`).
- Public hybrid `reportMobileVitalsMeasurement` overloads route through the new collector; defensive `Log.d` fires when the collector is not wired.
- Closure properties on `MetricsManager` remain as `@available(*, deprecated)` fallbacks until external test seams migrate.
- Init injection added to `ANRDetector`, `CPUDetector`, `MemoryDetector`, `RenderingDetector` (`FPSDetector`), `SlowFrozenFramesDetector` — reserved for the next ticket; stored but not used yet.

## Wire-format safety net
`Tests/CoralogixRumTests/MobileVitalsTests/WireFormatTests.swift` adds 13 tests in three layers:
1. **Schema pins** — exact key set + leaf type for each `statsDictionary()` and the `sendMobileVitals()` aggregate.
2. **Round-trip** — `[String: Any] → [VitalsMetric] → toDictionary() → [String: Any]` is byte-identical.
3. **End-to-end equivalence** — protocol path produces the same JSON as the legacy closure path (`testMetricsManager_protocolPath_equalsClosurePath_endToEnd`) for vitals and for ANR.

## Jira
[CX-40573](https://coralogix.atlassian.net/browse/CX-40573) — parent epic [CX-40569 — iOS SDK Strategic Refactoring](https://coralogix.atlassian.net/browse/CX-40569).

## Test plan
- [x] `xcodebuild test -scheme Coralogix-Package -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.2'` — 641 tests pass, 0 failures.
- [x] Build clean (`xcodebuild build`); deprecation warnings on legacy closure self-uses are intentional and document the migration path.
- [ ] Reviewer: drop into the demo app and confirm a vitals span lands with the same `mobileVitalsType` attribute shape as today.
- [ ] Reviewer: confirm the boundary `JSONSerialization.isValidJSONObject` check in `SpanMetricsCollector` is acceptable as the validation seam (alternative would be a typed `VitalsPayload` enum, deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CX-40573]: https://coralogix.atlassian.net/browse/CX-40573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Introduce EventReporter and MetricsCollector protocols so MetricsManager, detectors, and instrumentation route telemetry through typed sinks instead of legacy closures. Ensure SpanMetricsCollector, SpanEventReporter, and the new VitalsMetric type preserve the existing wire format while supporting mobile vitals and ANR flows.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/207?tool=ast&topic=Protocol+wiring>Protocol wiring</a>
        </td><td>Route mobile vitals and ANR reporting through the new EventReporter/MetricsCollector protocols by injecting SpanMetricsCollector/SpanEventReporter, wiring them via CoralogixRum/MetricsManager, and adding the VitalsMetric model while keeping deprecated closures as fallbacks.<details><summary>Modified files (14)</summary><ul><li>Coralogix/Sources/CoralogixRum.swift</li>
<li>Coralogix/Sources/Instrumentation/ANRInstrumentation.swift</li>
<li>Coralogix/Sources/Instrumentation/MobileVitalsInstrumentation.swift</li>
<li>Coralogix/Sources/Model/Reporting/EventReporter.swift</li>
<li>Coralogix/Sources/Model/Reporting/MetricsCollector.swift</li>
<li>Coralogix/Sources/Model/Reporting/SpanEventReporter.swift</li>
<li>Coralogix/Sources/Model/Reporting/SpanMetricsCollector.swift</li>
<li>Coralogix/Sources/Model/Reporting/VitalsMetric.swift</li>
<li>Coralogix/Sources/Utils/MobileVitals/ANRDetector.swift</li>
<li>Coralogix/Sources/Utils/MobileVitals/CPUDetector.swift</li>
<li>Coralogix/Sources/Utils/MobileVitals/MemoryDetector.swift</li>
<li>Coralogix/Sources/Utils/MobileVitals/MetricsManager.swift</li>
<li>Coralogix/Sources/Utils/MobileVitals/RenderingDetector.swift</li>
<li>Coralogix/Sources/Utils/MobileVitals/SlowFrozenFramesDetector.swift</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>feat(CX-40573): EventR...</td><td>May 20, 2026</td></tr>
<tr><td>aking618</td><td>Allow clearing user co...</td><td>February 19, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/207?tool=ast&topic=Wire+format+tests>Wire format tests</a>
        </td><td>Verify that schema pins, round-trip conversion, and end-to-end ANR/vitals behavior keep the wired JSON identical to the legacy closure path.<details><summary>Modified files (1)</summary><ul><li>Tests/CoralogixRumTests/MobileVitalsTests/WireFormatTests.swift</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>test(CX-40573): make j...</td><td>May 21, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/coralogix/cx-ios-sdk/207?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New public method for Mobile Vitals instrumentation initialization
  * ANR events now capture screenshots

* **Deprecations**
  * Legacy mobile vitals closure callback marked deprecated
  * Legacy ANR error closure callback marked deprecated

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coralogix/cx-ios-sdk/pull/207?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->