### PR TITLE
ci(demo-ui): install AFNetworking via CocoaPods before UI build

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -235,6 +235,18 @@ jobs:
           echo "✅ Created placeholder GoogleService-Info.plist (app will skip Firebase init)"
           ls -la GoogleService-Info.plist
 
+      - name: Install CocoaPods dependencies (AFNetworking)
+        run: |
+          set -euo pipefail
+          cd Example
+          echo "📦 Installing CocoaPods dependencies..."
+          echo "    CocoaPods version: $(pod --version)"
+          pod install 2>&1 | tail -30
+          echo "✅ pod install completed"
+          echo ""
+          echo "📋 Workspace contents after pod install:"
+          cat DemoApp.xcworkspace/contents.xcworkspacedata
+
       - name: Build for testing
         run: |
           set -uo pipefail

--- a/Example/DemoApp.xcodeproj/project.pbxproj
+++ b/Example/DemoApp.xcodeproj/project.pbxproj
@@ -19,10 +19,8 @@
 		E622116C2BFF2A7B00052682 /* Keys.swift in Sources */ = {isa = PBXBuildFile; fileRef = E622116B2BFF2A7B00052682 /* Keys.swift */; };
 		E622116D2BFF2D5300052682 /* Keys.swift in Sources */ = {isa = PBXBuildFile; fileRef = E622116B2BFF2A7B00052682 /* Keys.swift */; };
 		E648914C2ED35B2600624978 /* FullImageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E648914B2ED35B2600624978 /* FullImageCell.swift */; };
-		E64ABB282F3C5CFA00D990A9 /* AFNetworking in Frameworks */ = {isa = PBXBuildFile; productRef = E64ABB272F3C5CFA00D990A9 /* AFNetworking */; };
 		E64ABB2B2F3C5ECB00D990A9 /* SDWebImage in Frameworks */ = {isa = PBXBuildFile; productRef = E64ABB2A2F3C5ECB00D990A9 /* SDWebImage */; };
 		E64ABB2E2F3C5F0300D990A9 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = E64ABB2D2F3C5F0300D990A9 /* Alamofire */; };
-		E64ABB312F3C5CFA00D990B9 /* AFNetworking in Frameworks */ = {isa = PBXBuildFile; productRef = E64ABB302F3C5CFA00D990B9 /* AFNetworking */; };
 		E64ABB332F3C5ECB00D990B9 /* SDWebImage in Frameworks */ = {isa = PBXBuildFile; productRef = E64ABB322F3C5ECB00D990B9 /* SDWebImage */; };
 		E64ABB352F3C5F0300D990B9 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = E64ABB342F3C5F0300D990B9 /* Alamofire */; };
 		E6525B5B2E38BE3C006DB4AA /* envs.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6525B5A2E38BE3A006DB4AA /* envs.swift */; };
@@ -246,7 +244,6 @@
 			files = (
 				E66E3B6C2DA7FB6400FBC86B /* Coralogix in Frameworks */,
 				E6B60A022DB4E53F003AD35D /* SessionReplay in Frameworks */,
-				E64ABB312F3C5CFA00D990B9 /* AFNetworking in Frameworks */,
 				E64ABB332F3C5ECB00D990B9 /* SDWebImage in Frameworks */,
 				E64ABB352F3C5F0300D990B9 /* Alamofire in Frameworks */,
 			);
@@ -272,7 +269,6 @@
 				E64ABB2B2F3C5ECB00D990A9 /* SDWebImage in Frameworks */,
 				E690EADE2EF182F60011C147 /* FirebaseCore in Frameworks */,
 				E690EADC2EF182F60011C147 /* FirebaseAnalytics in Frameworks */,
-				E64ABB282F3C5CFA00D990A9 /* AFNetworking in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -500,7 +496,6 @@
 			packageProductDependencies = (
 				E66E3B6B2DA7FB6400FBC86B /* Coralogix */,
 				E6B60A012DB4E53F003AD35D /* SessionReplay */,
-				E64ABB302F3C5CFA00D990B9 /* AFNetworking */,
 				E64ABB322F3C5ECB00D990B9 /* SDWebImage */,
 				E64ABB342F3C5F0300D990B9 /* Alamofire */,
 			);
@@ -551,7 +546,6 @@
 				E690EADB2EF182F60011C147 /* FirebaseAnalytics */,
 				E690EADD2EF182F60011C147 /* FirebaseCore */,
 				E690EADF2EF182F60011C147 /* FirebaseCrashlytics */,
-				E64ABB272F3C5CFA00D990A9 /* AFNetworking */,
 				E64ABB2A2F3C5ECB00D990A9 /* SDWebImage */,
 				E64ABB2D2F3C5F0300D990A9 /* Alamofire */,
 			);
@@ -600,7 +594,6 @@
 			packageReferences = (
 				E66E3B662DA7F76C00FBC86B /* XCLocalSwiftPackageReference "../../cx-ios-sdk" */,
 				E690EADA2EF182F60011C147 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
-				E64ABB262F3C5CFA00D990A9 /* XCRemoteSwiftPackageReference "AFNetworking" */,
 				E64ABB292F3C5ECB00D990A9 /* XCRemoteSwiftPackageReference "SDWebImage" */,
 				E64ABB2C2F3C5F0300D990A9 /* XCRemoteSwiftPackageReference "Alamofire" */,
 			);
@@ -1290,14 +1283,6 @@
 /* End XCLocalSwiftPackageReference section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		E64ABB262F3C5CFA00D990A9 /* XCRemoteSwiftPackageReference "AFNetworking" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/AFNetworking/AFNetworking.git";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 4.0.1;
-			};
-		};
 		E64ABB292F3C5ECB00D990A9 /* XCRemoteSwiftPackageReference "SDWebImage" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SDWebImage/SDWebImage.git";
@@ -1325,11 +1310,6 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		E64ABB272F3C5CFA00D990A9 /* AFNetworking */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = E64ABB262F3C5CFA00D990A9 /* XCRemoteSwiftPackageReference "AFNetworking" */;
-			productName = AFNetworking;
-		};
 		E64ABB2A2F3C5ECB00D990A9 /* SDWebImage */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = E64ABB292F3C5ECB00D990A9 /* XCRemoteSwiftPackageReference "SDWebImage" */;
@@ -1339,11 +1319,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = E64ABB2C2F3C5F0300D990A9 /* XCRemoteSwiftPackageReference "Alamofire" */;
 			productName = Alamofire;
-		};
-		E64ABB302F3C5CFA00D990B9 /* AFNetworking */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = E64ABB262F3C5CFA00D990A9 /* XCRemoteSwiftPackageReference "AFNetworking" */;
-			productName = AFNetworking;
 		};
 		E64ABB322F3C5ECB00D990B9 /* SDWebImage */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,14 +1,16 @@
 platform :ios, '13.0'
 use_frameworks!
 
+# AFNetworking is the only Pod-managed dependency.
+# Alamofire and SDWebImage are linked via SwiftPM in DemoApp.xcodeproj.
+# AFNetworking went through CocoaPods because its SwiftPM distribution fails
+# to compile against the iOS 26.5 SDK ("Use of private header from outside its
+# module: 'netinet6/in6.h'"); CocoaPods builds it cleanly on the CI iOS 18 sim.
+
 target 'DemoAppSwift' do
-  pod 'Alamofire'
   pod 'AFNetworking'
-  pod 'SDWebImage'
 end
 
 target 'DemoAppSwiftUI' do
-  pod 'Alamofire'
   pod 'AFNetworking'
-  pod 'SDWebImage'
 end

--- a/Example/Shared/SimulateFolder/NetworkSim.swift
+++ b/Example/Shared/SimulateFolder/NetworkSim.swift
@@ -9,7 +9,9 @@ import Foundation
 import UIKit
 import Coralogix
 import Alamofire
+#if canImport(AFNetworking)
 import AFNetworking
+#endif
 import SDWebImage
 
 //https://github.com/AFNetworking/AFNetworking.git
@@ -80,6 +82,7 @@ class NetworkSim {
         task.resume()
     }
     
+    #if canImport(AFNetworking)
     static func sendAFNetworkingRequest() {
         let manager = AFHTTPSessionManager()
         manager.responseSerializer = AFJSONResponseSerializer()
@@ -89,6 +92,11 @@ class NetworkSim {
             print("Error: \(error.localizedDescription)")
         }
     }
+    #else
+    static func sendAFNetworkingRequest() {
+        print("[NetworkSim] AFNetworking not linked in this build — sendAFNetworkingRequest is a no-op.")
+    }
+    #endif
     
     static func setNetworkRequestContextSuccsess() {
         let dict = ["url" : "\(url)",


### PR DESCRIPTION
# User description
## Summary

- Restore CI coverage of the AFNetworking instrumentation path that commit `4784cc2` had to give up to unblock local Xcode 26.x builds.
- Trim `Example/Podfile` to AFNetworking only (Alamofire and SDWebImage stay on SwiftPM — they already work cross-Xcode-version, doubling them would duplicate-link).
- Add a `pod install` step to `.github/workflows/ui-tests.yml` immediately before `build-for-testing`.

## Why this works in CI but not locally

| | Xcode | iOS sim | CocoaPods 1.16.2 | AFNetworking 4.0.1 |
|---|---|---|---|---|
| Local dev | 26.x | 26.5 SDK | ❌ doesn't parse `objectVersion 70` (upstream issues #12840, #12889) | ❌ `netinet6/in6.h` private-header crash |
| CI (`macos-15`) | 16.4 | 18.x (pinned via `CI_DEPLOYMENT_TARGET=18.0`) | ✅ | ✅ |

Local devs continue to use the `#if canImport(AFNetworking)` stub introduced in `4784cc2` — they never need to run `pod install`. Once CocoaPods adds `objectVersion 70` support and AFNetworking publishes a fix for iOS 26.x, local devs can opt into the real path.

## Coordination note

This branch cherry-picks `4784cc2` from `fix/session-rotation-stale-id-bug` so it can be self-contained. Merge ordering:

- If `fix/session-rotation-stale-id-bug` lands on master **first**, this PR's cherry-pick becomes patch-equivalent and merges cleanly (git skips the duplicate).
- If this PR lands **first**, the session-rotation branch will need a rebase to drop its now-duplicate `4784cc2` commit.

No conflict either way — just FYI for whoever merges second.

## What I could NOT verify locally

Couldn't smoke-test on this machine: CocoaPods 1.16.2 throws `[Xcodeproj] Unable to find compatibility version string for object version 70` on Xcode 26.5's pbxproj format — `pod install` can't even start, regardless of dependency set. This is the same root incompatibility we're stepping around. So **CI is the verification path**.

## Test plan

- [ ] `Install CocoaPods dependencies` step succeeds; workspace contents print shows `DemoApp.xcodeproj` + `Pods/Pods.xcodeproj`.
- [ ] `Build for testing` succeeds — AFNetworking compiles on iOS 18 sim, no SPM/Cocoapods duplicate-link errors for Alamofire/SDWebImage.
- [ ] `Run UI Tests` — `NetworkInstrumentationUITests` passes including entry `8. AFNetworking` in `verifyExpectedRequests` (`Example/DemoAppUITests/NetworkInstrumentationUITests.swift:546`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Enable AFNetworking instrumentation for <code>DemoApp</code> by trimming the <code>Podfile</code> to just that Pod, leaving Alamofire and SDWebImage on SwiftPM, and guarding the <code>NetworkSim</code> helper when AFNetworking isn’t linked. Add a CocoaPods install stage to the UI test workflow so the workspace rebuilds with AFNetworking before the <code>build-for-testing</code> step.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/219?tool=ast&topic=CI+pod+install>CI pod install</a>
        </td><td>Add a CocoaPods install stage so the UI test workflow rebuilds the workspace with AFNetworking before running the build-for-testing job.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/ui-tests.yml</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>ci(demo-ui): install A...</td><td>June 02, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/219?tool=ast&topic=AFNetworking+wiring>AFNetworking wiring</a>
        </td><td>Enable AFNetworking instrumentation by slimming the <code>Podfile</code> to a single CocoaPods dependency, updating the DemoApp project references accordingly, and guarding the <code>NetworkSim</code> helper when AFNetworking isn’t linked.<details><summary>Modified files (3)</summary><ul><li>Example/DemoApp.xcodeproj/project.pbxproj</li>
<li>Example/Podfile</li>
<li>Example/Shared/SimulateFolder/NetworkSim.swift</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>ci(demo-ui): install A...</td><td>June 02, 2026</td></tr>
<tr><td>NatanCoralogix</td><td>UI test (#85)</td><td>July 29, 2025</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/coralogix/cx-ios-sdk/219?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>