### PR TITLE
feat(CX-44438): reportError accepts data alongside stack trace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Release-mechanics commits (version bumps, podspec/script tweaks, README edits) a
 omitted; the focus here is user-facing behavior changes. Tickets are referenced as
 `CX-XXXXX` (Jira) or `ALPH-XXXX` (legacy). Pull request numbers are in parentheses.
 
+## [2.7.0] - 2026-06-02
+
+### Added
+- `data: [String: Any]?` parameter on `reportError(message:, stackTrace:, ...)` and `reportError(message:, obfuscatedStackTrace:, ...)` overloads. Custom attributes now ride alongside the parsed stack frames on the emitted error event instead of being mutually exclusive with the stack trace (CX-44438, #TBD)
+
 ## [2.6.4] - 2026-05-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ omitted; the focus here is user-facing behavior changes. Tickets are referenced 
 ## [2.7.0] - 2026-06-02
 
 ### Added
-- `data: [String: Any]?` parameter on `reportError(message:, stackTrace:, ...)` and `reportError(message:, obfuscatedStackTrace:, ...)` overloads. Custom attributes now ride alongside the parsed stack frames on the emitted error event instead of being mutually exclusive with the stack trace (CX-44438, #TBD)
+- `customAttributes: [String: Any]?` parameter on `reportError(message:, stackTrace:, ...)` and `reportError(message:, obfuscatedStackTrace:, ...)` overloads. Custom attributes now ride alongside the parsed stack frames on the emitted error event instead of being mutually exclusive with the stack trace (CX-44438, #TBD)
 
 ## [2.6.4] - 2026-05-12
 

--- a/Coralogix.podspec
+++ b/Coralogix.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "Coralogix"
-  spec.version      = "2.6.4"
+  spec.version      = "2.7.0"
   spec.summary      = "Coralogix OpenTelemetry pod for iOS."
 
   spec.description  = <<-DESC
@@ -29,7 +29,7 @@ Pod::Spec.new do |spec|
 
   spec.static_framework = true
   spec.dependency 'PLCrashReporter', '~> 1.12'
-  spec.dependency 'CoralogixInternal', '2.6.4'
+  spec.dependency 'CoralogixInternal', '2.7.0'
 
   spec.test_spec 'Tests' do |test|
     test.source_files = 'Tests/CoralogixRumTests/**/*.swift'

--- a/Coralogix/Sources/CoralogixRum.swift
+++ b/Coralogix/Sources/CoralogixRum.swift
@@ -269,7 +269,7 @@ public class CoralogixRum {
                             arch: String? = nil,
                             buildId: String? = nil,
                             stackTraceType: String? = nil,
-                            data: [String: Any]? = nil) {
+                            customAttributes: [String: Any]? = nil) {
         guard CoralogixRum.isInitialized else { return }
         self.reportErrorWith(message: message,
                              stackTrace: stackTrace,
@@ -278,7 +278,7 @@ public class CoralogixRum {
                              arch: arch,
                              buildId: buildId,
                              stackTraceType: stackTraceType,
-                             data: data)
+                             customAttributes: customAttributes)
     }
 
     /// Reports a Dart obfuscated error from Flutter.
@@ -292,20 +292,20 @@ public class CoralogixRum {
     ///   - arch: The CPU architecture (e.g. `"arm64"`).
     ///   - buildId: The Dart snapshot build ID used for symbolication.
     ///   - stackTraceType: The stack trace type (e.g. `"obfuscated"`).
-    ///   - data: Optional custom attributes to attach to the error event.
+    ///   - customAttributes: Optional custom attributes to attach to the error event.
     public func reportError(message: String,
                             obfuscatedStackTrace: [String],
                             arch: String? = nil,
                             buildId: String? = nil,
                             stackTraceType: String? = Keys.obfuscated.rawValue,
-                            data: [String: Any]? = nil) {
+                            customAttributes: [String: Any]? = nil) {
         guard CoralogixRum.isInitialized else { return }
         self.reportErrorWith(message: message,
                              obfuscatedStackTrace: obfuscatedStackTrace,
                              arch: arch,
                              buildId: buildId,
                              stackTraceType: stackTraceType,
-                             data: data)
+                             customAttributes: customAttributes)
     }
     
     public func reportMobileVitalsMeasurement(type: String, metrics: [HybridMetric]) {

--- a/Coralogix/Sources/CoralogixRum.swift
+++ b/Coralogix/Sources/CoralogixRum.swift
@@ -307,7 +307,7 @@ public class CoralogixRum {
                              stackTraceType: stackTraceType,
                              data: data)
     }
-
+    
     public func reportMobileVitalsMeasurement(type: String, metrics: [HybridMetric]) {
         guard CoralogixRum.isInitialized else { return }
         if (CoralogixRum.mobileSDK.sdkFramework.isNative) { return }

--- a/Coralogix/Sources/CoralogixRum.swift
+++ b/Coralogix/Sources/CoralogixRum.swift
@@ -268,7 +268,8 @@ public class CoralogixRum {
                             isCrash: Bool = false,
                             arch: String? = nil,
                             buildId: String? = nil,
-                            stackTraceType: String? = nil) {
+                            stackTraceType: String? = nil,
+                            data: [String: Any]? = nil) {
         guard CoralogixRum.isInitialized else { return }
         self.reportErrorWith(message: message,
                              stackTrace: stackTrace,
@@ -276,7 +277,8 @@ public class CoralogixRum {
                              isCrash: isCrash,
                              arch: arch,
                              buildId: buildId,
-                             stackTraceType: stackTraceType)
+                             stackTraceType: stackTraceType,
+                             data: data)
     }
 
     /// Reports a Dart obfuscated error from Flutter.
@@ -290,19 +292,22 @@ public class CoralogixRum {
     ///   - arch: The CPU architecture (e.g. `"arm64"`).
     ///   - buildId: The Dart snapshot build ID used for symbolication.
     ///   - stackTraceType: The stack trace type (e.g. `"obfuscated"`).
+    ///   - data: Optional custom attributes to attach to the error event.
     public func reportError(message: String,
                             obfuscatedStackTrace: [String],
                             arch: String? = nil,
                             buildId: String? = nil,
-                            stackTraceType: String? = Keys.obfuscated.rawValue) {
+                            stackTraceType: String? = Keys.obfuscated.rawValue,
+                            data: [String: Any]? = nil) {
         guard CoralogixRum.isInitialized else { return }
         self.reportErrorWith(message: message,
                              obfuscatedStackTrace: obfuscatedStackTrace,
                              arch: arch,
                              buildId: buildId,
-                             stackTraceType: stackTraceType)
+                             stackTraceType: stackTraceType,
+                             data: data)
     }
-    
+
     public func reportMobileVitalsMeasurement(type: String, metrics: [HybridMetric]) {
         guard CoralogixRum.isInitialized else { return }
         if (CoralogixRum.mobileSDK.sdkFramework.isNative) { return }

--- a/Coralogix/Sources/Instrumentation/ErrorInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/ErrorInstrumentation.swift
@@ -192,7 +192,14 @@ extension CoralogixRum {
         if let buildId, !buildId.isEmpty { span.setAttribute(key: Keys.buildId.rawValue, value: buildId) }
         if let stackTraceType, !stackTraceType.isEmpty { span.setAttribute(key: Keys.stackTraceType.rawValue, value: stackTraceType) }
         if let data, !data.isEmpty {
-            span.setAttribute(key: Keys.data.rawValue, value: Helper.convertDictionaryToJsonString(dict: data))
+            // Helper.convertDictionaryToJsonString returns "" on encoding failure (e.g. non-JSON
+            // values inside `data`). Skip emitting the attribute in that case so the wire-side
+            // reader doesn't see a blank Keys.data — mirrors the "" → nil normalisation in
+            // ErrorEvent.make.
+            let json = Helper.convertDictionaryToJsonString(dict: data)
+            if !json.isEmpty {
+                span.setAttribute(key: Keys.data.rawValue, value: json)
+            }
         }
         // Note: hybrid error paths (Flutter/RN) intentionally omit the code attribute — there is
         // no meaningful error code in these contexts. Native paths pass an explicit code when relevant.

--- a/Coralogix/Sources/Instrumentation/ErrorInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/ErrorInstrumentation.swift
@@ -69,14 +69,16 @@ extension CoralogixRum {
                          obfuscatedStackTrace: [String],
                          arch: String?,
                          buildId: String?,
-                         stackTraceType: String?) {
+                         stackTraceType: String?,
+                         data: [String: Any]? = nil) {
         let frames: [[String: Any]] = obfuscatedStackTrace.map { [Keys.virt.rawValue: $0] }
         let stackTraceJson = Helper.convertArrayToJsonString(array: frames)
         reportErrorInternal(message: message,
                             stackTraceJson: stackTraceJson,
                             arch: arch,
                             buildId: buildId,
-                            stackTraceType: stackTraceType)
+                            stackTraceType: stackTraceType,
+                            data: data)
     }
 
     // MARK: - Used By React Native
@@ -86,7 +88,8 @@ extension CoralogixRum {
                          isCrash: Bool = false,
                          arch: String? = nil,
                          buildId: String? = nil,
-                         stackTraceType: String? = nil) {
+                         stackTraceType: String? = nil,
+                         data: [String: Any]? = nil) {
         let stackTraceJson = Helper.convertArrayToJsonString(array: stackTrace)
         reportErrorInternal(message: message,
                             stackTraceJson: stackTraceJson,
@@ -94,7 +97,8 @@ extension CoralogixRum {
                             isCrash: isCrash,
                             arch: arch,
                             buildId: buildId,
-                            stackTraceType: stackTraceType)
+                            stackTraceType: stackTraceType,
+                            data: data)
     }
 
     private func reportErrorInternal(message: String,
@@ -103,7 +107,8 @@ extension CoralogixRum {
                                      isCrash: Bool = false,
                                      arch: String? = nil,
                                      buildId: String? = nil,
-                                     stackTraceType: String? = nil) {
+                                     stackTraceType: String? = nil,
+                                     data: [String: Any]? = nil) {
         guard isErrorsEnabled else { return }
         self.writeError(
             domain: "",
@@ -113,7 +118,8 @@ extension CoralogixRum {
             isCrash: isCrash,
             arch: arch,
             buildId: buildId,
-            stackTraceType: stackTraceType
+            stackTraceType: stackTraceType,
+            data: data
         )
     }
 
@@ -170,7 +176,8 @@ extension CoralogixRum {
                             isCrash: Bool = false,
                             arch: String? = nil,
                             buildId: String? = nil,
-                            stackTraceType: String? = nil) {
+                            stackTraceType: String? = nil,
+                            data: [String: Any]? = nil) {
         var span = makeSpan(event: .error, source: .console, severity: .error)
         span.setAttribute(key: Keys.domain.rawValue, value: domain)
         if let code { span.setAttribute(key: Keys.code.rawValue, value: code) }
@@ -184,6 +191,9 @@ extension CoralogixRum {
         if let arch, !arch.isEmpty { span.setAttribute(key: Keys.arch.rawValue, value: arch) }
         if let buildId, !buildId.isEmpty { span.setAttribute(key: Keys.buildId.rawValue, value: buildId) }
         if let stackTraceType, !stackTraceType.isEmpty { span.setAttribute(key: Keys.stackTraceType.rawValue, value: stackTraceType) }
+        if let data, !data.isEmpty {
+            span.setAttribute(key: Keys.data.rawValue, value: Helper.convertDictionaryToJsonString(dict: data))
+        }
         // Note: hybrid error paths (Flutter/RN) intentionally omit the code attribute — there is
         // no meaningful error code in these contexts. Native paths pass an explicit code when relevant.
         recordScreenshotForSpan(to: &span)

--- a/Coralogix/Sources/Instrumentation/ErrorInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/ErrorInstrumentation.swift
@@ -70,7 +70,7 @@ extension CoralogixRum {
                          arch: String?,
                          buildId: String?,
                          stackTraceType: String?,
-                         data: [String: Any]? = nil) {
+                         customAttributes: [String: Any]? = nil) {
         let frames: [[String: Any]] = obfuscatedStackTrace.map { [Keys.virt.rawValue: $0] }
         let stackTraceJson = Helper.convertArrayToJsonString(array: frames)
         reportErrorInternal(message: message,
@@ -78,7 +78,7 @@ extension CoralogixRum {
                             arch: arch,
                             buildId: buildId,
                             stackTraceType: stackTraceType,
-                            data: data)
+                            customAttributes: customAttributes)
     }
 
     // MARK: - Used By React Native
@@ -89,7 +89,7 @@ extension CoralogixRum {
                          arch: String? = nil,
                          buildId: String? = nil,
                          stackTraceType: String? = nil,
-                         data: [String: Any]? = nil) {
+                         customAttributes: [String: Any]? = nil) {
         let stackTraceJson = Helper.convertArrayToJsonString(array: stackTrace)
         reportErrorInternal(message: message,
                             stackTraceJson: stackTraceJson,
@@ -98,7 +98,7 @@ extension CoralogixRum {
                             arch: arch,
                             buildId: buildId,
                             stackTraceType: stackTraceType,
-                            data: data)
+                            customAttributes: customAttributes)
     }
 
     private func reportErrorInternal(message: String,
@@ -108,7 +108,7 @@ extension CoralogixRum {
                                      arch: String? = nil,
                                      buildId: String? = nil,
                                      stackTraceType: String? = nil,
-                                     data: [String: Any]? = nil) {
+                                     customAttributes: [String: Any]? = nil) {
         guard isErrorsEnabled else { return }
         self.writeError(
             domain: "",
@@ -119,7 +119,7 @@ extension CoralogixRum {
             arch: arch,
             buildId: buildId,
             stackTraceType: stackTraceType,
-            data: data
+            customAttributes: customAttributes
         )
     }
 
@@ -177,7 +177,7 @@ extension CoralogixRum {
                             arch: String? = nil,
                             buildId: String? = nil,
                             stackTraceType: String? = nil,
-                            data: [String: Any]? = nil) {
+                            customAttributes: [String: Any]? = nil) {
         var span = makeSpan(event: .error, source: .console, severity: .error)
         span.setAttribute(key: Keys.domain.rawValue, value: domain)
         if let code { span.setAttribute(key: Keys.code.rawValue, value: code) }
@@ -191,15 +191,8 @@ extension CoralogixRum {
         if let arch, !arch.isEmpty { span.setAttribute(key: Keys.arch.rawValue, value: arch) }
         if let buildId, !buildId.isEmpty { span.setAttribute(key: Keys.buildId.rawValue, value: buildId) }
         if let stackTraceType, !stackTraceType.isEmpty { span.setAttribute(key: Keys.stackTraceType.rawValue, value: stackTraceType) }
-        if let data, !data.isEmpty {
-            // Helper.convertDictionaryToJsonString returns "" on encoding failure (e.g. non-JSON
-            // values inside `data`). Skip emitting the attribute in that case so the wire-side
-            // reader doesn't see a blank Keys.data — mirrors the "" → nil normalisation in
-            // ErrorEvent.make.
-            let json = Helper.convertDictionaryToJsonString(dict: data)
-            if !json.isEmpty {
-                span.setAttribute(key: Keys.data.rawValue, value: json)
-            }
+        if let json = Helper.jsonAttributeString(dict: customAttributes) {
+            span.setAttribute(key: Keys.data.rawValue, value: json)
         }
         // Note: hybrid error paths (Flutter/RN) intentionally omit the code attribute — there is
         // no meaningful error code in these contexts. Native paths pass an explicit code when relevant.

--- a/Coralogix/Sources/Model/Contexts/ErrorContext.swift
+++ b/Coralogix/Sources/Model/Contexts/ErrorContext.swift
@@ -26,6 +26,7 @@ struct ErrorContext {
     var isCrash: Bool = false
     let buildId: String?
     let stackTraceType: String?
+    var data: [String: Any]?
 
     init(otel: SpanDataProtocol) {
         self.domain = otel.getAttribute(forKey: Keys.domain.rawValue) as? String ?? ""
@@ -34,6 +35,10 @@ struct ErrorContext {
         if let jsonString = otel.getAttribute(forKey: Keys.userInfo.rawValue) as? String,
            let dict = Helper.convertJsonStringToDict(jsonString: jsonString) {
             self.userInfo = dict
+        }
+        if let jsonString = otel.getAttribute(forKey: Keys.data.rawValue) as? String,
+           let dict = Helper.convertJsonStringToDict(jsonString: jsonString) {
+            self.data = dict
         }
         
         self.exceptionType = otel.getAttribute(forKey: Keys.exceptionType.rawValue) as? String ?? ""
@@ -124,6 +129,10 @@ struct ErrorContext {
 
             if let stackTraceType = self.stackTraceType {
                 errorContext[Keys.stackTraceType.rawValue] = stackTraceType
+            }
+
+            if let data = self.data {
+                errorContext[Keys.data.rawValue] = data
             }
 
             errorContext[Keys.isCrash.rawValue] = self.isCrash

--- a/Coralogix/Sources/Model/TelemetryEvents/ErrorEvent.swift
+++ b/Coralogix/Sources/Model/TelemetryEvents/ErrorEvent.swift
@@ -97,9 +97,7 @@ struct ErrorEvent: TelemetryEvent {
         let stackTraceJson = stackTrace
             .map { Helper.convertArrayToJsonString(array: $0) }
             .flatMap { $0.isEmpty ? nil : $0 }
-        let dataJson = customAttributes
-            .map { Helper.convertDictionaryToJsonString(dict: $0) }
-            .flatMap { $0.isEmpty ? nil : $0 }
+        let dataJson = Helper.jsonAttributeString(dict: customAttributes)
         return ErrorEvent(
             id: id,
             timestamp: timestamp,

--- a/Coralogix/Sources/Model/TelemetryEvents/ErrorEvent.swift
+++ b/Coralogix/Sources/Model/TelemetryEvents/ErrorEvent.swift
@@ -89,7 +89,7 @@ struct ErrorEvent: TelemetryEvent {
         stackTraceType: String? = nil,
         userInfo: [String: Any]? = nil,
         stackTrace: [[String: Any]]? = nil,
-        data: [String: Any]? = nil
+        customAttributes: [String: Any]? = nil
     ) -> ErrorEvent {
         let userInfoJson = userInfo
             .map { Helper.convertDictionaryToJsonString(dict: $0) }
@@ -97,7 +97,7 @@ struct ErrorEvent: TelemetryEvent {
         let stackTraceJson = stackTrace
             .map { Helper.convertArrayToJsonString(array: $0) }
             .flatMap { $0.isEmpty ? nil : $0 }
-        let dataJson = data
+        let dataJson = customAttributes
             .map { Helper.convertDictionaryToJsonString(dict: $0) }
             .flatMap { $0.isEmpty ? nil : $0 }
         return ErrorEvent(

--- a/Coralogix/Sources/Model/TelemetryEvents/ErrorEvent.swift
+++ b/Coralogix/Sources/Model/TelemetryEvents/ErrorEvent.swift
@@ -26,6 +26,7 @@ struct ErrorEvent: TelemetryEvent {
     // convertJsonStringToArray).
     let userInfoJson: String?
     let stackTraceJson: String?
+    let dataJson: String?
 
     // NOTE: crash-path fields (exceptionType, crashTimestamp, processName,
     // applicationIdentifier, triggeredByThread, baseAddress, threads) are NOT
@@ -46,7 +47,8 @@ struct ErrorEvent: TelemetryEvent {
         buildId: String? = nil,
         stackTraceType: String? = nil,
         userInfoJson: String? = nil,
-        stackTraceJson: String? = nil
+        stackTraceJson: String? = nil,
+        dataJson: String? = nil
     ) {
         self.id = id
         self.timestamp = timestamp
@@ -60,6 +62,7 @@ struct ErrorEvent: TelemetryEvent {
         self.stackTraceType = stackTraceType
         self.userInfoJson = userInfoJson
         self.stackTraceJson = stackTraceJson
+        self.dataJson = dataJson
     }
 
     /// Ergonomic factory that accepts unencoded `userInfo` / `stackTrace`
@@ -85,13 +88,17 @@ struct ErrorEvent: TelemetryEvent {
         buildId: String? = nil,
         stackTraceType: String? = nil,
         userInfo: [String: Any]? = nil,
-        stackTrace: [[String: Any]]? = nil
+        stackTrace: [[String: Any]]? = nil,
+        data: [String: Any]? = nil
     ) -> ErrorEvent {
         let userInfoJson = userInfo
             .map { Helper.convertDictionaryToJsonString(dict: $0) }
             .flatMap { $0.isEmpty ? nil : $0 }
         let stackTraceJson = stackTrace
             .map { Helper.convertArrayToJsonString(array: $0) }
+            .flatMap { $0.isEmpty ? nil : $0 }
+        let dataJson = data
+            .map { Helper.convertDictionaryToJsonString(dict: $0) }
             .flatMap { $0.isEmpty ? nil : $0 }
         return ErrorEvent(
             id: id,
@@ -105,7 +112,8 @@ struct ErrorEvent: TelemetryEvent {
             buildId: buildId,
             stackTraceType: stackTraceType,
             userInfoJson: userInfoJson,
-            stackTraceJson: stackTraceJson
+            stackTraceJson: stackTraceJson,
+            dataJson: dataJson
         )
     }
 
@@ -123,6 +131,7 @@ struct ErrorEvent: TelemetryEvent {
         if let stackTraceType { attrs[Keys.stackTraceType.rawValue] = .string(stackTraceType) }
         if let userInfoJson   { attrs[Keys.userInfo.rawValue]       = .string(userInfoJson) }
         if let stackTraceJson { attrs[Keys.stackTrace.rawValue]     = .string(stackTraceJson) }
+        if let dataJson       { attrs[Keys.data.rawValue]           = .string(dataJson) }
         return attrs
     }
 }

--- a/Coralogix/Sources/Model/TelemetryEvents/NetworkRequestEvent.swift
+++ b/Coralogix/Sources/Model/TelemetryEvents/NetworkRequestEvent.swift
@@ -94,21 +94,11 @@ struct NetworkRequestEvent: TelemetryEvent {
             SemanticAttributes.httpStatusCode.rawValue:       .int(statusCode),
             SemanticAttributes.httpResponseBodySize.rawValue: .int(responseContentLength),
         ]
-        // `Helper.convertDictionaryToJsonString` logs via `Log.e(...)` and
-        // returns "" on encoding failure. Omit the attribute on failure
-        // instead of emitting an empty string that the downstream parser
-        // would silently drop again (mirrors `ErrorEvent.make`).
-        if let requestHeaders {
-            let json = Helper.convertDictionaryToJsonString(dict: requestHeaders)
-            if !json.isEmpty {
-                attrs[Keys.requestHeaders.rawValue] = .string(json)
-            }
+        if let json = Helper.jsonAttributeString(dict: requestHeaders) {
+            attrs[Keys.requestHeaders.rawValue] = .string(json)
         }
-        if let responseHeaders {
-            let json = Helper.convertDictionaryToJsonString(dict: responseHeaders)
-            if !json.isEmpty {
-                attrs[Keys.responseHeaders.rawValue] = .string(json)
-            }
+        if let json = Helper.jsonAttributeString(dict: responseHeaders) {
+            attrs[Keys.responseHeaders.rawValue] = .string(json)
         }
         if let requestPayload  { attrs[Keys.requestPayload.rawValue]  = .string(requestPayload) }
         if let responsePayload { attrs[Keys.responsePayload.rawValue] = .string(responsePayload) }

--- a/Coralogix/Sources/Model/TelemetryEvents/UserActionEvent.swift
+++ b/Coralogix/Sources/Model/TelemetryEvents/UserActionEvent.swift
@@ -65,12 +65,7 @@ struct UserActionEvent: TelemetryEvent {
         var attrs: [String: AttributeValue] = [
             Keys.eventType.rawValue: .string(type.rawValue),
         ]
-        // `Helper.convertDictionaryToJsonString` logs via `Log.e(...)` and
-        // returns "" on encoding failure. Omit the attribute on failure
-        // instead of emitting an empty string that the downstream parser
-        // would silently drop again (mirrors `ErrorEvent.make`).
-        let json = Helper.convertDictionaryToJsonString(dict: tapObject)
-        if !json.isEmpty {
+        if let json = Helper.jsonAttributeString(dict: tapObject) {
             attrs[Keys.tapObject.rawValue] = .string(json)
         }
         return attrs

--- a/Coralogix/Sources/Utils/Helper.swift
+++ b/Coralogix/Sources/Utils/Helper.swift
@@ -94,6 +94,16 @@ class Helper {
         return ""
     }
 
+    /// JSON-encodes a non-empty dictionary for emission as a span attribute, returning `nil`
+    /// when the input is `nil`/empty or when encoding fails. `convertDictionaryToJsonString`
+    /// returns `""` on encoding failure; the downstream parser drops empty-string attributes
+    /// silently, so callers should suppress the attribute entirely rather than emit `""`.
+    internal static func jsonAttributeString(dict: [String: Any]?) -> String? {
+        guard let dict, !dict.isEmpty else { return nil }
+        let json = convertDictionaryToJsonString(dict: dict)
+        return json.isEmpty ? nil : json
+    }
+
     /// Builds a dictionary `JSONSerialization` accepts: unwraps nested `Optional`s, converts `Date`/`URL`/etc.,
     /// and replaces unknown types with `String(describing:)` so one bad value does not drop the whole payload.
     private static func jsonSerializationSafeDictionary(_ dict: [String: Any], keyPath: String) -> [String: Any] {

--- a/CoralogixInternal.podspec
+++ b/CoralogixInternal.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "CoralogixInternal"
-  spec.version      = "2.6.4"
+  spec.version      = "2.7.0"
   spec.summary      = "Coralogix Internal Package. This module is not for public use."
 
   spec.description  = <<-DESC

--- a/CoralogixInternal/Sources/Utils.swift
+++ b/CoralogixInternal/Sources/Utils.swift
@@ -16,7 +16,7 @@ public enum ImageFormat {
 }
 
 public enum Global: String {
-    case sdk = "2.6.4"
+    case sdk = "2.7.0"
     case swiftVersion = "5.9"
     case coralogixPath = "/browser/v1beta/logs"
     case sessionReplayPath = "/browser/alpha/sessionrecording"

--- a/SessionReplay.podspec
+++ b/SessionReplay.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "SessionReplay"
-  spec.version      = "2.6.4"
+  spec.version      = "2.7.0"
   spec.summary      = "Coralogix Session-Replay pod for iOS."
 
   spec.description  = <<-DESC
@@ -23,7 +23,7 @@ Pod::Spec.new do |spec|
   spec.static_framework = true
 
   spec.source_files  = 'SessionReplay/Sources/**/*.swift'
-  spec.dependency 'CoralogixInternal', '2.6.4'
+  spec.dependency 'CoralogixInternal', '2.7.0'
   
     spec.test_spec 'Tests' do |test|
         test.source_files = 'Tests/SessionReplayTests/**/*.swift'

--- a/Tests/CoralogixRumTests/ErrorEventTests.swift
+++ b/Tests/CoralogixRumTests/ErrorEventTests.swift
@@ -45,7 +45,7 @@ final class ErrorEventTests: XCTestCase {
         let event = ErrorEvent.make(
             domain: "d",
             errorMessage: "m",
-            data: ["fruit": "banana"]
+            customAttributes: ["fruit": "banana"]
         )
         let attrs = event.toOTelAttributes()
         let dataAttr = try XCTUnwrap(attrs[Keys.data.rawValue])
@@ -65,7 +65,7 @@ final class ErrorEventTests: XCTestCase {
             domain: "io.app.network",
             errorMessage: "boom",
             stackTrace: [["function": "main", "file": "AppDelegate.swift", "line": 12]],
-            data: ["fruit": "banana", "count": 3]
+            customAttributes: ["fruit": "banana", "count": 3]
         )
 
         let mockSpan = MockSpanData(attributes: event.toOTelAttributes())

--- a/Tests/CoralogixRumTests/ErrorEventTests.swift
+++ b/Tests/CoralogixRumTests/ErrorEventTests.swift
@@ -51,7 +51,8 @@ final class ErrorEventTests: XCTestCase {
         let dataAttr = try XCTUnwrap(attrs[Keys.data.rawValue])
         // Encoded as a JSON string (same shape used by the log path).
         guard case .string(let raw) = dataAttr else {
-            return XCTFail("expected .string attribute, got \(dataAttr)")
+            XCTFail("expected .string attribute, got \(dataAttr)")
+            return
         }
         let decoded = try XCTUnwrap(Helper.convertJsonStringToDict(jsonString: raw))
         XCTAssertEqual(decoded["fruit"] as? String, "banana")
@@ -176,7 +177,8 @@ final class ErrorEventTests: XCTestCase {
             buildId: nil,
             stackTraceType: "objc",
             userInfoJson: nil,
-            stackTraceJson: "[]"
+            stackTraceJson: "[]",
+            dataJson: "{\"fruit\":\"banana\"}"
         )
 
         let encoded = try JSONEncoder().encode(original)
@@ -195,5 +197,6 @@ final class ErrorEventTests: XCTestCase {
         XCTAssertEqual(decoded.stackTraceType, original.stackTraceType)
         XCTAssertNil(decoded.userInfoJson)
         XCTAssertEqual(decoded.stackTraceJson, original.stackTraceJson)
+        XCTAssertEqual(decoded.dataJson,       original.dataJson)
     }
 }

--- a/Tests/CoralogixRumTests/ErrorEventTests.swift
+++ b/Tests/CoralogixRumTests/ErrorEventTests.swift
@@ -38,6 +38,53 @@ final class ErrorEventTests: XCTestCase {
         XCTAssertNil(attrs[Keys.stackTraceType.rawValue])
         XCTAssertNil(attrs[Keys.userInfo.rawValue])
         XCTAssertNil(attrs[Keys.stackTrace.rawValue])
+        XCTAssertNil(attrs[Keys.data.rawValue])
+    }
+
+    func testAdapterEmitsDataAsEncodedJsonString() throws {
+        let event = ErrorEvent.make(
+            domain: "d",
+            errorMessage: "m",
+            data: ["fruit": "banana"]
+        )
+        let attrs = event.toOTelAttributes()
+        let dataAttr = try XCTUnwrap(attrs[Keys.data.rawValue])
+        // Encoded as a JSON string (same shape used by the log path).
+        guard case .string(let raw) = dataAttr else {
+            return XCTFail("expected .string attribute, got \(dataAttr)")
+        }
+        let decoded = try XCTUnwrap(Helper.convertJsonStringToDict(jsonString: raw))
+        XCTAssertEqual(decoded["fruit"] as? String, "banana")
+    }
+
+    // Parity: pipe data through ErrorEvent → toOTelAttributes() → ErrorContext
+    // and assert the wire dict carries the data dictionary alongside the stack trace.
+    func testDictParityViaExistingContextPath_withDataAndStackTrace() throws {
+        let event = ErrorEvent.make(
+            domain: "io.app.network",
+            errorMessage: "boom",
+            stackTrace: [["function": "main", "file": "AppDelegate.swift", "line": 12]],
+            data: ["fruit": "banana", "count": 3]
+        )
+
+        let mockSpan = MockSpanData(attributes: event.toOTelAttributes())
+        let context = ErrorContext(otel: mockSpan)
+        let dict = context.getDictionary()
+
+        let data = try XCTUnwrap(dict[Keys.data.rawValue] as? [String: Any])
+        XCTAssertEqual(data["fruit"] as? String, "banana")
+        XCTAssertEqual(data["count"] as? Int, 3)
+
+        // Stack trace must still land alongside data (the bug this ticket fixes).
+        let stack = try XCTUnwrap(dict[Keys.originalStackTrace.rawValue] as? [[String: Any]])
+        XCTAssertEqual(stack.first?["function"] as? String, "main")
+    }
+
+    func testContextOmitsDataWhenAbsent() {
+        let event = ErrorEvent(domain: "d", errorMessage: "m")
+        let mockSpan = MockSpanData(attributes: event.toOTelAttributes())
+        let context = ErrorContext(otel: mockSpan)
+        XCTAssertNil(context.getDictionary()[Keys.data.rawValue])
     }
 
     func testAdapterEmitsCodeAsInt() {


### PR DESCRIPTION
# User description
## Summary
- Adds `data: [String: Any]?` parameter to both stack-trace `reportError` public overloads (`stackTrace:` and `obfuscatedStackTrace:`).
- Plumbs `data` through `reportErrorWith` → `reportErrorInternal` → `writeError`; JSON-encoded onto `Keys.data` so the existing wire-side reader picks it up unchanged.
- Extends `ErrorEvent` (new `dataJson` + factory `data:` param) and `ErrorContext` (read + emit) so the attribute round-trips through the existing model/wire layer.
- Bumps SDK 2.6.4 → 2.7.0 (`feat:` per AGENTS.md SemVer rule).

## Context
Closes CX-44438. Until now `reportError(message:, data:)` and `reportError(message:, stackTrace:, ...)` were mutually exclusive — hybrid SDKs (Flutter, React Native) had to choose between custom attributes and a parsed stack trace on a single error event. This change adds an optional `data:` parameter to the stack-trace overloads, source-compatible with all existing callers (default `nil`).

Related tickets:
- CX-44437 — parent Flutter epic
- CX-44440 — downstream Flutter plugin wiring (depends on this release)

## Test plan
- [x] `xcodebuild test -scheme Coralogix-Package -only-testing:CoralogixRumTests` → 653 tests, 0 failures (full suite re-run after version bump).
- [x] 3 new `ErrorEventTests` cover: attribute emission shape, `Keys.data` absence when nil, full `ErrorEvent → toOTelAttributes → ErrorContext → getDictionary` parity with both stack trace and data set (the regression case for the ticket).
- [x] `./verify_podspec_versions.sh v2.7.0` → all three podspecs match.

## Notes for the reviewer
- Crash-path fields on `ErrorEvent` (`exceptionType`, `threads`, etc.) were intentionally left untouched — the existing struct comment flags them as out-of-scope until the crash variant is specified. This PR only adds `data` to the hand-written error path.
- The `CHANGELOG.md` entry references `#TBD` — happy to swap for the real PR number in a follow-up commit if you prefer, otherwise the squash-merge title carries the PR number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Extend <code>CoralogixRum.reportError</code> stack-trace overloads to accept optional <code>customAttributes</code> and flow them through <code>ErrorInstrumentation</code> and <code>writeError</code> so data rides alongside parsed stack frames in emitted spans. Publish SDK 2.7.0 with updated podspecs, helper improvements, and enriched error event/context models so the new API ships with correct package metadata.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/217?tool=ast&topic=Error+stack+data>Error stack data</a>
        </td><td>Add <code>customAttributes</code> handling to stack-trace error reporting so <code>ErrorEvent</code>/<code>ErrorContext</code> encode the attributes, helper/json changes drop empty values, and tests cover the emitted data payloads.<details><summary>Modified files (8)</summary><ul><li>Coralogix/Sources/CoralogixRum.swift</li>
<li>Coralogix/Sources/Instrumentation/ErrorInstrumentation.swift</li>
<li>Coralogix/Sources/Model/Contexts/ErrorContext.swift</li>
<li>Coralogix/Sources/Model/TelemetryEvents/ErrorEvent.swift</li>
<li>Coralogix/Sources/Model/TelemetryEvents/NetworkRequestEvent.swift</li>
<li>Coralogix/Sources/Model/TelemetryEvents/UserActionEvent.swift</li>
<li>Coralogix/Sources/Utils/Helper.swift</li>
<li>Tests/CoralogixRumTests/ErrorEventTests.swift</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>chore(CX-44438): renam...</td><td>June 02, 2026</td></tr>
<tr><td>aking618</td><td>Allow clearing user co...</td><td>February 19, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/217?tool=ast&topic=SDK+release+prep>SDK release prep</a>
        </td><td>Publish SDK 2.7.0 by bumping podspec versions, the internal SDK constant, and logging the release in <code>CHANGELOG.md</code> to match the new feature.<details><summary>Modified files (5)</summary><ul><li>CHANGELOG.md</li>
<li>Coralogix.podspec</li>
<li>CoralogixInternal.podspec</li>
<li>CoralogixInternal/Sources/Utils.swift</li>
<li>SessionReplay.podspec</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>chore(CX-44438): renam...</td><td>June 02, 2026</td></tr>
<tr><td>NatanCoralogix</td><td>bump crash reporter (#...</td><td>September 01, 2025</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/coralogix/cx-ios-sdk/217?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>