### PR TITLE
chore(demo): enable all mobile-vitals detectors in CoralogixRumManager

### DIFF
--- a/Example/Shared/CoralogixRumManager.swift
+++ b/Example/Shared/CoralogixRumManager.swift
@@ -53,12 +53,12 @@ final class CoralogixRumManager {
                                                enableSwizzling: true,
                                                proxyUrl: Envs.PROXY_URL.rawValue, // remove if not need to use proxy
                                                traceParentInHeader: ["enable": true],
-                                               mobileVitals:[.cpuDetector: false,
-                                                             .warmDetector: false,
-                                                             .coldDetector: false,
-                                                             .slowFrozenFramesDetector: false,
-                                                             .memoryDetector: false,
-                                                             .renderingDetector: false],
+                                               mobileVitals:[.cpuDetector: true,
+                                                             .warmDetector: true,
+                                                             .coldDetector: true,
+                                                             .slowFrozenFramesDetector: true,
+                                                             .memoryDetector: true,
+                                                             .renderingDetector: true],
                                                networkExtraConfig: [
                                                 NetworkCaptureRule(url: "https://jsonplaceholder.typicode.com/posts",
                                                                    reqHeaders: ["Content-Type", "Accept", "X-Demo-Header"],


### PR DESCRIPTION
# User description
## Summary
- Flip every mobile-vitals detector (`cpuDetector`, `warmDetector`, `coldDetector`, `slowFrozenFramesDetector`, `memoryDetector`, `renderingDetector`) from `false` to `true` in `Example/Shared/CoralogixRumManager.swift`
- Demo-only — the SDK itself is unchanged

## Why
The shared demo `CoralogixRumManager` had every mobile-vitals detector disabled, so the demo apps never exercised the mobile-vitals pipeline at runtime. Enabling them by default makes the demo a useful smoke test for new vitals work (e.g. CX-43340 self-pushing detectors).

## Test plan
- [ ] Build & run `DemoAppSwift` and `DemoAppSwiftUI`
- [ ] Confirm vitals events appear in the local logs / Coralogix dashboard
- [ ] Verify no perf regression on the demo home screen
- [ ] Check that the existing UI tests (`DemoAppUITests`, `DemoAppSwiftUIUITests`) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Enable the <code>CoralogixRumManager</code> demo configuration to exercise the mobile vitals pipeline by toggling every detector on. Confirm the shared demo environment now runs CPU, warm, cold, slow frozen frames, memory, and rendering detectors alongside the existing network configuration.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>chore(demo): enable al...</td><td>May 26, 2026</td></tr>
<tr><td>NatanCoralogix</td><td>UI test (#85)</td><td>July 29, 2025</td></tr></table></details>
<sub><a href="https://baz.co/changes/coralogix/cx-ios-sdk/212?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>