### PR TITLE
feat(CX-43341): delete deprecated metricsManagerClosure / anrErrorClosure

### DIFF
--- a/Coralogix/Sources/Instrumentation/ANRInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/ANRInstrumentation.swift
@@ -12,11 +12,10 @@ extension CoralogixRum {
     /// Initializes ANR (Application Not Responding) detection.
     /// ANR events are reported as error events, not mobile vitals.
     ///
-    /// CX-40573: ANR events now flow through the typed EventReporter
+    /// CX-40573: ANR events flow through the typed EventReporter
     /// protocol — the orchestrator wires SpanEventReporter here and the
     /// underlying span-building logic lives in that struct. The
-    /// pre-refactor `anrErrorClosure` path remains on MetricsManager as a
-    /// deprecated fallback for test code that pokes the closure directly.
+    /// `anrErrorClosure` fallback path was removed in CX-43341.
     public func initializeANRInstrumentation() {
         self.metricsManager.eventReporter = SpanEventReporter(
             createErrorSpan: { [weak self] in

--- a/Coralogix/Sources/Model/Reporting/MetricsCollector.swift
+++ b/Coralogix/Sources/Model/Reporting/MetricsCollector.swift
@@ -8,12 +8,8 @@
 import Foundation
 
 /// Receives a batch of mobile-vitals metrics (one `VitalsMetric` per
-/// category). Replaces `MetricsManager.metricsManagerClosure` with a
-/// protocol-typed dependency.
-///
-/// `collect` must produce a payload byte-identical to what the legacy
-/// closure path emits today — the wire format is pinned by
-/// `WireFormatTests`. Concrete implementations decide their own threading.
+/// category). The wire format is pinned by `WireFormatTests`.
+/// Concrete implementations decide their own threading.
 protocol MetricsCollector {
     func collect(_ metrics: [VitalsMetric])
 }

--- a/Coralogix/Sources/Model/Reporting/VitalsMetric.swift
+++ b/Coralogix/Sources/Model/Reporting/VitalsMetric.swift
@@ -11,13 +11,12 @@ import Foundation
 ///
 /// `name` is the wire-format category key (e.g. `Keys.cpu.rawValue`,
 /// `Keys.memory.rawValue`, `Keys.fps.rawValue`). `payload` is the same
-/// shape `Detector.statsDictionary()` returns today — usually a
+/// shape `Detector.statsDictionary()` returns — usually a
 /// `[String: Any]` dict, but the hybrid-SDK entry points
 /// (`reportMobileVitalsMeasurement(type:metrics:)`) wrap an
-/// `[[String: Any]]` array. `payload` is therefore typed `Any` to match
-/// every shape the legacy `metricsManagerClosure` accepted; the type is
-/// intentionally untyped at this phase so wire compatibility with the
-/// pre-refactor path is byte-identical (pinned by `WireFormatTests`).
+/// `[[String: Any]]` array. `payload` is intentionally typed `Any` so
+/// either shape reaches the collector unchanged (pinned by
+/// `WireFormatTests`).
 ///
 /// - Important: `payload` must be JSON-serializable
 ///   (`JSONSerialization.isValidJSONObject(["x": payload])` must return
@@ -34,10 +33,9 @@ struct VitalsMetric {
 }
 
 extension Array where Element == VitalsMetric {
-    /// Re-flattens `[VitalsMetric]` back to the `[String: Any]` shape the
-    /// legacy `metricsManagerClosure` path emitted. `SpanMetricsCollector`
-    /// uses this transform on the wire; `WireFormatTests` pins it to be
-    /// byte-identical to the pre-refactor payload.
+    /// Re-flattens `[VitalsMetric]` back to the `[String: Any]` shape
+    /// `SpanMetricsCollector` JSON-encodes onto the `mobile_vitals` span
+    /// attribute. `WireFormatTests` pins the round-trip.
     func toDictionary() -> [String: Any] {
         var dict: [String: Any] = [:]
         for metric in self {

--- a/Coralogix/Sources/Utils/MobileVitals/MetricsManager.swift
+++ b/Coralogix/Sources/Utils/MobileVitals/MetricsManager.swift
@@ -23,11 +23,11 @@ public class MetricsManager {
 
     // MARK: - Reporting dependencies (CX-40573)
     //
-    // When set, these protocol-typed sinks take precedence over the legacy
-    // closure properties below. Production wires `SpanMetricsCollector` /
-    // `SpanEventReporter`; the wire format produced by either path is
-    // byte-identical to the dict the deprecated closures emit — pinned by
-    // `WireFormatTests`.
+    // Production wires `SpanMetricsCollector` / `SpanEventReporter`. When
+    // unwired, calls into `emitMetricKitPayload` / `reportANR` /
+    // `flushAll` drop with a `Log.d`. The wire format is pinned by
+    // `WireFormatTests`. (Deprecated closure fallbacks removed in
+    // CX-43341.)
     //
     // Threading: expected to be set once during init on the main thread.
     // Subsequent reads from background callbacks (MetricKit, ANR timer)
@@ -50,12 +50,6 @@ public class MetricsManager {
         }
     }
 
-    // MARK: - Legacy closure fallbacks (deprecated)
-    @available(*, deprecated, message: "Inject a MetricsCollector via the new metricsCollector property instead. Closure-based wiring will be removed in a future major release.")
-    var metricsManagerClosure: (([String: Any]) -> Void)?
-    @available(*, deprecated, message: "Inject an EventReporter via the new eventReporter property instead. Closure-based wiring will be removed in a future major release.")
-    var anrErrorClosure: ((String, String) -> Void)?
-
     // MARK: - Internal timer for periodic send
     private let sendInterval: TimeInterval = 15.0
     private var lastSendTime: Date?
@@ -72,35 +66,33 @@ public class MetricsManager {
         MXMetricManager.shared.add(MyMetricSubscriber.shared)
     }
 
-    /// Re-emits a category-keyed dict (`{ "<category>": <payload> }`) — used
-    /// by MetricKit and the cold/warm detectors — through whichever sink is
-    /// wired, preferring the protocol path. The shape sent on the wire is
-    /// byte-identical either way (pinned by `WireFormatTests`).
+    /// Emits a category-keyed dict (`{ "<category>": <payload> }`) — used
+    /// by MetricKit and the cold/warm detectors — through the injected
+    /// `MetricsCollector`. Wire format pinned by `WireFormatTests`.
+    /// Drops with a debug log when no collector is wired (set in
+    /// production by `CoralogixRum.setupCoreModules`).
     private func emitMetricKitPayload(_ dict: [String: Any]) {
-        if let metricsCollector = self.metricsCollector {
-            // Pass the value through as-is: `VitalsMetric.payload` is typed
-            // `Any` precisely so the dict / array shape produced by the
-            // upstream producer reaches the collector unchanged.
-            let metrics: [VitalsMetric] = dict.map { VitalsMetric(name: $0.key, payload: $0.value) }
-            metricsCollector.collect(metrics)
+        guard let metricsCollector = self.metricsCollector else {
+            Log.d("[MetricsManager] no metricsCollector wired; dropping MetricKit/cold/warm payload with keys \(dict.keys.sorted())")
             return
         }
-        self.metricsManagerClosure?(dict)
+        // Pass the value through as-is: `VitalsMetric.payload` is typed
+        // `Any` precisely so the dict / array shape produced by the
+        // upstream producer reaches the collector unchanged.
+        let metrics: [VitalsMetric] = dict.map { VitalsMetric(name: $0.key, payload: $0.value) }
+        metricsCollector.collect(metrics)
     }
 
-    /// Routes an ANR-shaped event through whichever sink is wired. Uses the
-    /// typed `ANRErrorEvent` (from CX-40572) when going through the protocol;
-    /// falls back to the deprecated closure otherwise.
+    /// Routes an ANR-shaped event through the injected `EventReporter`
+    /// as a typed `ANRErrorEvent` (from CX-40572). Drops with a debug log
+    /// when no reporter is wired (set in production by
+    /// `CoralogixRum.initializeANRInstrumentation`).
     private func reportANR(message: String, errorType: String, source: String) {
-        if let eventReporter = self.eventReporter {
-            eventReporter.report(ANRErrorEvent(errorMessage: message, errorType: errorType))
+        guard let eventReporter = self.eventReporter else {
+            Log.d("[MetricsManager] Warning: no eventReporter set, \(source) not reported")
             return
         }
-        guard let anrErrorClosure = self.anrErrorClosure else {
-            Log.d("[MetricsManager] Warning: no eventReporter or anrErrorClosure set, \(source) not reported")
-            return
-        }
-        anrErrorClosure(message, errorType)
+        eventReporter.report(ANRErrorEvent(errorMessage: message, errorType: errorType))
     }
     
     public func removeObservers() {

--- a/Tests/CoralogixRumTests/MetricsManagerTests.swift
+++ b/Tests/CoralogixRumTests/MetricsManagerTests.swift
@@ -37,64 +37,29 @@ final class MetricsManagerTests: XCTestCase {
         XCTAssertNotNil(metricsManager.anrDetector, "ANR monitoring should start and anrDetector should be initialized")
     }
     
-    func testANRErrorClosureIsCalled() {
-        let expectation = XCTestExpectation(description: "ANR error closure should be called")
-        var receivedErrorMessage: String?
-        var receivedErrorType: String?
-        var mobileVitalsWasCalled = false
-        
-        // Set up mobile vitals closure (should NOT be called)
-        metricsManager.metricsManagerClosure = { _ in
-            mobileVitalsWasCalled = true
-        }
-        
-        // Set up the ANR error closure
-        metricsManager.anrErrorClosure = { errorMessage, errorType in
-            receivedErrorMessage = errorMessage
-            receivedErrorType = errorType
+    func testANRErrorIsRoutedToEventReporter() {
+        let expectation = XCTestExpectation(description: "ANRErrorEvent should be reported")
+        var receivedEvent: ANRErrorEvent?
+        let vitalsCollector = BatchRecordingCollector()
+
+        // metricsCollector must NOT receive anything for an ANR event
+        metricsManager.metricsCollector = vitalsCollector
+
+        // ANR routes through the EventReporter protocol
+        metricsManager.eventReporter = RecordingEventReporter { event in
+            receivedEvent = event as? ANRErrorEvent
             expectation.fulfill()
         }
-        
-        // Start monitoring
+
         metricsManager.startANRMonitoring()
-        
-        // Simulate ANR detection by directly calling the detector's handleANR
         metricsManager.anrDetector?.handleANR()
-        
+
         wait(for: [expectation], timeout: 1.0)
-        
-        // Verify the error message and type
-        XCTAssertNotNil(receivedErrorMessage, "Error message should be received")
-        XCTAssertNotNil(receivedErrorType, "Error type should be received")
-        XCTAssertEqual(receivedErrorType, "ANR", "Error type should be 'ANR'")
-        XCTAssertEqual(receivedErrorMessage, "Application Not Responding", "Error message should be 'Application Not Responding'")
-        
-        // Verify mobile vitals closure was NOT called
-        XCTAssertFalse(mobileVitalsWasCalled, "Mobile vitals closure should not be called for ANR events")
-    }
-    
-    func testANRDoesNotCallMobileVitalsClosure() {
-        let expectation = XCTestExpectation(description: "Mobile vitals closure should NOT be called for ANR")
-        expectation.isInverted = true
-        
-        // Set up the mobile vitals closure (should NOT be called)
-        metricsManager.metricsManagerClosure = { _ in
-            XCTFail("Mobile vitals closure should not be called for ANR events")
-            expectation.fulfill()
-        }
-        
-        // Set up the ANR error closure (should be called)
-        metricsManager.anrErrorClosure = { _, _ in
-            // ANR error closure called correctly
-        }
-        
-        // Start monitoring
-        metricsManager.startANRMonitoring()
-        
-        // Simulate ANR detection
-        metricsManager.anrDetector?.handleANR()
-        
-        wait(for: [expectation], timeout: 1.0)
+
+        // Wire-constant guard: hard-coded strings catch accidental WireValues changes
+        XCTAssertEqual(receivedEvent?.errorType, "ANR", "Error type should be 'ANR'")
+        XCTAssertEqual(receivedEvent?.errorMessage, "Application Not Responding", "Error message should be 'Application Not Responding'")
+        XCTAssertTrue(vitalsCollector.batches.isEmpty, "metricsCollector must not be called for ANR events")
     }
 
     // MARK: - MetricKit Hang Diagnostics
@@ -142,31 +107,29 @@ final class MetricsManagerTests: XCTestCase {
     }
 
     /// Verifies that `addMetricKitObservers()` wires `hangDiagnosticClosure` so that a MetricKit
-    /// hang is forwarded to `anrErrorClosure` — not to `metricsManagerClosure` (mobile vitals).
-    func testAddMetricKitObservers_hangRoutesToAnrErrorClosure() {
-        var errorMessage: String?
-        var errorType: String?
-        var mobileVitalsCalled = false
+    /// hang is forwarded to `eventReporter` as an `ANRErrorEvent` — not to `metricsCollector` (mobile vitals).
+    func testAddMetricKitObservers_hangRoutesToEventReporter() {
+        var receivedEvent: ANRErrorEvent?
+        let vitalsCollector = BatchRecordingCollector()
 
-        metricsManager.metricsManagerClosure = { _ in mobileVitalsCalled = true }
-        metricsManager.anrErrorClosure = { msg, type in
-            errorMessage = msg
-            errorType = type
+        metricsManager.metricsCollector = vitalsCollector
+        metricsManager.eventReporter = RecordingEventReporter { event in
+            receivedEvent = event as? ANRErrorEvent
         }
 
         metricsManager.addMetricKitObservers()
 
         MyMetricSubscriber.shared.processHang(MockHangDiagnostic(hangDurationMs: 3000))
 
-        XCTAssertEqual(errorType, "MXHangDiagnostic", "Hang must be routed to the error closure")
-        XCTAssertEqual(errorMessage, "App hang detected by MetricKit for 3000 ms")
-        XCTAssertFalse(mobileVitalsCalled, "Hang must not trigger mobile vitals closure")
+        XCTAssertEqual(receivedEvent?.errorType, "MXHangDiagnostic", "Hang must be routed via EventReporter as ANRErrorEvent")
+        XCTAssertEqual(receivedEvent?.errorMessage, "App hang detected by MetricKit for 3000 ms")
+        XCTAssertTrue(vitalsCollector.batches.isEmpty, "Hang must not trigger metricsCollector")
     }
 
-    /// Verifies that when `anrErrorClosure` is not set, a MetricKit hang is silently dropped
+    /// Verifies that when `eventReporter` is not set, a MetricKit hang is silently dropped
     /// without crashing.
-    func testAddMetricKitObservers_hangDroppedWhenAnrErrorClosureIsNil() {
-        metricsManager.anrErrorClosure = nil
+    func testAddMetricKitObservers_hangDroppedWhenEventReporterIsNil() {
+        // eventReporter is nil by default — explicit no-op.
         metricsManager.addMetricKitObservers()
 
         MyMetricSubscriber.shared.processHang(MockHangDiagnostic(hangDurationMs: 1500))

--- a/Tests/CoralogixRumTests/MobileVitalsTests/TestDoubles.swift
+++ b/Tests/CoralogixRumTests/MobileVitalsTests/TestDoubles.swift
@@ -1,0 +1,34 @@
+//
+//  TestDoubles.swift
+//
+//
+//  Created by Coralogix DEV TEAM on 25/05/2026.
+//
+//  Shared `MetricsCollector` / `EventReporter` test doubles. Used by
+//  `WireFormatTests` and `MetricsManagerTests` to inspect what the
+//  production code emits through the protocol-typed sinks. Promoted
+//  from file-private in CX-43341 once a second caller appeared.
+
+import Foundation
+@testable import Coralogix
+
+/// Records each `collect(_:)` call as a separate batch so tests can
+/// assert both *what* was emitted and *how many times*. Production uses
+/// `SpanMetricsCollector`.
+///
+/// A class (not struct) so callers hold a single reference and observe
+/// mutations from background-thread emissions.
+final class BatchRecordingCollector: MetricsCollector {
+    var batches: [[VitalsMetric]] = []
+    func collect(_ metrics: [VitalsMetric]) {
+        batches.append(metrics)
+    }
+}
+
+/// Records a `TelemetryEvent` for assertions. Test-target only.
+struct RecordingEventReporter: EventReporter {
+    let onEvent: (TelemetryEvent) -> Void
+    func report(_ event: TelemetryEvent) {
+        onEvent(event)
+    }
+}

--- a/Tests/CoralogixRumTests/MobileVitalsTests/WireFormatTests.swift
+++ b/Tests/CoralogixRumTests/MobileVitalsTests/WireFormatTests.swift
@@ -17,10 +17,10 @@
 //      the migration. ANRDetector emits one ANRErrorEvent through its
 //      EventReporter on handleANR().
 //   3. Round-trip — [String: Any] -> [VitalsMetric] -> toDictionary() is
-//      byte-identical to the legacy payload (still used by the
-//      cold/warm/MetricKit path through MetricsManager.emitMetricKitPayload).
-//   4. End-to-end ANR — protocol path produces the same fields as the
-//      legacy closure path (closure removal is out of scope per CX-43340).
+//      byte-identical to the dict the cold/warm/MetricKit producers
+//      hand to MetricsManager.emitMetricKitPayload.
+//   4. End-to-end ANR — protocol path emits the exact WireValues
+//      constants the backend reads (snapshot assertion).
 //
 //  We pin *key set and leaf type* at every nesting level, not the float
 //  values (which depend on live stats and would be flaky).
@@ -279,13 +279,13 @@ final class WireFormatTests: XCTestCase {
     // MARK: - Round-trip: dict → [VitalsMetric] → toDictionary() → dict
     //
     // Pins the contract the production `SpanMetricsCollector` relies on:
-    // a dict shaped like the legacy `metricsManagerClosure` payload must
-    // round-trip byte-identical through the new `[VitalsMetric]` value
-    // type. `SpanMetricsCollector.collect` calls `toDictionary()` and
-    // JSON-encodes the result onto a span attribute — so this property
-    // is what guarantees wire compatibility.
+    // a dict produced by `MetricsManager.emitMetricKitPayload` (cold /
+    // warm / MetricKit) must round-trip byte-identical through the
+    // `[VitalsMetric]` value type. `SpanMetricsCollector.collect` calls
+    // `toDictionary()` and JSON-encodes the result onto a span attribute
+    // — so this property is what guarantees wire compatibility.
 
-    func testVitalsMetric_toDictionary_roundTripsLegacyDict() throws {
+    func testVitalsMetric_toDictionary_roundTripsEmitMetricKitPayloadShape() throws {
         let original: [String: Any] = [
             Keys.cpu.rawValue: [
                 MobileVitalsType.cpuUsage.stringValue: [
@@ -323,35 +323,27 @@ final class WireFormatTests: XCTestCase {
                        "Round-trip dict must be byte-identical to the legacy payload")
     }
 
-    // MARK: - End-to-end ANR equivalence
+    // MARK: - End-to-end ANR: protocol path matches expected wire snapshot
+    //
+    // Pre-CX-43341 this test compared a "closure path" capture against a
+    // "protocol path" capture. With the deprecated closures gone, the
+    // equivalence framing collapses to a snapshot assertion: the protocol
+    // path emits an `ANRErrorEvent` carrying the exact `WireValues`
+    // constants — the wire format the backend reads.
 
-    func testANR_protocolPath_equalsClosurePath_endToEnd() {
-        // Capture (message, errorType) via the closure path…
-        let viaClosure = captureANR(useProtocolPath: false)
-
-        // …and capture the same fields from the typed ANRErrorEvent on the protocol path.
-        let viaProtocol = captureANR(useProtocolPath: true)
-
-        XCTAssertEqual(viaClosure?.message, viaProtocol?.message)
-        XCTAssertEqual(viaClosure?.errorType, viaProtocol?.errorType)
-        XCTAssertEqual(viaClosure?.message, WireValues.anrErrorMessage.rawValue)
-        XCTAssertEqual(viaClosure?.errorType, WireValues.anrErrorType.rawValue)
-    }
-
-    private func captureANR(useProtocolPath: Bool) -> (message: String, errorType: String)? {
+    func testANR_protocolPath_emitsExpectedWireSnapshot() throws {
         let manager = MetricsManager()
-        var captured: (message: String, errorType: String)?
-        if useProtocolPath {
-            manager.eventReporter = RecordingEventReporter { event in
-                guard let anr = event as? ANRErrorEvent else { return }
-                captured = (anr.errorMessage, anr.errorType)
-            }
-        } else {
-            manager.anrErrorClosure = { msg, type in captured = (msg, type) }
+        var captured: ANRErrorEvent?
+        manager.eventReporter = RecordingEventReporter { event in
+            captured = event as? ANRErrorEvent
         }
+
         manager.startANRMonitoring()
         manager.anrDetector?.handleANR()
-        return captured
+
+        let event = try XCTUnwrap(captured, "ANRDetector did not push ANRErrorEvent through eventReporter")
+        XCTAssertEqual(event.errorMessage, WireValues.anrErrorMessage.rawValue)
+        XCTAssertEqual(event.errorType, WireValues.anrErrorType.rawValue)
     }
 
     // MARK: - JSON helper
@@ -370,25 +362,6 @@ final class WireFormatTests: XCTestCase {
     }
 }
 
-// MARK: - Test doubles
-
-/// Records each `collect(_:)` call as a separate batch so per-detector
-/// self-push tests can assert both *what* was emitted and *how many
-/// times*. Production uses `SpanMetricsCollector`.
-///
-/// A class (not struct) so callers can hold a single reference and
-/// observe mutations from `flush()`.
-private final class BatchRecordingCollector: MetricsCollector {
-    var batches: [[VitalsMetric]] = []
-    func collect(_ metrics: [VitalsMetric]) {
-        batches.append(metrics)
-    }
-}
-
-/// Records a `TelemetryEvent` for assertions. Test-target only.
-private struct RecordingEventReporter: EventReporter {
-    let onEvent: (TelemetryEvent) -> Void
-    func report(_ event: TelemetryEvent) {
-        onEvent(event)
-    }
-}
+// Test doubles (`BatchRecordingCollector`, `RecordingEventReporter`)
+// live in `TestDoubles.swift` since CX-43341 — shared with
+// `MetricsManagerTests`.


### PR DESCRIPTION
# User description
## Summary

Finishes the closure-to-protocol migration started in CX-40573 (#207). With production wired through `SpanMetricsCollector` / `SpanEventReporter` and self-pushing detectors landed in CX-43340 (#209), the two `@available(*, deprecated)` closure properties on `MetricsManager` existed solely so a few tests could drive the fallback path. This PR deletes them and migrates the affected tests off.

## Changes

**Source:**
- Delete `MetricsManager.metricsManagerClosure` and `MetricsManager.anrErrorClosure`.
- `emitMetricKitPayload()` and `reportANR()` become unconditional protocol calls — drop with a `Log.d` when the sink is unwired (matches `flushAll()` and `reportMobileVitalsMeasurement`).
- Doc-comment cleanup in `ANRInstrumentation` / `MetricsCollector` / `VitalsMetric` where the deleted closures were still referenced.

**Tests:**
- New `Tests/CoralogixRumTests/MobileVitalsTests/TestDoubles.swift` promotes `BatchRecordingCollector` + `RecordingEventReporter` from file-private (`WireFormatTests`) to internal so `MetricsManagerTests` reuses the same fixtures.
- `MetricsManagerTests`: the two ANR-routing tests collapse into one `testANRErrorIsRoutedToEventReporter` (the `RecordingEventReporter` + empty-collector pair already covers "vitals path not invoked"); the two MetricKit-hang tests migrate off `anrErrorClosure` to `RecordingEventReporter`.
- `WireFormatTests`: closure-vs-protocol equivalence test reframed as a snapshot assertion against `WireValues` constants (`testANR_protocolPath_emitsExpectedWireSnapshot`). Helper `captureANR` and the file-private test doubles deleted.

**Diff stat:** +130 / -175 — net deletion, as expected for a cleanup ticket.

## AC delta

The ticket description mentioned removing the closure-fallback branch inside `sendMobileVitals()`, but that method was already deleted in CX-43340 (replaced by `flushAll()` + per-detector `flush()`). Only `emitMetricKitPayload()` and `reportANR()` had closure-fallback branches left to remove.

## Test plan

- [x] `xcodebuild test` — full suite green (50+ test suites)
- [x] Zero new deprecation warnings; only pre-existing warnings (URLSessionLogger, ViewHelper, untouched) remain
- [x] `WireFormatTests` + `MetricsManagerTests` + `ANRDetectorTests` all green after the migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update MetricsManager to rely solely on the injected <code>MetricsCollector</code> and <code>EventReporter</code>, causing <code>emitMetricKitPayload</code> and <code>reportANR</code> to always hit the protocol sinks with debug logs when unwired while cleaning up docs referencing the removed closures. Promote shared test doubles and reframe the wire-format expectations so <code>MetricsManagerTests</code> and <code>WireFormatTests</code> assert the protocol-path output against the expected snapshot without closure helpers.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/210?tool=ast&topic=Reporting+flow>Reporting flow</a>
        </td><td>Enforce MetricsManager to call <code>MetricsCollector</code>/<code>EventReporter</code> sinks unconditionally, drop the deprecated fallback docs, and keep <code>ANRInstrumentation</code> comments aligned with the protocol-only pipeline.<details><summary>Modified files (4)</summary><ul><li>Coralogix/Sources/Instrumentation/ANRInstrumentation.swift</li>
<li>Coralogix/Sources/Model/Reporting/MetricsCollector.swift</li>
<li>Coralogix/Sources/Model/Reporting/VitalsMetric.swift</li>
<li>Coralogix/Sources/Utils/MobileVitals/MetricsManager.swift</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>feat(CX-43341): delete...</td><td>May 25, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/210?tool=ast&topic=Testing+flow>Testing flow</a>
        </td><td>Migrate MetricsManagerTests and WireFormatTests to reuse shared recording doubles and assert the protocol-path snapshot for ANR routing and vitals wire-format.<details><summary>Modified files (3)</summary><ul><li>Tests/CoralogixRumTests/MetricsManagerTests.swift</li>
<li>Tests/CoralogixRumTests/MobileVitalsTests/TestDoubles.swift</li>
<li>Tests/CoralogixRumTests/MobileVitalsTests/WireFormatTests.swift</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>feat(CX-43341): delete...</td><td>May 25, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/coralogix/cx-ios-sdk/210?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed deprecated closure fallback properties from metrics and error reporting.
  * Updated ANR event and mobile vitals routing to exclusively use core reporting mechanisms.
  * Enhanced internal test infrastructure with shared test utilities for metrics and event verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coralogix/cx-ios-sdk/pull/210?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->