### PR TITLE
feat(CX-43340): self-pushing detectors via injected EventReporter/MetricsCollector

### DIFF
--- a/Coralogix/Sources/Instrumentation/NavigationInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/NavigationInstrumentation.swift
@@ -26,7 +26,7 @@ extension CoralogixRum {
             if viewManager.isUniqueView(name: cxView.name) {
                 // Only send mobile vitals if instrumentation is enabled
                 if options?.shouldInitInstrumentation(instrumentation: .mobileVitals) == true {
-                    metricsManager.sendMobileVitals()
+                    metricsManager.flushAll()
                 }
                 
                 var span = makeSpan(event: .navigation, source: .console, severity: .info)

--- a/Coralogix/Sources/Utils/MobileVitals/ANRDetector.swift
+++ b/Coralogix/Sources/Utils/MobileVitals/ANRDetector.swift
@@ -24,10 +24,12 @@ internal class ANRDetector {
     // ANR handling closure (useful for testing)
     var handleANRClosure: (() -> Void)?
 
-    /// Injected typed event sink (CX-40573). Reserved for the follow-up
-    /// ticket that migrates ANR delivery off `MetricsManager.handleANREvent`
-    /// onto self-pushing detectors. Stored but not invoked here yet so the
-    /// existing wire format stays untouched.
+    /// Injected typed event sink (CX-40573 / CX-43340). When set,
+    /// `handleANR()` reports the ANR directly through this protocol instead
+    /// of routing through `MetricsManager.handleANREvent` via the legacy
+    /// `handleANRClosure`. Production wires `SpanEventReporter`; tests
+    /// inject a recorder. nil falls back to the closure path for backward
+    /// compatibility (closure removal is out of scope per CX-43340; covered by 1.5b).
     let eventReporter: EventReporter?
 
     init(checkInterval: TimeInterval = 1.0,
@@ -66,9 +68,17 @@ internal class ANRDetector {
     }
 
     public func handleANR() {
-        handleANRClosure?()
-
         let duration = clock.now().timeIntervalSince(lastCheckTimestamp)
         Log.d("[Metric] ANR detected: Main thread unresponsive for \(String(format: "%.2f", duration)) seconds")
+
+        if let eventReporter = eventReporter {
+            let event = ANRErrorEvent(
+                errorMessage: WireValues.anrErrorMessage.rawValue,
+                errorType: WireValues.anrErrorType.rawValue
+            )
+            eventReporter.report(event)
+            return
+        }
+        handleANRClosure?()
     }
 }

--- a/Coralogix/Sources/Utils/MobileVitals/CPUDetector.swift
+++ b/Coralogix/Sources/Utils/MobileVitals/CPUDetector.swift
@@ -54,9 +54,10 @@ final class CPUDetector {
     var avgMainThreadMs: Double { mainThreadDeltaMsSamples.isEmpty ? 0 : mainThreadDeltaMsSamples.reduce(0, +) / Double(mainThreadDeltaMsSamples.count) }
     var p95MainThreadMs: Double { percentile95(of: mainThreadDeltaMsSamples) }
 
-    /// Injected metrics sink (CX-40573). Reserved for the follow-up ticket
-    /// that migrates the pull-based send loop in `MetricsManager` onto
-    /// self-pushing detectors. Stored but not invoked here yet.
+    /// Injected metrics sink (CX-40573 / CX-43340). Invoked from `flush()`
+    /// to push this detector's CPU category through the protocol path.
+    /// Production wires `SpanMetricsCollector`; tests inject a recorder.
+    /// nil disables the push (the detector still samples; nothing is emitted).
     let metricsCollector: MetricsCollector?
 
     init(checkInterval: TimeInterval = 1.0,
@@ -64,6 +65,16 @@ final class CPUDetector {
         mach_timebase_info(&timebase)
         self.checkInterval = max(checkInterval, minInterval)
         self.metricsCollector = metricsCollector
+    }
+
+    /// Pushes one `VitalsMetric` for the CPU category through `metricsCollector`
+    /// and resets the accumulated samples so the next window starts fresh.
+    /// Called by `MetricsManager.flushAll()` on the periodic scheduler tick
+    /// and on view-change boundaries.
+    func flush() {
+        guard let metricsCollector = metricsCollector else { return }
+        metricsCollector.collect([VitalsMetric(name: Keys.cpu.rawValue, payload: statsDictionary())])
+        reset()
     }
     
     public func startMonitoring() {

--- a/Coralogix/Sources/Utils/MobileVitals/MemoryDetector.swift
+++ b/Coralogix/Sources/Utils/MobileVitals/MemoryDetector.swift
@@ -28,13 +28,24 @@ final class MemoryDetector {
     // See CX-31659 for analysis and rationale
     private let defaultInterval: TimeInterval = 1.0
 
-    /// Injected metrics sink (CX-40573). Reserved for the follow-up ticket
-    /// that migrates the pull-based send loop in `MetricsManager` onto
-    /// self-pushing detectors. Stored but not invoked here yet.
+    /// Injected metrics sink (CX-40573 / CX-43340). Invoked from `flush()`
+    /// to push this detector's memory category through the protocol path.
+    /// Production wires `SpanMetricsCollector`; tests inject a recorder.
+    /// nil disables the push (the detector still samples; nothing is emitted).
     let metricsCollector: MetricsCollector?
 
     init(metricsCollector: MetricsCollector? = nil) {
         self.metricsCollector = metricsCollector
+    }
+
+    /// Pushes one `VitalsMetric` for the memory category through `metricsCollector`
+    /// and resets the accumulated samples so the next window starts fresh.
+    /// Called by `MetricsManager.flushAll()` on the periodic scheduler tick
+    /// and on view-change boundaries.
+    func flush() {
+        guard let metricsCollector = metricsCollector else { return }
+        metricsCollector.collect([VitalsMetric(name: Keys.memory.rawValue, payload: statsDictionary())])
+        reset()
     }
     
     // MARK: - Stored samples (instantaneous per sample)

--- a/Coralogix/Sources/Utils/MobileVitals/MetricsManager.swift
+++ b/Coralogix/Sources/Utils/MobileVitals/MetricsManager.swift
@@ -19,7 +19,7 @@ public class MetricsManager {
     var cpuDetector: CPUDetector?
     var memoryDetector: MemoryDetector?
     var slowFrozenFramesDetector: SlowFrozenFramesDetector?
-    var fpsDetector = FPSDetector()
+    var fpsDetector: FPSDetector?
 
     // MARK: - Reporting dependencies (CX-40573)
     //
@@ -109,47 +109,36 @@ public class MetricsManager {
         self.stopSendScheduler()
     }
     
-    public func sendMobileVitals() {
-        // Build a [VitalsMetric] in the same category order used by the
-        // legacy dict path. The dict and the protocol path are equivalent —
-        // see `WireFormatTests.testMetricsManager_sendMobileVitals_*`.
-        var metrics: [VitalsMetric] = []
-        if let cpuDetector = cpuDetector {
-            metrics.append(VitalsMetric(name: Keys.cpu.rawValue, payload: cpuDetector.statsDictionary()))
-        }
-        if let memoryDetector = memoryDetector {
-            metrics.append(VitalsMetric(name: Keys.memory.rawValue, payload: memoryDetector.statsDictionary()))
-        }
-        if let slowFrozenFramesDetector = slowFrozenFramesDetector {
-            metrics.append(VitalsMetric(name: Keys.slowFrozen.rawValue, payload: slowFrozenFramesDetector.statsDictionary()))
-        }
-        if fpsDetector.isRunning {
-            metrics.append(VitalsMetric(name: MobileVitalsType.fps.stringValue, payload: fpsDetector.statsDictionary()))
-        }
-
-        guard !metrics.isEmpty else {
-            Log.d("[MetricsManager] No vitals to send, skipping")
-            return
-        }
-
-        if let metricsCollector = self.metricsCollector {
-            metricsCollector.collect(metrics)
-        } else {
-            // Legacy closure path — reconstruct the same dict shape callers
-            // have always received. Inlined so the fallback doesn't require
-            // a separate `MetricsCollector` impl; `WireFormatTests` pins
-            // this reconstruction to be byte-identical to
-            // `[VitalsMetric].toDictionary()`.
-            self.metricsManagerClosure?(metrics.toDictionary())
-        }
-        lastSendTime = Date()
-
-        // Reset stats after sending
-        cpuDetector?.reset()
-        memoryDetector?.reset()
-        slowFrozenFramesDetector?.reset()
-        if fpsDetector.isRunning {
-            fpsDetector.reset()
+    /// Fan-out: signal every periodic detector to push its current category
+    /// through its own `metricsCollector` and reset. Replaces the previous
+    /// pull-loop (`sendMobileVitals()` in CX-40573) — detectors now own
+    /// their own emit per CX-43340.
+    ///
+    /// Each detector produces one `mobile_vitals` span via the production
+    /// `SpanMetricsCollector` (one per category, instead of the pre-refactor
+    /// single batched span). Wire format per span is unchanged — pinned by
+    /// `WireFormatTests`.
+    ///
+    /// Called by the periodic scheduler (every 15s) and on view-change
+    /// boundaries (`NavigationInstrumentation`). ANR is event-driven and
+    /// pushes itself from `ANRDetector.handleANR()`; it does not participate
+    /// in `flushAll`.
+    public func flushAll() {
+        cpuDetector?.flush()
+        memoryDetector?.flush()
+        slowFrozenFramesDetector?.flush()
+        fpsDetector?.flush()
+        // Match the pre-refactor invariant: bump lastSendTime only if at
+        // least one detector would have contributed — otherwise an empty
+        // scheduler tick (no detectors wired) would debounce subsequent
+        // ticks for 15s. CPU/Memory/SlowFrozen contribute iff non-nil;
+        // FPS contributes iff its display-link sampler is running.
+        let anyContribution = cpuDetector != nil
+            || memoryDetector != nil
+            || slowFrozenFramesDetector != nil
+            || (fpsDetector?.isRunning ?? false)
+        if anyContribution {
+            lastSendTime = Date()
         }
     }
     
@@ -167,7 +156,7 @@ public class MetricsManager {
         let mobileVitalsMap: [(CoralogixExporterOptions.MobileVitalsType, () -> Void)] = [
             (.coldDetector, self.startColdStartMonitoring),
             (.warmDetector, self.startWarmStartMonitoring),
-            (.renderingDetector, self.fpsDetector.startMonitoring),
+            (.renderingDetector, self.startFPSMonitoring),
             (.cpuDetector, self.startCPUMonitoring),
             (.memoryDetector, self.startMemoryMonitoring),
             (.slowFrozenFramesDetector, self.startSlowFrozenFramesMonitoring)
@@ -203,41 +192,48 @@ public class MetricsManager {
     }
     
     func startANRMonitoring() {
-        self.anrDetector = ANRDetector()
+        self.anrDetector = ANRDetector(eventReporter: self.eventReporter)
         self.anrDetector?.handleANRClosure = { [weak self] in
             self?.handleANREvent()
         }
         self.anrDetector?.startMonitoring()
     }
-    
+
     private func handleANREvent() {
         let errorMessage = WireValues.anrErrorMessage.rawValue
         let errorType = WireValues.anrErrorType.rawValue
         reportANR(message: errorMessage, errorType: errorType, source: "ANR event")
         Log.d("[MetricsManager] ANR error reported: \(errorMessage)")
     }
-    
+
     func startCPUMonitoring() {
         guard cpuDetector == nil else { return }
-        let detector = CPUDetector()
+        let detector = CPUDetector(metricsCollector: self.metricsCollector)
         detector.startMonitoring()
         self.cpuDetector = detector
     }
-    
+
     func startMemoryMonitoring() {
         guard memoryDetector == nil else { return }
-        let detector = MemoryDetector()
+        let detector = MemoryDetector(metricsCollector: self.metricsCollector)
         detector.startMonitoring()
         self.memoryDetector = detector
     }
-    
+
     func startSlowFrozenFramesMonitoring() {
         guard slowFrozenFramesDetector == nil else { return }
-        let detector = SlowFrozenFramesDetector()
+        let detector = SlowFrozenFramesDetector(metricsCollector: self.metricsCollector)
         detector.startMonitoring()
         self.slowFrozenFramesDetector = detector
     }
-    
+
+    func startFPSMonitoring() {
+        guard fpsDetector == nil else { return }
+        let detector = FPSDetector(metricsCollector: self.metricsCollector)
+        detector.startMonitoring()
+        self.fpsDetector = detector
+    }
+
     private func stopAllDetectors() {
         anrDetector?.stopMonitoring()
         anrDetector = nil
@@ -247,7 +243,8 @@ public class MetricsManager {
         memoryDetector = nil
         slowFrozenFramesDetector?.stopMonitoring()
         slowFrozenFramesDetector = nil
-        fpsDetector.stopMonitoring()
+        fpsDetector?.stopMonitoring()
+        fpsDetector = nil
     }
     
     private func startSendScheduler() {
@@ -274,13 +271,13 @@ public class MetricsManager {
                 let now = Date()
                 if let last = self.lastSendTime {
                     if now.timeIntervalSince(last) >= self.sendInterval {
-                        self.sendMobileVitals()
+                        self.flushAll()
                     } else {
                         Log.d("[MetricsManager] Skipped send, only \(now.timeIntervalSince(last))s since last event")
                     }
                 } else {
                     // First time we fire the scheduler
-                    self.sendMobileVitals()
+                    self.flushAll()
                 }
                 
                 // Re-schedule the next check

--- a/Coralogix/Sources/Utils/MobileVitals/RenderingDetector.swift
+++ b/Coralogix/Sources/Utils/MobileVitals/RenderingDetector.swift
@@ -52,13 +52,24 @@ class FPSDetector {
     static let defaultInterval: TimeInterval = 1.0 // second
     internal var samples: [Double] = []
 
-    /// Injected metrics sink (CX-40573). Reserved for the follow-up ticket
-    /// that migrates the pull-based send loop in `MetricsManager` onto
-    /// self-pushing detectors. Stored but not invoked here yet.
+    /// Injected metrics sink (CX-40573 / CX-43340). Invoked from `flush()`
+    /// to push this detector's FPS category through the protocol path.
+    /// Production wires `SpanMetricsCollector`; tests inject a recorder.
+    /// nil disables the push (the detector still samples; nothing is emitted).
     let metricsCollector: MetricsCollector?
 
     init(metricsCollector: MetricsCollector? = nil) {
         self.metricsCollector = metricsCollector
+    }
+
+    /// Pushes one `VitalsMetric` for the FPS category through `metricsCollector`
+    /// and resets the accumulated samples so the next window starts fresh.
+    /// Called by `MetricsManager.flushAll()` on the periodic scheduler tick
+    /// and on view-change boundaries.
+    func flush() {
+        guard isRunning, let metricsCollector = metricsCollector else { return }
+        metricsCollector.collect([VitalsMetric(name: MobileVitalsType.fps.stringValue, payload: statsDictionary())])
+        reset()
     }
 
     // MARK: - Public stats

--- a/Coralogix/Sources/Utils/MobileVitals/SlowFrozenFramesDetector.swift
+++ b/Coralogix/Sources/Utils/MobileVitals/SlowFrozenFramesDetector.swift
@@ -110,9 +110,11 @@ final class SlowFrozenFramesDetector {
     
     
     
-    /// Injected metrics sink (CX-40573). Reserved for the follow-up ticket
-    /// that migrates the pull-based send loop in `MetricsManager` onto
-    /// self-pushing detectors. Stored but not invoked here yet.
+    /// Injected metrics sink (CX-40573 / CX-43340). Invoked from `flush()`
+    /// to push this detector's slow/frozen-frame category through the
+    /// protocol path. Production wires `SpanMetricsCollector`; tests inject
+    /// a recorder. nil disables the push (the detector still records
+    /// windows; nothing is emitted).
     let metricsCollector: MetricsCollector?
 
     // MARK: - Init
@@ -124,7 +126,7 @@ final class SlowFrozenFramesDetector {
     ///     Industry thresholds range from 250ms (sensitive) to 700ms (severe freezes only).
     ///   - reportIntervalMs: Window size for aggregating frame counts. Default 60s.
     ///   - tolerancePercentage: Tolerance for slow frame detection. Default 3% to prevent false positives.
-    ///   - metricsCollector: See `metricsCollector` property doc. Reserved for follow-up; pass nil today.
+    ///   - metricsCollector: See `metricsCollector` property doc.
     init(
         frozenThresholdMs: Double = 700.0,
         reportIntervalMs: Int64 = 60_000,
@@ -136,6 +138,16 @@ final class SlowFrozenFramesDetector {
         self.tolerancePercentage = tolerancePercentage
         self.metricsCollector = metricsCollector
         updateRefreshRateAndBudget()
+    }
+
+    /// Pushes one `VitalsMetric` for the slow/frozen-frame category through
+    /// `metricsCollector` and resets accumulated windows. Called by
+    /// `MetricsManager.flushAll()` on the periodic scheduler tick and on
+    /// view-change boundaries.
+    func flush() {
+        guard let metricsCollector = metricsCollector else { return }
+        metricsCollector.collect([VitalsMetric(name: Keys.slowFrozen.rawValue, payload: statsDictionary())])
+        reset()
     }
 
     // MARK: - Public API

--- a/Tests/CoralogixRumTests/MobileVitalsTests/WireFormatTests.swift
+++ b/Tests/CoralogixRumTests/MobileVitalsTests/WireFormatTests.swift
@@ -4,17 +4,23 @@
 //
 //  Created by Coralogix DEV TEAM on 20/05/2026.
 //
-//  Pins the exact dict shape each MetricsManager / detector emits. The
-//  EventReporter / MetricsCollector refactor (CX-40573) must preserve these
+//  Pins the exact dict shape each detector emits. The EventReporter /
+//  MetricsCollector refactor (CX-40573 / CX-43340) must preserve these
 //  shapes byte-for-byte — these tests are the contract.
 //
-//  Three layers, in order:
-//   1. Schema pins — key set + leaf type for each statsDictionary() and
-//      the MetricsManager.sendMobileVitals() aggregate.
-//   2. Round-trip — [String: Any] -> [VitalsMetric] -> toDictionary() is
-//      byte-identical to the legacy payload.
-//   3. End-to-end — protocol path produces the same JSON as the closure
-//      path, both for sendMobileVitals() and for ANR.
+//  Four layers, in order:
+//   1. Schema pins — key set + leaf type for each detector's
+//      statsDictionary().
+//   2. Per-detector self-push (CX-43340) — each detector, wired with a
+//      MetricsCollector, emits exactly one VitalsMetric on flush() with
+//      its category key and the same payload shape it produced before
+//      the migration. ANRDetector emits one ANRErrorEvent through its
+//      EventReporter on handleANR().
+//   3. Round-trip — [String: Any] -> [VitalsMetric] -> toDictionary() is
+//      byte-identical to the legacy payload (still used by the
+//      cold/warm/MetricKit path through MetricsManager.emitMetricKitPayload).
+//   4. End-to-end ANR — protocol path produces the same fields as the
+//      legacy closure path (closure removal is out of scope per CX-43340).
 //
 //  We pin *key set and leaf type* at every nesting level, not the float
 //  values (which depend on live stats and would be flaky).
@@ -122,83 +128,124 @@ final class WireFormatTests: XCTestCase {
         ])
     }
 
-    // MARK: - MetricsManager.sendMobileVitals() aggregate pin
+    // MARK: - Per-detector self-push (CX-43340)
+    //
+    // Each periodic detector, when constructed with a `MetricsCollector`,
+    // emits exactly one `VitalsMetric` on `flush()` — the category key
+    // plus the same payload shape `statsDictionary()` would produce.
+    // These tests pin the contract that `MetricsManager.flushAll()` and
+    // `NavigationInstrumentation` rely on.
 
-    func testMetricsManager_sendMobileVitals_aggregateSchema_allDetectorsActive() {
-        let manager = MetricsManager()
-        // Wire up all detectors so the aggregate dict reaches its maximum shape.
-        manager.cpuDetector = CPUDetector()
-        manager.memoryDetector = MemoryDetector()
-        manager.slowFrozenFramesDetector = SlowFrozenFramesDetector()
-        manager.fpsDetector.isRunning = true  // FPS is only included when its detector is running
+    func testCPUDetector_flush_pushesOneMetricViaCollector() throws {
+        let recorder = BatchRecordingCollector()
+        let detector = CPUDetector(metricsCollector: recorder)
 
-        var captured: [String: Any]?
-        manager.metricsManagerClosure = { dict in captured = dict }
+        detector.flush()
 
-        manager.sendMobileVitals()
-
-        guard let dict = captured else {
-            XCTFail("metricsManagerClosure was not invoked")
-            return
-        }
-
-        XCTAssertEqual(schema(dict), [
-            "cpu.cpu_usage.avg: Double",
-            "cpu.cpu_usage.max: Double",
-            "cpu.cpu_usage.min: Double",
-            "cpu.cpu_usage.p95: Double",
-            "cpu.cpu_usage.units: String",
-            "cpu.main_thread_cpu_time.avg: Double",
-            "cpu.main_thread_cpu_time.max: Double",
-            "cpu.main_thread_cpu_time.min: Double",
-            "cpu.main_thread_cpu_time.p95: Double",
-            "cpu.main_thread_cpu_time.units: String",
-            "cpu.total_cpu_time.avg: Double",
-            "cpu.total_cpu_time.max: Double",
-            "cpu.total_cpu_time.min: Double",
-            "cpu.total_cpu_time.p95: Double",
-            "cpu.total_cpu_time.units: String",
-            "fps.avg: Double",
-            "fps.max: Double",
-            "fps.min: Double",
-            "fps.p95: Double",
-            "fps.units: String",
-            "memory.footprint_memory.avg: Double",
-            "memory.footprint_memory.max: Double",
-            "memory.footprint_memory.min: Double",
-            "memory.footprint_memory.p95: Double",
-            "memory.footprint_memory.units: String",
-            "memory.memory_utilization.avg: Double",
-            "memory.memory_utilization.max: Double",
-            "memory.memory_utilization.min: Double",
-            "memory.memory_utilization.p95: Double",
-            "memory.memory_utilization.units: String",
-            "memory.resident_memory.avg: Double",
-            "memory.resident_memory.max: Double",
-            "memory.resident_memory.min: Double",
-            "memory.resident_memory.p95: Double",
-            "memory.resident_memory.units: String",
-            "slow_frozen.frozen_frames.avg: Double",
-            "slow_frozen.frozen_frames.max: Double",
-            "slow_frozen.frozen_frames.min: Double",
-            "slow_frozen.frozen_frames.p95: Double",
-            "slow_frozen.frozen_frames.units: String",
-            "slow_frozen.slow_frames.avg: Double",
-            "slow_frozen.slow_frames.max: Double",
-            "slow_frozen.slow_frames.min: Double",
-            "slow_frozen.slow_frames.p95: Double",
-            "slow_frozen.slow_frames.units: String"
-        ])
+        let batch = try XCTUnwrap(recorder.batches.first, "flush() did not call collect()")
+        XCTAssertEqual(recorder.batches.count, 1, "flush() must emit exactly one batch")
+        XCTAssertEqual(batch.count, 1, "CPU flush must emit a single VitalsMetric")
+        XCTAssertEqual(batch.first?.name, Keys.cpu.rawValue)
+        let payload = try XCTUnwrap(batch.first?.payload as? [String: Any])
+        XCTAssertEqual(schema(payload), schema(detector.statsDictionary()),
+                       "CPU flush payload must match statsDictionary() schema")
     }
 
-    func testMetricsManager_sendMobileVitals_skipsEmptyPayload() {
-        // Guard against silent regression: when no detector is attached and
-        // FPS isn't running, sendMobileVitals() must NOT call the closure.
-        let manager = MetricsManager()
-        var callCount = 0
-        manager.metricsManagerClosure = { _ in callCount += 1 }
-        manager.sendMobileVitals()
-        XCTAssertEqual(callCount, 0, "Empty vitals payload must not be sent")
+    func testMemoryDetector_flush_pushesOneMetricViaCollector() throws {
+        let recorder = BatchRecordingCollector()
+        let detector = MemoryDetector(metricsCollector: recorder)
+
+        detector.flush()
+
+        let batch = try XCTUnwrap(recorder.batches.first, "flush() did not call collect()")
+        XCTAssertEqual(recorder.batches.count, 1)
+        XCTAssertEqual(batch.count, 1)
+        XCTAssertEqual(batch.first?.name, Keys.memory.rawValue)
+        let payload = try XCTUnwrap(batch.first?.payload as? [String: Any])
+        XCTAssertEqual(schema(payload), schema(detector.statsDictionary()))
+    }
+
+    func testSlowFrozenFramesDetector_flush_pushesOneMetricViaCollector() throws {
+        let recorder = BatchRecordingCollector()
+        let detector = SlowFrozenFramesDetector(metricsCollector: recorder)
+
+        detector.flush()
+
+        let batch = try XCTUnwrap(recorder.batches.first, "flush() did not call collect()")
+        XCTAssertEqual(recorder.batches.count, 1)
+        XCTAssertEqual(batch.count, 1)
+        XCTAssertEqual(batch.first?.name, Keys.slowFrozen.rawValue)
+        let payload = try XCTUnwrap(batch.first?.payload as? [String: Any])
+        XCTAssertEqual(schema(payload), schema(detector.statsDictionary()))
+    }
+
+    func testFPSDetector_flush_pushesOneMetricViaCollector_whenRunning() throws {
+        let recorder = BatchRecordingCollector()
+        let detector = FPSDetector(metricsCollector: recorder)
+        detector.isRunning = true   // FPS only emits while its display link is active
+
+        detector.flush()
+
+        let batch = try XCTUnwrap(recorder.batches.first, "flush() did not call collect()")
+        XCTAssertEqual(recorder.batches.count, 1)
+        XCTAssertEqual(batch.count, 1)
+        XCTAssertEqual(batch.first?.name, MobileVitalsType.fps.stringValue)
+        let payload = try XCTUnwrap(batch.first?.payload as? [String: Any])
+        XCTAssertEqual(schema(payload), schema(detector.statsDictionary()))
+    }
+
+    func testFPSDetector_flush_skipsEmit_whenNotRunning() {
+        // Preserves the legacy semantic: FPS is only included when its
+        // display-link sampler is active (pre-CX-43340 this was an
+        // `if fpsDetector.isRunning` gate in MetricsManager.sendMobileVitals).
+        let recorder = BatchRecordingCollector()
+        let detector = FPSDetector(metricsCollector: recorder)
+        // detector.isRunning is false by default
+
+        detector.flush()
+
+        XCTAssertTrue(recorder.batches.isEmpty, "FPS must not emit when not running")
+    }
+
+    func testDetector_flush_isNoOp_whenNoCollectorWired() {
+        // A detector with no metricsCollector silently drops the flush —
+        // this is the legacy path for test code that constructs detectors
+        // directly. No throw, no log spam, no closure path.
+        CPUDetector().flush()
+        MemoryDetector().flush()
+        SlowFrozenFramesDetector().flush()
+        let fps = FPSDetector()
+        fps.isRunning = true
+        fps.flush()
+        // No assertion needed — the test asserts only that the calls return.
+    }
+
+    // MARK: - ANRDetector self-push (CX-43340)
+
+    func testANRDetector_handleANR_pushesViaEventReporter_whenWired() throws {
+        var captured: TelemetryEvent?
+        let reporter = RecordingEventReporter { captured = $0 }
+        let detector = ANRDetector(eventReporter: reporter)
+
+        detector.handleANR()
+
+        let event = try XCTUnwrap(captured as? ANRErrorEvent,
+                                  "handleANR must emit an ANRErrorEvent through the protocol path")
+        XCTAssertEqual(event.errorMessage, WireValues.anrErrorMessage.rawValue)
+        XCTAssertEqual(event.errorType, WireValues.anrErrorType.rawValue)
+    }
+
+    func testANRDetector_handleANR_fallsBackToClosure_whenEventReporterNil() {
+        // Backward-compat path: when no protocol sink is wired, handleANR
+        // still routes through the legacy closure (out of scope to remove
+        // per CX-43340; covered by 1.5b).
+        var closureFired = false
+        let detector = ANRDetector()
+        detector.handleANRClosure = { closureFired = true }
+
+        detector.handleANR()
+
+        XCTAssertTrue(closureFired, "Closure path must still fire when eventReporter is nil")
     }
 
     // MARK: - Cold / Warm / MetricKit single-shot payload pins
@@ -276,38 +323,6 @@ final class WireFormatTests: XCTestCase {
                        "Round-trip dict must be byte-identical to the legacy payload")
     }
 
-    // MARK: - End-to-end: protocol path emits the same bytes as the closure path
-
-    func testMetricsManager_protocolPath_equalsClosurePath_endToEnd() throws {
-        // Run sendMobileVitals() twice with identical state — first via the
-        // deprecated closure, then via the new MetricsCollector — and assert
-        // the captured dicts serialize to the same JSON.
-
-        let closureDict = try captureSendMobileVitals(useProtocolPath: false)
-        let protocolDict = try captureSendMobileVitals(useProtocolPath: true)
-
-        XCTAssertEqual(try jsonString(closureDict), try jsonString(protocolDict),
-                       "Protocol path must produce the same bytes as the closure path")
-    }
-
-    private func captureSendMobileVitals(useProtocolPath: Bool) throws -> [String: Any] {
-        let manager = MetricsManager()
-        manager.cpuDetector = CPUDetector()
-        manager.memoryDetector = MemoryDetector()
-        manager.slowFrozenFramesDetector = SlowFrozenFramesDetector()
-        manager.fpsDetector.isRunning = true
-
-        var captured: [String: Any]?
-        if useProtocolPath {
-            manager.metricsCollector = RecordingMetricsCollector { dict in captured = dict }
-        } else {
-            manager.metricsManagerClosure = { dict in captured = dict }
-        }
-
-        manager.sendMobileVitals()
-        return try XCTUnwrap(captured, "sendMobileVitals did not emit on \(useProtocolPath ? "protocol" : "closure") path")
-    }
-
     // MARK: - End-to-end ANR equivalence
 
     func testANR_protocolPath_equalsClosurePath_endToEnd() {
@@ -357,15 +372,16 @@ final class WireFormatTests: XCTestCase {
 
 // MARK: - Test doubles
 
-/// Records the `[VitalsMetric]` batch and re-emits it as the legacy dict
-/// shape so the wire-format equivalence tests can compare bytes against
-/// the closure path. Lives in the test target only; production uses
-/// `SpanMetricsCollector`.
-private struct RecordingMetricsCollector: MetricsCollector {
-    let onDict: ([String: Any]) -> Void
+/// Records each `collect(_:)` call as a separate batch so per-detector
+/// self-push tests can assert both *what* was emitted and *how many
+/// times*. Production uses `SpanMetricsCollector`.
+///
+/// A class (not struct) so callers can hold a single reference and
+/// observe mutations from `flush()`.
+private final class BatchRecordingCollector: MetricsCollector {
+    var batches: [[VitalsMetric]] = []
     func collect(_ metrics: [VitalsMetric]) {
-        guard !metrics.isEmpty else { return }
-        onDict(metrics.toDictionary())
+        batches.append(metrics)
     }
 }
 


### PR DESCRIPTION
# User description
## Summary

- Flips mobile-vitals from `MetricsManager`'s 15s pull-loop to each detector pushing its own `VitalsMetric` through the injected `MetricsCollector` on `flush()`. `ANRDetector` now reports `ANRErrorEvent` directly through `EventReporter` on hang detection.
- `MetricsManager.sendMobileVitals()` is gone; `flushAll()` is the new scheduler-only entry point that fans out `detector.flush()` calls. Periodic detectors gained a `flush()`; `fpsDetector` moved to optional + `startFPSMonitoring()` for parity with the others.
- `WireFormatTests` extended with per-detector self-push assertions covering CPU, Memory, FPS, SlowFrozenFrames, and ANR.
- `flushAll()` only bumps `lastSendTime` when at least one detector would have contributed, matching the pre-refactor empty-batch guard.

## Behavioural change to verify

Wire format per span is unchanged (pinned by `WireFormatTests` and verified end-to-end via the demo app). But each flush now emits **one `mobile_vitals` span per category (4 spans/cycle)** instead of one batched span carrying all four. Demo-app verification confirmed the four-spans-per-cycle shape and unchanged `mobileVitalsType` JSON per span. Backend dashboards that count spans (vs. group by category/timestamp) will see counts spike.

The deprecated `metricsManagerClosure` / `anrErrorClosure` stay on `MetricsManager` for the cold/warm/MetricKit path and the test fallback — closure removal is out of scope per 1.5b.

## Note on history

This replaces draft PR #208 (auto-closed when its parent branch `feat/CX-40573-event-reporter-metrics-collector` was deleted on merge of #207). Same single commit, now stacked directly on master.

## Test plan

- [x] `xcodebuild test` — full suite green (50+ test suites)
- [x] `WireFormatTests` — 17 tests covering schema pins, per-detector self-push, ANR equivalence, dict round-trip
- [x] Demo-app end-to-end (DemoAppSwift on iPhone 16 sim, iOS 18.3.1) — 4 mobile-vitals spans per cycle observed with the expected `mobileVitalsType` JSON shape; scheduler debounce confirmed via `[MetricsManager] Skipped send` log
- [ ] Backend sanity-check on the 4-spans-per-cycle behavioural change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Enable each MobileVitals detector (CPU, Memory, SlowFrozenFrames, FPS, and ANR) to emit its own <code>VitalsMetric</code>/<code>ANRErrorEvent</code> through their injected <code>MetricsCollector</code>/<code>EventReporter</code> when flushed, with <code>MetricsManager.flushAll()</code> serving as the scheduler fan-out and <code>NavigationInstrumentation</code> triggering the new entry point. Validate those self-push semantics with expanded wire-format coverage so the per-detector spans keep their existing JSON shape alongside the legacy ANR payload.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/209?tool=ast&topic=Detector+Flush+Flow>Detector Flush Flow</a>
        </td><td>Enable each detector to emit its own span by wiring the injected <code>MetricsCollector</code>/<code>EventReporter</code>, adding <code>flush()</code> hooks, and having <code>MetricsManager.flushAll()</code> fan out those calls (while keeping the scheduler debounce semantics) instead of using <code>sendMobileVitals()</code>; <code>NavigationInstrumentation</code> now invokes <code>flushAll()</code> on view changes.<details><summary>Modified files (7)</summary><ul><li>Coralogix/Sources/Instrumentation/NavigationInstrumentation.swift</li>
<li>Coralogix/Sources/Utils/MobileVitals/ANRDetector.swift</li>
<li>Coralogix/Sources/Utils/MobileVitals/CPUDetector.swift</li>
<li>Coralogix/Sources/Utils/MobileVitals/MemoryDetector.swift</li>
<li>Coralogix/Sources/Utils/MobileVitals/MetricsManager.swift</li>
<li>Coralogix/Sources/Utils/MobileVitals/RenderingDetector.swift</li>
<li>Coralogix/Sources/Utils/MobileVitals/SlowFrozenFramesDetector.swift</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>feat(CX-43340): self-p...</td><td>May 24, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/209?tool=ast&topic=Wire+Format+Tests>Wire Format Tests</a>
        </td><td>Validate per-detector self-push behavior and ANR reporting by extending <code>WireFormatTests</code> so each detector flush emits one <code>VitalsMetric</code> with the pinned schema and <code>ANRDetector</code> reports through <code>EventReporter</code> while still allowing the legacy closure fallback.<details><summary>Modified files (1)</summary><ul><li>Tests/CoralogixRumTests/MobileVitalsTests/WireFormatTests.swift</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>feat(CX-43340): self-p...</td><td>May 24, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/coralogix/cx-ios-sdk/209?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>