### PR TITLE
feat(CX-40574): EventMiddleware protocol + EventPipeline

### DIFF
--- a/Coralogix/Sources/Model/Reporting/EventMiddleware.swift
+++ b/Coralogix/Sources/Model/Reporting/EventMiddleware.swift
@@ -1,0 +1,18 @@
+//
+//  EventMiddleware.swift
+//
+//
+//  Created by Coralogix DEV TEAM on 26/05/2026.
+//
+
+import Foundation
+
+/// One stage of an `EventPipeline`. Receives a `TelemetryEvent`, returns the
+/// (possibly transformed) event to forward to the next stage, or `nil` to
+/// drop it — which short-circuits the rest of the pipeline.
+///
+/// Implementations must be pure and synchronous. Concurrency belongs to the
+/// pipeline's caller; this protocol promises nothing about threading.
+protocol EventMiddleware {
+    func process(_ event: TelemetryEvent) -> TelemetryEvent?
+}

--- a/Coralogix/Sources/Model/Reporting/EventPipeline.swift
+++ b/Coralogix/Sources/Model/Reporting/EventPipeline.swift
@@ -1,0 +1,32 @@
+//
+//  EventPipeline.swift
+//
+//
+//  Created by Coralogix DEV TEAM on 26/05/2026.
+//
+
+import Foundation
+
+/// Ordered chain of `EventMiddleware` instances. Each middleware sees the
+/// output of the previous one; the first `nil` short-circuits and `process`
+/// returns `nil`.
+///
+/// Pure and synchronous — no internal locking. Callers that invoke
+/// `add(_:)` or `process(_:)` from multiple threads must provide their own
+/// synchronization.
+final class EventPipeline {
+    private var middlewares: [EventMiddleware] = []
+
+    func add(_ middleware: EventMiddleware) {
+        middlewares.append(middleware)
+    }
+
+    func process(_ event: TelemetryEvent) -> TelemetryEvent? {
+        var current: TelemetryEvent = event
+        for middleware in middlewares {
+            guard let next = middleware.process(current) else { return nil }
+            current = next
+        }
+        return current
+    }
+}

--- a/Tests/CoralogixRumTests/EventPipelineTests.swift
+++ b/Tests/CoralogixRumTests/EventPipelineTests.swift
@@ -1,0 +1,109 @@
+//
+//  EventPipelineTests.swift
+//
+//
+//  Created by Coralogix DEV TEAM on 26/05/2026.
+//
+
+import XCTest
+import CoralogixInternal
+@testable import Coralogix
+
+final class EventPipelineTests: XCTestCase {
+
+    // MARK: - fixtures
+
+    private struct LabelEvent: TelemetryEvent {
+        let id: UUID = UUID()
+        let timestamp: Date = Date()
+        var type: EventType { .error }
+        let label: String
+
+        func toOTelAttributes() -> [String: AttributeValue] { [:] }
+    }
+
+    private struct AppendMiddleware: EventMiddleware {
+        let marker: String
+        func process(_ event: TelemetryEvent) -> TelemetryEvent? {
+            guard let labelEvent = event as? LabelEvent else { return event }
+            return LabelEvent(label: labelEvent.label + marker)
+        }
+    }
+
+    private struct DroppingMiddleware: EventMiddleware {
+        func process(_ event: TelemetryEvent) -> TelemetryEvent? { nil }
+    }
+
+    private final class SpyMiddleware: EventMiddleware {
+        var seenLabels: [String] = []
+        func process(_ event: TelemetryEvent) -> TelemetryEvent? {
+            if let labelEvent = event as? LabelEvent {
+                seenLabels.append(labelEvent.label)
+            }
+            return event
+        }
+    }
+
+    // MARK: - empty / passthrough
+
+    func testEmptyPipelineReturnsEventUnchanged() {
+        let pipeline = EventPipeline()
+        let event = LabelEvent(label: "x")
+
+        let result = pipeline.process(event)
+
+        XCTAssertEqual((result as? LabelEvent)?.label, "x")
+    }
+
+    // MARK: - ordering & mutation propagation
+
+    func testMiddlewaresRunInInsertionOrder() {
+        let pipeline = EventPipeline()
+        pipeline.add(AppendMiddleware(marker: "A"))
+        pipeline.add(AppendMiddleware(marker: "B"))
+        pipeline.add(AppendMiddleware(marker: "C"))
+
+        let result = pipeline.process(LabelEvent(label: "start:"))
+
+        XCTAssertEqual((result as? LabelEvent)?.label, "start:ABC")
+    }
+
+    func testEachMiddlewareSeesPreviousMiddlewaresOutput() {
+        let pipeline = EventPipeline()
+        pipeline.add(AppendMiddleware(marker: "1"))
+        let spy = SpyMiddleware()
+        pipeline.add(spy)
+        pipeline.add(AppendMiddleware(marker: "2"))
+
+        _ = pipeline.process(LabelEvent(label: "input"))
+
+        XCTAssertEqual(spy.seenLabels, ["input1"])
+    }
+
+    // MARK: - short-circuit
+
+    func testReturningNilShortCircuitsPipeline() {
+        let pipeline = EventPipeline()
+        pipeline.add(AppendMiddleware(marker: "A"))
+        pipeline.add(DroppingMiddleware())
+        let afterDrop = SpyMiddleware()
+        pipeline.add(afterDrop)
+
+        let result = pipeline.process(LabelEvent(label: "start:"))
+
+        XCTAssertNil(result)
+        XCTAssertEqual(afterDrop.seenLabels, [], "middleware after a dropping stage must not be invoked")
+    }
+
+    func testFirstMiddlewareDroppingShortCircuitsImmediately() {
+        let pipeline = EventPipeline()
+        pipeline.add(DroppingMiddleware())
+        let spy = SpyMiddleware()
+        pipeline.add(spy)
+
+        let result = pipeline.process(LabelEvent(label: "x"))
+
+        XCTAssertNil(result)
+        XCTAssertEqual(spy.seenLabels, [])
+    }
+}

--- a/Tests/CoralogixRumTests/EventPipelineTests.swift
+++ b/Tests/CoralogixRumTests/EventPipelineTests.swift
@@ -16,7 +16,7 @@ final class EventPipelineTests: XCTestCase {
     private struct LabelEvent: TelemetryEvent {
         let id: UUID = UUID()
         let timestamp: Date = Date()
-        var type: EventType { .error }
+        var type: EventType { .unknown }
         let label: String
 
         func toOTelAttributes() -> [String: AttributeValue] { [:] }


### PR DESCRIPTION
# User description
## Summary
- Adds `EventMiddleware` protocol and `EventPipeline` class — the foundational primitives for [Phase 2](https://coralogix.atlassian.net/browse/CX-40569) of the iOS SDK Strategic Refactoring epic
- Pure / sync / no locks — concurrency belongs to the caller (lands later in [CX-40576 `TelemetryCoordinator`](https://coralogix.atlassian.net/browse/CX-40576))
- 5 new unit tests covering ordering, short-circuit, and mutation propagation
- **Purely additive** — no edits to existing code, zero regression risk

## Surface
```swift
protocol EventMiddleware {
    func process(_ event: TelemetryEvent) -> TelemetryEvent?
}

final class EventPipeline {
    func add(_ middleware: EventMiddleware)
    func process(_ event: TelemetryEvent) -> TelemetryEvent?
}
```

Semantics: middlewares run in insertion order, each receiving the output of the previous one; the first `nil` short-circuits the chain and `process` returns `nil`.

## Out of scope (intentionally — separate tickets)
- Concrete middlewares (Sampling, Enrichment, Filter, Validation, Batching) → [CX-40575](https://coralogix.atlassian.net/browse/CX-40575)
- Actor-based concurrency wrapper → [CX-40576](https://coralogix.atlassian.net/browse/CX-40576)
- `MetricsManager` migration to actor → [CX-40577](https://coralogix.atlassian.net/browse/CX-40577)
- Integration with `CoralogixExporter` / `EventReporter` / instrumentations

## Test plan
- [x] `xcodebuild test ... -only-testing:CoralogixRumTests/EventPipelineTests` → 5/5 pass (0.006s)
- [x] Full suite on iPhone 16 / iOS 18.5 → **650 tests pass**, 0 failures (up from 645, accounting for the 5 new cases)
- [ ] Reviewer to confirm: protocol surface matches the ticket's AC and is suitable for CX-40575's five concrete middlewares to plug into

Jira: https://coralogix.atlassian.net/browse/CX-40574

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CX-40575]: https://coralogix.atlassian.net/browse/CX-40575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Introduce the <code>EventMiddleware</code> protocol and <code>EventPipeline</code> to support a pure synchronous middleware chain that short-circuits when a stage returns <code>nil</code>, forming the foundation for the upcoming Strategic Refactoring flow. Ensure middlewares run in insertion order and mutations propagate through the pipeline so callers can rely on deterministic processing.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/214?tool=ast&topic=Pipeline+tests>Pipeline tests</a>
        </td><td>Validate the pipeline’s empty, ordering, mutation, and short-circuit behaviors through targeted unit tests that cover each acceptance criterion.<details><summary>Modified files (1)</summary><ul><li>Tests/CoralogixRumTests/EventPipelineTests.swift</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>test(CX-40574): use .u...</td><td>May 26, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/214?tool=ast&topic=Middleware+pipeline>Middleware pipeline</a>
        </td><td>Implement ordered <code>EventPipeline</code> that stores <code>EventMiddleware</code> instances, appends them, processes events synchronously while short-circuiting on <code>nil</code>, and propagates mutations to downstream stages.<details><summary>Modified files (2)</summary><ul><li>Coralogix/Sources/Model/Reporting/EventMiddleware.swift</li>
<li>Coralogix/Sources/Model/Reporting/EventPipeline.swift</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>feat(CX-40574): EventM...</td><td>May 26, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/coralogix/cx-ios-sdk/214?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>