### PR TITLE
fix(CX-44686): align instrumentation_data attrs with beforeSend modifications

### DIFF
--- a/Coralogix/Sources/Model/CxSpan.swift
+++ b/Coralogix/Sources/Model/CxSpan.swift
@@ -175,13 +175,14 @@ public class CxSpan {
               var instrumentationData = self.instrumentationData?.getDictionary() else {
             return
         }
-        // CX-44686: `instrumentationData` was built in init() from the pre-`beforeSend`
-        // cxRum, so its `otelSpan.attributes` carry the original values. Rebuild that
-        // attribute map from the FINAL cx_rum dictionary (text.cx_rum — which is either
-        // mergedDict after beforeSend or originalCxRum when no callback was supplied) so
-        // both serialized destinations of the span (text.cx_rum and instrumentation_data)
-        // carry the same final, beforeSend-modified attribute values.
-        if var otelSpanDict = instrumentationData[Keys.otelSpan.rawValue] as? [String: Any],
+        // CX-44686: rebuild `otelSpan.attributes` from the FINAL cx_rum dictionary
+        // (post-`beforeSend` mergedDict) so customer modifications propagate into both
+        // `text.cx_rum` and `instrumentation_data`. Gated on `beforeSend != nil` because
+        // the cx_rum dict is a lossy view of the struct (e.g. CxRumPayloadBuilder omits
+        // `error_context` for non-`.error` events) — rebuilding unconditionally would
+        // silently drop those struct-only fields for customers who don't use beforeSend.
+        if self.beforeSend != nil,
+           var otelSpanDict = instrumentationData[Keys.otelSpan.rawValue] as? [String: Any],
            let textDict = result[Keys.text.rawValue] as? [String: Any],
            let finalCxRumDict = textDict[Keys.cxRum.rawValue] as? [String: Any] {
             otelSpanDict[Keys.attributes.rawValue] = OtelSpan.buildRumContextAttributes(

--- a/Coralogix/Sources/Model/CxSpan.swift
+++ b/Coralogix/Sources/Model/CxSpan.swift
@@ -83,11 +83,18 @@ public class CxSpan {
 
                 // Restore stripped sessionContext fields (sessionId, sessionCreationDate)
                 // for the same reason — a callback could inject them inside sessionContext.
-                if var mergedSession = mergedDict[Keys.sessionContext.rawValue] as? [String: Any],
-                   let originalSession = originalCxRum[Keys.sessionContext.rawValue] as? [String: Any] {
-                    mergedSession[Keys.sessionId.rawValue] = originalSession[Keys.sessionId.rawValue]
-                    mergedSession[Keys.sessionCreationDate.rawValue] = originalSession[Keys.sessionCreationDate.rawValue]
-                    mergedDict[Keys.sessionContext.rawValue] = mergedSession
+                // If the callback corrupted sessionContext to a non-dict value
+                // (e.g. returned a string), mergeDictionaries replaced our dict with it
+                // entirely; restore the whole original sessionContext in that case so
+                // sessionId/sessionCreationDate aren't lost downstream.
+                if let originalSession = originalCxRum[Keys.sessionContext.rawValue] as? [String: Any] {
+                    if var mergedSession = mergedDict[Keys.sessionContext.rawValue] as? [String: Any] {
+                        mergedSession[Keys.sessionId.rawValue] = originalSession[Keys.sessionId.rawValue]
+                        mergedSession[Keys.sessionCreationDate.rawValue] = originalSession[Keys.sessionCreationDate.rawValue]
+                        mergedDict[Keys.sessionContext.rawValue] = mergedSession
+                    } else {
+                        mergedDict[Keys.sessionContext.rawValue] = originalSession
+                    }
                 }
 
                 // Sync severity from editableCxRum to both the top-level field and

--- a/Coralogix/Sources/Model/CxSpan.swift
+++ b/Coralogix/Sources/Model/CxSpan.swift
@@ -66,12 +66,29 @@ public class CxSpan {
             if let editableCxRum = self.beforeSend?(subsetOfCxRum) {
                 var mergedDict = mergeDictionaries(original: originalCxRum, editable: editableCxRum)
 
-                // snapshotContext is stripped from the editable subset before beforeSend is called,
-                // but a callback could still inject it into the returned dict, causing mergeDictionaries
-                // to deep-merge corrupted counts into our internal value.
-                // Always restore from originalCxRum so errorCount/viewCount cannot be tampered with.
-                // Assigning nil removes the key when the original had no snapshot (no-snapshot spans).
-                mergedDict[Keys.snapshotContext.rawValue] = originalCxRum[Keys.snapshotContext.rawValue]
+                // CX-44686: read-only keys are stripped from the editable subset before
+                // beforeSend is called, but a callback could still inject them into the
+                // returned dict, causing mergeDictionaries to deep-merge tampered values.
+                // Always restore each from originalCxRum so span identity (traceId/spanId),
+                // dedup (fingerPrint), session continuity (prevSession), runtime constants
+                // (mobileSdk/timestamp/platform), and SDK-owned counters (snapshotContext /
+                // isSnapshotEvent) cannot be edited or forged.
+                for key in CxSpan.readOnlyCxRumKeys {
+                    if let original = originalCxRum[key] {
+                        mergedDict[key] = original
+                    } else {
+                        mergedDict.removeValue(forKey: key)
+                    }
+                }
+
+                // Restore stripped sessionContext fields (sessionId, sessionCreationDate)
+                // for the same reason — a callback could inject them inside sessionContext.
+                if var mergedSession = mergedDict[Keys.sessionContext.rawValue] as? [String: Any],
+                   let originalSession = originalCxRum[Keys.sessionContext.rawValue] as? [String: Any] {
+                    mergedSession[Keys.sessionId.rawValue] = originalSession[Keys.sessionId.rawValue]
+                    mergedSession[Keys.sessionCreationDate.rawValue] = originalSession[Keys.sessionCreationDate.rawValue]
+                    mergedDict[Keys.sessionContext.rawValue] = mergedSession
+                }
 
                 // Sync severity from editableCxRum to both the top-level field and
                 // mergedDict[eventContext][severity] so they remain consistent.
@@ -147,10 +164,27 @@ public class CxSpan {
     }
     
     private func addInstrumentationData(to result: inout [String: Any]) {
-        if cxRum.eventContext.type == .networkRequest || cxRum.eventContext.type == .customSpan,
-           let instrumentationData = self.instrumentationData?.getDictionary() {
-            result[Keys.instrumentationData.rawValue] = instrumentationData
+        guard cxRum.eventContext.type == .networkRequest || cxRum.eventContext.type == .customSpan,
+              var instrumentationData = self.instrumentationData?.getDictionary() else {
+            return
         }
+        // CX-44686: `instrumentationData` was built in init() from the pre-`beforeSend`
+        // cxRum, so its `otelSpan.attributes` carry the original values. Rebuild that
+        // attribute map from the FINAL cx_rum dictionary (text.cx_rum — which is either
+        // mergedDict after beforeSend or originalCxRum when no callback was supplied) so
+        // both serialized destinations of the span (text.cx_rum and instrumentation_data)
+        // carry the same final, beforeSend-modified attribute values.
+        if var otelSpanDict = instrumentationData[Keys.otelSpan.rawValue] as? [String: Any],
+           let textDict = result[Keys.text.rawValue] as? [String: Any],
+           let finalCxRumDict = textDict[Keys.cxRum.rawValue] as? [String: Any] {
+            otelSpanDict[Keys.attributes.rawValue] = OtelSpan.buildRumContextAttributes(
+                fromCxRumDict: finalCxRumDict,
+                viewManager: self.viewManager,
+                mobileSdkVersion: self.cxRum.mobileSDK.sdkFramework.version
+            )
+            instrumentationData[Keys.otelSpan.rawValue] = otelSpanDict
+        }
+        result[Keys.instrumentationData.rawValue] = instrumentationData
     }
     
     func mergeDictionaries(original: [String: Any], editable: [String: Any]) -> [String: Any] {
@@ -199,6 +233,22 @@ public class CxSpan {
         result[Keys.text.rawValue] = textDict
     }
 
+    // CX-44686: keys the customer's `beforeSend` callback must not see or modify.
+    // Restored from the original cx_rum after `mergeDictionaries` so a callback that
+    // injects any of them in its return dict cannot tamper with span identity, dedup,
+    // or SDK-owned counters.
+    static let readOnlyCxRumKeys: [String] = [
+        Keys.snapshotContext.rawValue,
+        Keys.isSnapshotEvent.rawValue,
+        Keys.mobileSdk.rawValue,
+        Keys.timestamp.rawValue,
+        Keys.traceId.rawValue,
+        Keys.spanId.rawValue,
+        Keys.fingerPrint.rawValue,
+        Keys.prevSession.rawValue,
+        Keys.platform.rawValue
+    ]
+
     func createSubsetOfCxRum(from originalCxRum: [String: Any]) -> [String: Any] {
         var editableCxRum = originalCxRum
         // Remove sessionCreationDate and sessionId form sessionContext
@@ -207,11 +257,11 @@ public class CxSpan {
             sessionContext.removeValue(forKey: Keys.sessionId.rawValue)
             editableCxRum[Keys.sessionContext.rawValue] = sessionContext
         }
-        
-        editableCxRum.removeValue(forKey: Keys.snapshotContext.rawValue)
-        editableCxRum.removeValue(forKey: Keys.mobileSdk.rawValue)
-        editableCxRum.removeValue(forKey: Keys.timestamp.rawValue)
-       
+
+        for key in CxSpan.readOnlyCxRumKeys {
+            editableCxRum.removeValue(forKey: key)
+        }
+
         return editableCxRum
     }
 }

--- a/Coralogix/Sources/Model/InstrumentationData.swift
+++ b/Coralogix/Sources/Model/InstrumentationData.swift
@@ -121,6 +121,81 @@ struct OtelSpan {
 
     // Mirrors the web SDK's buildRumContextAttributes(), using cx_rum.* prefixed keys.
     // N/A mobile fields (browser, browserVersion, url_blueprint, resource_context) are omitted.
+    //
+    // CX-44686: dictionary variant — reads the same fields from the post-`beforeSend`
+    // cx_rum dictionary (as produced by `CxRumPayloadBuilder.build()` / `mergeDictionaries`)
+    // so that customer modifications applied via `beforeSend` propagate into
+    // `instrumentation_data.otelSpan.attributes` and not just into `text.cx_rum`.
+    // The two destinations of a span must carry the same final attribute values.
+    internal static func buildRumContextAttributes(
+        fromCxRumDict cxRumDict: [String: Any],
+        viewManager: ViewManager?,
+        mobileSdkVersion: String
+    ) -> [String: Any] {
+        var attrs = [String: Any]()
+
+        attrs[AttrKey.mobileSdkVersion] = mobileSdkVersion
+
+        if let env = cxRumDict[Keys.environment.rawValue] as? String, !env.isEmpty {
+            attrs[AttrKey.environment] = env
+        }
+        let platform = (Global.getOs() == Keys.tvos.rawValue) ? Keys.television.rawValue : Keys.mobile.rawValue
+        attrs[AttrKey.platform] = platform
+
+        if let vm = cxRumDict[Keys.versionMetaData.rawValue] as? [String: Any] {
+            attrs[AttrKey.versionMetadataAppName]    = vm[Keys.appName.rawValue]
+            attrs[AttrKey.versionMetadataAppVersion] = vm[Keys.appVersion.rawValue]
+        }
+
+        if let labels = cxRumDict[Keys.labels.rawValue] as? [String: Any], !labels.isEmpty {
+            attrs[AttrKey.labels] = labels
+        }
+
+        if let session = cxRumDict[Keys.sessionContext.rawValue] as? [String: Any] {
+            if let v = session[Keys.sessionId.rawValue] as? String { attrs[AttrKey.sessionId] = v }
+            if let v = session[Keys.sessionCreationDate.rawValue] { attrs[AttrKey.sessionCreationDate] = v }
+            if let v = session[Keys.hasRecording.rawValue] as? Bool { attrs[AttrKey.hasRecording] = v }
+            if let v = session[Keys.userId.rawValue] as? String, !v.isEmpty { attrs[AttrKey.userId] = v }
+            if let v = session[Keys.userName.rawValue] as? String, !v.isEmpty { attrs[AttrKey.userName] = v }
+            if let v = session[Keys.userEmail.rawValue] as? String, !v.isEmpty { attrs[AttrKey.userEmail] = v }
+        }
+        attrs[AttrKey.os]        = Global.getOs()
+        attrs[AttrKey.osVersion] = Global.osVersionInfo()
+        attrs[AttrKey.device]    = Global.getDeviceModel()
+        attrs[AttrKey.userAgent] = UserAgentManager.shared.getUserAgent()
+
+        if let event = cxRumDict[Keys.eventContext.rawValue] as? [String: Any] {
+            if let v = event[Keys.type.rawValue]     { attrs[AttrKey.eventType]     = v }
+            if let v = event[Keys.severity.rawValue] { attrs[AttrKey.eventSeverity] = v }
+            if let v = event[Keys.source.rawValue] as? String, !v.isEmpty { attrs[AttrKey.eventSource] = v }
+        }
+
+        if let err = cxRumDict[Keys.errorContext.rawValue] as? [String: Any] {
+            if let v = err[Keys.errorType.rawValue] as? String, !v.isEmpty { attrs[AttrKey.errorType] = v }
+            if let v = err[Keys.errorMessage.rawValue] as? String, !v.isEmpty { attrs[AttrKey.errorMessage] = v }
+        }
+
+        if let net = cxRumDict[Keys.networkRequestContext.rawValue] as? [String: Any],
+           let url = net[Keys.url.rawValue] as? String, !url.isEmpty {
+            attrs[AttrKey.networkUrl]        = url
+            attrs[AttrKey.networkMethod]     = net[Keys.method.rawValue]
+            attrs[AttrKey.networkStatusCode] = net[Keys.statusCode.rawValue]
+            attrs[AttrKey.networkStatusText] = net[Keys.statusText.rawValue]
+            attrs[AttrKey.networkFragments]  = net[Keys.fragments.rawValue]
+            if let h = net[Keys.requestHeaders.rawValue]  { attrs[AttrKey.networkRequestHeaders]  = h }
+            if let h = net[Keys.responseHeaders.rawValue] { attrs[AttrKey.networkResponseHeaders] = h }
+            if let p = net[Keys.requestPayload.rawValue]  { attrs[AttrKey.networkRequestPayload]  = p }
+            if let p = net[Keys.responsePayload.rawValue] { attrs[AttrKey.networkResponsePayload] = p }
+        }
+
+        if let pageUrl = viewManager?.getDictionary()[Keys.view.rawValue] as? String, !pageUrl.isEmpty {
+            attrs[AttrKey.pageUrl]       = pageUrl
+            attrs[AttrKey.pageFragments] = pageUrl
+        }
+
+        return attrs
+    }
+
     private static func buildRumContextAttributes(cxRum: CxRum, viewManager: ViewManager?) -> [String: Any] {
         var attrs = [String: Any]()
 

--- a/Tests/CoralogixRumTests/BeforeSendInstrumentationDataTests.swift
+++ b/Tests/CoralogixRumTests/BeforeSendInstrumentationDataTests.swift
@@ -1,0 +1,492 @@
+//
+//  BeforeSendInstrumentationDataTests.swift
+//
+//  CX-44686: when `beforeSend` modifies a cx_rum field, the change must propagate
+//  to BOTH `text.cx_rum` AND `instrumentation_data.otelSpan.attributes.cx_rum.*`.
+//  Read-only / identity / counter / runtime-constant fields must not be exposed
+//  in the editable subset, and customer-supplied values for those keys must be
+//  ignored even if the callback injects them in its return dict.
+//
+
+import XCTest
+import CoralogixInternal
+import Foundation
+
+@testable import Coralogix
+
+final class BeforeSendInstrumentationDataTests: XCTestCase {
+
+    // MARK: - Fixture
+
+    private var mockSpanData: SpanDataProtocol!
+    private var mockVersionMetadata: VersionMetadata!
+    private var mockSessionManager: SessionManager!
+    private var mockNetworkManager: NetworkManager!
+    private var mockViewManager: ViewManager!
+    private var mockMetricsManager: MetricsManager!
+
+    override func setUpWithError() throws {
+        mockSpanData = makeNetworkRequestMockSpan()
+        mockVersionMetadata = VersionMetadata(appName: "ExampleApp", appVersion: "1.1.1")
+        mockSessionManager = SessionManager()
+        mockNetworkManager = NetworkManager()
+        mockViewManager = ViewManager(keyChain: KeychainManager())
+        mockMetricsManager = MetricsManager()
+    }
+
+    override func tearDownWithError() throws {
+        mockSpanData = nil
+        mockVersionMetadata = nil
+        mockSessionManager = nil
+        mockNetworkManager = nil
+        mockViewManager = nil
+        mockMetricsManager = nil
+    }
+
+    private func makeNetworkRequestMockSpan() -> MockSpanData {
+        // network-request event type → instrumentation_data is emitted.
+        // Covers all attributes that the cx_rum.* mirror reads.
+        return MockSpanData(
+            attributes: [
+                Keys.severity.rawValue: AttributeValue("3"),
+                Keys.eventType.rawValue: AttributeValue(CoralogixEventType.networkRequest.rawValue),
+                Keys.source.rawValue: AttributeValue("fetch"),
+                Keys.environment.rawValue: AttributeValue("PROD"),
+                Keys.userId.rawValue: AttributeValue("user-orig"),
+                Keys.userName.rawValue: AttributeValue("Original Name"),
+                Keys.userEmail.rawValue: AttributeValue("orig@example.com"),
+                Keys.sessionId.rawValue: AttributeValue("session_001"),
+                Keys.sessionCreationDate.rawValue: AttributeValue(1609459200),
+                Keys.errorMessage.rawValue: AttributeValue("orig error"),
+                Keys.errorType.rawValue: AttributeValue("OrigType"),
+                SemanticAttributes.httpUrl.rawValue: AttributeValue("https://example.com/orig"),
+                SemanticAttributes.httpMethod.rawValue: AttributeValue("GET"),
+                SemanticAttributes.httpStatusCode.rawValue: AttributeValue("200"),
+                SemanticAttributes.httpTarget.rawValue: AttributeValue("/orig"),
+                SemanticAttributes.httpScheme.rawValue: AttributeValue("https"),
+                SemanticAttributes.netPeerName.rawValue: AttributeValue("example.com")
+            ],
+            startTime: Date(),
+            endTime: Date(),
+            spanId: "20",
+            traceId: "30",
+            name: "testSpan",
+            kind: 2,
+            statusCode: ["status": "ok"],
+            resources: [:]
+        )
+    }
+
+    private func makeOptions(beforeSend: (([String: Any]) -> [String: Any]?)?) -> CoralogixExporterOptions {
+        return CoralogixExporterOptions(
+            coralogixDomain: .US2,
+            userContext: nil,
+            environment: "PROD",
+            application: "ExampleApp",
+            version: "1.1.1",
+            publicKey: "token",
+            ignoreUrls: [],
+            ignoreErrors: [],
+            labels: ["initial": "label"],
+            beforeSend: beforeSend,
+            debug: true
+        )
+    }
+
+    /// Helper: spins a `CxSpan` through `beforeSend` and returns
+    /// `(textCxRum, otelSpanAttributes)` — the two destinations a span lands in.
+    private func runSpan(beforeSend: @escaping ([String: Any]) -> [String: Any]?) throws -> (text: [String: Any], otel: [String: Any]) {
+        let options = makeOptions(beforeSend: beforeSend)
+        guard let cxSpan = CxSpan(
+            otel: mockSpanData,
+            versionMetadata: mockVersionMetadata,
+            sessionManager: mockSessionManager,
+            networkManager: mockNetworkManager,
+            viewManager: mockViewManager,
+            metricsManager: mockMetricsManager,
+            options: options
+        ) else {
+            throw NSError(domain: "CxSpanInit", code: 0)
+        }
+        let dict = try XCTUnwrap(cxSpan.getDictionary())
+        let textWrapper = try XCTUnwrap(dict[Keys.text.rawValue] as? [String: Any])
+        let textCxRum = try XCTUnwrap(textWrapper[Keys.cxRum.rawValue] as? [String: Any])
+        let inst = try XCTUnwrap(dict[Keys.instrumentationData.rawValue] as? [String: Any])
+        let otelSpan = try XCTUnwrap(inst[Keys.otelSpan.rawValue] as? [String: Any])
+        let attrs = try XCTUnwrap(otelSpan[Keys.attributes.rawValue] as? [String: Any])
+        return (textCxRum, attrs)
+    }
+
+    // MARK: - Editable field propagation (text.cx_rum ↔ instrumentation_data parity)
+    //
+    // For each editable field, change the value via `beforeSend` and assert the
+    // modification appears in BOTH text.cx_rum AND instrumentation_data.otelSpan.attributes.
+    // This is the primary acceptance test for CX-44686.
+
+    func test_severity_propagatesToInstrumentationData() throws {
+        let result = try runSpan { cxRum in
+            var edit = cxRum
+            if var ec = edit[Keys.eventContext.rawValue] as? [String: Any] {
+                ec[Keys.severity.rawValue] = 5
+                edit[Keys.eventContext.rawValue] = ec
+            }
+            return edit
+        }
+        let textSeverity = (result.text[Keys.eventContext.rawValue] as? [String: Any])?[Keys.severity.rawValue] as? Int
+        XCTAssertEqual(textSeverity, 5)
+        XCTAssertEqual(result.otel["cx_rum.event_context.severity"] as? Int, 5)
+    }
+
+    func test_eventSource_propagatesToInstrumentationData() throws {
+        let result = try runSpan { cxRum in
+            var edit = cxRum
+            if var ec = edit[Keys.eventContext.rawValue] as? [String: Any] {
+                ec[Keys.source.rawValue] = "modified-source"
+                edit[Keys.eventContext.rawValue] = ec
+            }
+            return edit
+        }
+        let textSource = (result.text[Keys.eventContext.rawValue] as? [String: Any])?[Keys.source.rawValue] as? String
+        XCTAssertEqual(textSource, "modified-source")
+        XCTAssertEqual(result.otel["cx_rum.event_context.source"] as? String, "modified-source")
+    }
+
+    func test_userEmail_propagatesToInstrumentationData() throws {
+        let result = try runSpan { cxRum in
+            var edit = cxRum
+            if var sc = edit[Keys.sessionContext.rawValue] as? [String: Any] {
+                sc[Keys.userEmail.rawValue] = "redacted@coralogix.com"
+                edit[Keys.sessionContext.rawValue] = sc
+            }
+            return edit
+        }
+        let textEmail = (result.text[Keys.sessionContext.rawValue] as? [String: Any])?[Keys.userEmail.rawValue] as? String
+        XCTAssertEqual(textEmail, "redacted@coralogix.com")
+        XCTAssertEqual(result.otel["cx_rum.session_context.user_email"] as? String, "redacted@coralogix.com")
+    }
+
+    func test_userName_propagatesToInstrumentationData() throws {
+        let result = try runSpan { cxRum in
+            var edit = cxRum
+            if var sc = edit[Keys.sessionContext.rawValue] as? [String: Any] {
+                sc[Keys.userName.rawValue] = "Modified Name"
+                edit[Keys.sessionContext.rawValue] = sc
+            }
+            return edit
+        }
+        let textName = (result.text[Keys.sessionContext.rawValue] as? [String: Any])?[Keys.userName.rawValue] as? String
+        XCTAssertEqual(textName, "Modified Name")
+        XCTAssertEqual(result.otel["cx_rum.session_context.user_name"] as? String, "Modified Name")
+    }
+
+    func test_userId_propagatesToInstrumentationData() throws {
+        let result = try runSpan { cxRum in
+            var edit = cxRum
+            if var sc = edit[Keys.sessionContext.rawValue] as? [String: Any] {
+                sc[Keys.userId.rawValue] = "user-edited-42"
+                edit[Keys.sessionContext.rawValue] = sc
+            }
+            return edit
+        }
+        let textId = (result.text[Keys.sessionContext.rawValue] as? [String: Any])?[Keys.userId.rawValue] as? String
+        XCTAssertEqual(textId, "user-edited-42")
+        XCTAssertEqual(result.otel["cx_rum.session_context.user_id"] as? String, "user-edited-42")
+    }
+
+    func test_errorType_propagatesToInstrumentationData() throws {
+        let result = try runSpan { cxRum in
+            var edit = cxRum
+            if var ec = edit[Keys.errorContext.rawValue] as? [String: Any] {
+                ec[Keys.errorType.rawValue] = "ModifiedType"
+                edit[Keys.errorContext.rawValue] = ec
+            } else {
+                edit[Keys.errorContext.rawValue] = [Keys.errorType.rawValue: "ModifiedType"]
+            }
+            return edit
+        }
+        // errorContext only appears in text.cx_rum when event type is .error.
+        // For network-request events, the cx_rum.* mirror still surfaces error_type
+        // when present in the dict, so we only assert the mirror side here.
+        XCTAssertEqual(result.otel["cx_rum.error_context.error_type"] as? String, "ModifiedType")
+    }
+
+    func test_errorMessage_propagatesToInstrumentationData() throws {
+        let result = try runSpan { cxRum in
+            var edit = cxRum
+            if var ec = edit[Keys.errorContext.rawValue] as? [String: Any] {
+                ec[Keys.errorMessage.rawValue] = "redacted error"
+                edit[Keys.errorContext.rawValue] = ec
+            } else {
+                edit[Keys.errorContext.rawValue] = [Keys.errorMessage.rawValue: "redacted error"]
+            }
+            return edit
+        }
+        XCTAssertEqual(result.otel["cx_rum.error_context.error_message"] as? String, "redacted error")
+    }
+
+    func test_networkUrl_propagatesToInstrumentationData() throws {
+        let result = try runSpan { cxRum in
+            var edit = cxRum
+            if var nrc = edit[Keys.networkRequestContext.rawValue] as? [String: Any] {
+                nrc[Keys.url.rawValue] = "https://example.com/redacted"
+                edit[Keys.networkRequestContext.rawValue] = nrc
+            }
+            return edit
+        }
+        let textUrl = (result.text[Keys.networkRequestContext.rawValue] as? [String: Any])?[Keys.url.rawValue] as? String
+        XCTAssertEqual(textUrl, "https://example.com/redacted")
+        XCTAssertEqual(result.otel["cx_rum.network_request_context.url"] as? String, "https://example.com/redacted")
+    }
+
+    func test_networkMethod_propagatesToInstrumentationData() throws {
+        let result = try runSpan { cxRum in
+            var edit = cxRum
+            if var nrc = edit[Keys.networkRequestContext.rawValue] as? [String: Any] {
+                nrc[Keys.method.rawValue] = "POST"
+                edit[Keys.networkRequestContext.rawValue] = nrc
+            }
+            return edit
+        }
+        XCTAssertEqual(result.otel["cx_rum.network_request_context.method"] as? String, "POST")
+    }
+
+    func test_networkStatusCode_propagatesToInstrumentationData() throws {
+        let result = try runSpan { cxRum in
+            var edit = cxRum
+            if var nrc = edit[Keys.networkRequestContext.rawValue] as? [String: Any] {
+                nrc[Keys.statusCode.rawValue] = 503
+                edit[Keys.networkRequestContext.rawValue] = nrc
+            }
+            return edit
+        }
+        XCTAssertEqual(result.otel["cx_rum.network_request_context.status_code"] as? Int, 503)
+    }
+
+    func test_networkFragments_propagatesToInstrumentationData() throws {
+        let result = try runSpan { cxRum in
+            var edit = cxRum
+            if var nrc = edit[Keys.networkRequestContext.rawValue] as? [String: Any] {
+                nrc[Keys.fragments.rawValue] = "/redacted-path"
+                edit[Keys.networkRequestContext.rawValue] = nrc
+            }
+            return edit
+        }
+        XCTAssertEqual(result.otel["cx_rum.network_request_context.fragments"] as? String, "/redacted-path")
+    }
+
+    func test_networkRequestHeaders_propagatesToInstrumentationData() throws {
+        let result = try runSpan { cxRum in
+            var edit = cxRum
+            if var nrc = edit[Keys.networkRequestContext.rawValue] as? [String: Any] {
+                nrc[Keys.requestHeaders.rawValue] = ["X-Tenant": "redacted"]
+                edit[Keys.networkRequestContext.rawValue] = nrc
+            }
+            return edit
+        }
+        let headers = result.otel["cx_rum.network_request_context.request_headers"] as? [String: Any]
+        XCTAssertEqual(headers?["X-Tenant"] as? String, "redacted")
+    }
+
+    func test_networkRequestPayload_propagatesToInstrumentationData() throws {
+        let result = try runSpan { cxRum in
+            var edit = cxRum
+            if var nrc = edit[Keys.networkRequestContext.rawValue] as? [String: Any] {
+                nrc[Keys.requestPayload.rawValue] = "<redacted-body>"
+                edit[Keys.networkRequestContext.rawValue] = nrc
+            }
+            return edit
+        }
+        XCTAssertEqual(result.otel["cx_rum.network_request_context.request_payload"] as? String, "<redacted-body>")
+    }
+
+    func test_environment_propagatesToInstrumentationData() throws {
+        let result = try runSpan { cxRum in
+            var edit = cxRum
+            edit[Keys.environment.rawValue] = "staging-rewritten"
+            return edit
+        }
+        XCTAssertEqual(result.text[Keys.environment.rawValue] as? String, "staging-rewritten")
+        XCTAssertEqual(result.otel["cx_rum.environment"] as? String, "staging-rewritten")
+    }
+
+    func test_labels_propagateToInstrumentationData() throws {
+        let result = try runSpan { cxRum in
+            var edit = cxRum
+            edit[Keys.labels.rawValue] = ["team": "mobile", "tier": "edited"]
+            return edit
+        }
+        let textLabels = result.text[Keys.labels.rawValue] as? [String: Any]
+        XCTAssertEqual(textLabels?["tier"] as? String, "edited")
+        let otelLabels = result.otel["cx_rum.labels"] as? [String: Any]
+        XCTAssertEqual(otelLabels?["team"] as? String, "mobile")
+        XCTAssertEqual(otelLabels?["tier"] as? String, "edited")
+    }
+
+    func test_versionMetadataAppName_propagatesToInstrumentationData() throws {
+        let result = try runSpan { cxRum in
+            var edit = cxRum
+            if var vm = edit[Keys.versionMetaData.rawValue] as? [String: Any] {
+                vm[Keys.appName.rawValue] = "EditedApp"
+                edit[Keys.versionMetaData.rawValue] = vm
+            }
+            return edit
+        }
+        XCTAssertEqual(result.otel["cx_rum.version_metadata.app_name"] as? String, "EditedApp")
+    }
+
+    func test_versionMetadataAppVersion_propagatesToInstrumentationData() throws {
+        let result = try runSpan { cxRum in
+            var edit = cxRum
+            if var vm = edit[Keys.versionMetaData.rawValue] as? [String: Any] {
+                vm[Keys.appVersion.rawValue] = "9.9.9"
+                edit[Keys.versionMetaData.rawValue] = vm
+            }
+            return edit
+        }
+        XCTAssertEqual(result.otel["cx_rum.version_metadata.app_version"] as? String, "9.9.9")
+    }
+
+    // MARK: - Read-only field stripping
+    //
+    // The editable subset passed to `beforeSend` must not include identity,
+    // dedup, counter, or runtime-constant fields. A customer attempting to
+    // inject any of these in their return dict must NOT see the value flow
+    // through to the final payload.
+
+    func test_subset_doesNotContainReadOnlyFields() throws {
+        // Capture the subset by spying through a no-op beforeSend.
+        var captured: [String: Any] = [:]
+        _ = try runSpan { cxRum in
+            captured = cxRum
+            return cxRum
+        }
+        // All keys listed in CxSpan.readOnlyCxRumKeys must be absent from the subset.
+        XCTAssertNil(captured[Keys.isSnapshotEvent.rawValue], "isSnapshotEvent must not be editable")
+        XCTAssertNil(captured[Keys.traceId.rawValue], "traceId must not be editable")
+        XCTAssertNil(captured[Keys.spanId.rawValue], "spanId must not be editable")
+        XCTAssertNil(captured[Keys.fingerPrint.rawValue], "fingerPrint must not be editable")
+        XCTAssertNil(captured[Keys.prevSession.rawValue], "prevSession must not be editable")
+        XCTAssertNil(captured[Keys.platform.rawValue], "platform must not be editable")
+        XCTAssertNil(captured[Keys.snapshotContext.rawValue], "snapshotContext must not be editable")
+        XCTAssertNil(captured[Keys.mobileSdk.rawValue], "mobileSdk must not be editable")
+        XCTAssertNil(captured[Keys.timestamp.rawValue], "timestamp must not be editable")
+
+        if let session = captured[Keys.sessionContext.rawValue] as? [String: Any] {
+            XCTAssertNil(session[Keys.sessionId.rawValue], "sessionContext.sessionId must not be editable")
+            XCTAssertNil(session[Keys.sessionCreationDate.rawValue], "sessionContext.sessionCreationDate must not be editable")
+        }
+    }
+
+    func test_isSnapshotEvent_injectionIsIgnored() throws {
+        // First capture whether the SDK emitted a snapshot for this fixture (depends on
+        // SessionManager state — a fresh session always emits one). The test then asserts
+        // the SDK's value wins regardless of what the customer injects.
+        var sdkValue: Bool?
+        _ = try runSpan { cxRum in
+            sdkValue = cxRum[Keys.isSnapshotEvent.rawValue] as? Bool   // captured before injection
+            return cxRum
+        }
+
+        let result = try runSpan { cxRum in
+            var edit = cxRum
+            // Inject the OPPOSITE of whatever the SDK produced, so any leak is detectable.
+            edit[Keys.isSnapshotEvent.rawValue] = !(sdkValue ?? false)
+            return edit
+        }
+        XCTAssertEqual(result.text[Keys.isSnapshotEvent.rawValue] as? Bool, sdkValue,
+                       "isSnapshotEvent must be restored from the original cx_rum, not the callback's injected value")
+    }
+
+    func test_traceId_injectionIsIgnored() throws {
+        let result = try runSpan { cxRum in
+            var edit = cxRum
+            edit[Keys.traceId.rawValue] = "FORGED-TRACE-ID"
+            return edit
+        }
+        XCTAssertEqual(result.text[Keys.traceId.rawValue] as? String, "30",
+                       "traceId must be restored from the original cx_rum after beforeSend")
+    }
+
+    func test_spanId_injectionIsIgnored() throws {
+        let result = try runSpan { cxRum in
+            var edit = cxRum
+            edit[Keys.spanId.rawValue] = "FORGED-SPAN-ID"
+            return edit
+        }
+        XCTAssertEqual(result.text[Keys.spanId.rawValue] as? String, "20",
+                       "spanId must be restored from the original cx_rum after beforeSend")
+    }
+
+    func test_fingerPrint_injectionIsIgnored() throws {
+        let result = try runSpan { cxRum in
+            var edit = cxRum
+            edit[Keys.fingerPrint.rawValue] = "FORGED-FINGERPRINT"
+            return edit
+        }
+        let fp = result.text[Keys.fingerPrint.rawValue] as? String
+        XCTAssertNotEqual(fp, "FORGED-FINGERPRINT", "fingerPrint must not be forgeable")
+    }
+
+    func test_sessionId_injectionIsIgnored() throws {
+        let result = try runSpan { cxRum in
+            var edit = cxRum
+            var session = (edit[Keys.sessionContext.rawValue] as? [String: Any]) ?? [:]
+            session[Keys.sessionId.rawValue] = "FORGED-SESSION"
+            edit[Keys.sessionContext.rawValue] = session
+            return edit
+        }
+        let sessionId = (result.text[Keys.sessionContext.rawValue] as? [String: Any])?[Keys.sessionId.rawValue] as? String
+        XCTAssertNotEqual(sessionId, "FORGED-SESSION", "sessionId must be restored from the original cx_rum")
+    }
+
+    func test_platform_injectionIsIgnored() throws {
+        let result = try runSpan { cxRum in
+            var edit = cxRum
+            edit[Keys.platform.rawValue] = "console"
+            return edit
+        }
+        let platform = result.text[Keys.platform.rawValue] as? String
+        XCTAssertNotEqual(platform, "console", "platform must be restored from the original cx_rum")
+    }
+
+    func test_mobileSdk_injectionIsIgnored() throws {
+        let result = try runSpan { cxRum in
+            var edit = cxRum
+            edit[Keys.mobileSdk.rawValue] = ["sdk_version": "9.9.9-forged"]
+            return edit
+        }
+        let injected = (result.text[Keys.mobileSdk.rawValue] as? [String: Any])?["sdk_version"] as? String
+        XCTAssertNotEqual(injected, "9.9.9-forged", "mobileSdk must be restored from the original cx_rum")
+    }
+
+    // MARK: - Baseline parity: no beforeSend → mirror still matches the cx_rum dict.
+
+    func test_noBeforeSend_attributesStillMatchCxRum() throws {
+        let options = makeOptions(beforeSend: nil)
+        guard let cxSpan = CxSpan(
+            otel: mockSpanData,
+            versionMetadata: mockVersionMetadata,
+            sessionManager: mockSessionManager,
+            networkManager: mockNetworkManager,
+            viewManager: mockViewManager,
+            metricsManager: mockMetricsManager,
+            options: options
+        ) else { return XCTFail("CxSpan init failed") }
+
+        let dict = try XCTUnwrap(cxSpan.getDictionary())
+        let text = try XCTUnwrap(dict[Keys.text.rawValue] as? [String: Any])
+        let cxRum = try XCTUnwrap(text[Keys.cxRum.rawValue] as? [String: Any])
+        let inst = try XCTUnwrap(dict[Keys.instrumentationData.rawValue] as? [String: Any])
+        let otel = try XCTUnwrap(inst[Keys.otelSpan.rawValue] as? [String: Any])
+        let attrs = try XCTUnwrap(otel[Keys.attributes.rawValue] as? [String: Any])
+
+        let textSeverity = (cxRum[Keys.eventContext.rawValue] as? [String: Any])?[Keys.severity.rawValue] as? Int
+        XCTAssertEqual(attrs["cx_rum.event_context.severity"] as? Int, textSeverity)
+
+        let textEmail = (cxRum[Keys.sessionContext.rawValue] as? [String: Any])?[Keys.userEmail.rawValue] as? String
+        XCTAssertEqual(attrs["cx_rum.session_context.user_email"] as? String, textEmail)
+
+        let textUrl = (cxRum[Keys.networkRequestContext.rawValue] as? [String: Any])?[Keys.url.rawValue] as? String
+        XCTAssertEqual(attrs["cx_rum.network_request_context.url"] as? String, textUrl)
+    }
+}

--- a/Tests/CoralogixRumTests/BeforeSendInstrumentationDataTests.swift
+++ b/Tests/CoralogixRumTests/BeforeSendInstrumentationDataTests.swift
@@ -95,12 +95,18 @@ final class BeforeSendInstrumentationDataTests: XCTestCase {
 
     /// Helper: spins a `CxSpan` through `beforeSend` and returns
     /// `(textCxRum, otelSpanAttributes)` — the two destinations a span lands in.
-    private func runSpan(beforeSend: @escaping ([String: Any]) -> [String: Any]?) throws -> (text: [String: Any], otel: [String: Any]) {
+    /// `sessionManager` defaults to the shared fixture; tests that need
+    /// independent SessionManager state (e.g. snapshot-emission ordering)
+    /// can pass a fresh one.
+    private func runSpan(
+        sessionManager: SessionManager? = nil,
+        beforeSend: @escaping ([String: Any]) -> [String: Any]?
+    ) throws -> (text: [String: Any], otel: [String: Any]) {
         let options = makeOptions(beforeSend: beforeSend)
         guard let cxSpan = CxSpan(
             otel: mockSpanData,
             versionMetadata: mockVersionMetadata,
-            sessionManager: mockSessionManager,
+            sessionManager: sessionManager ?? mockSessionManager,
             networkManager: mockNetworkManager,
             viewManager: mockViewManager,
             metricsManager: mockMetricsManager,
@@ -378,18 +384,24 @@ final class BeforeSendInstrumentationDataTests: XCTestCase {
     }
 
     func test_isSnapshotEvent_injectionIsIgnored() throws {
-        // First capture whether the SDK emitted a snapshot for this fixture (depends on
-        // SessionManager state — a fresh session always emits one). The test then asserts
-        // the SDK's value wins regardless of what the customer injects.
-        var sdkValue: Bool?
-        _ = try runSpan { cxRum in
-            sdkValue = cxRum[Keys.isSnapshotEvent.rawValue] as? Bool   // captured before injection
-            return cxRum
-        }
+        // Each run gets a fresh SessionManager so the SDK's snapshot decision is
+        // independent — sharing one would mean the probe run sets
+        // lastSnapshotEventTime and the second run skips snapshot emission,
+        // collapsing the assertion to nil == nil (which would pass even if
+        // the restore code were deleted).
 
-        let result = try runSpan { cxRum in
+        // 1) Probe run: read the SDK's emitted isSnapshotEvent from the FINAL
+        //    payload (text.cx_rum), not from inside the callback — the callback
+        //    sees the subset, which has isSnapshotEvent stripped.
+        let probe = try runSpan(sessionManager: SessionManager()) { $0 }
+        let sdkValue = probe.text[Keys.isSnapshotEvent.rawValue] as? Bool
+        XCTAssertEqual(sdkValue, true,
+                       "Fresh SessionManager + network event should emit a snapshot — guard against regressions in CxRumBuilder")
+
+        // 2) Forgery run: inject the OPPOSITE of what the SDK produced and
+        //    assert the SDK's value still wins after restore.
+        let result = try runSpan(sessionManager: SessionManager()) { cxRum in
             var edit = cxRum
-            // Inject the OPPOSITE of whatever the SDK produced, so any leak is detectable.
             edit[Keys.isSnapshotEvent.rawValue] = !(sdkValue ?? false)
             return edit
         }

--- a/Tests/CoralogixRumTests/BeforeSendInstrumentationDataTests.swift
+++ b/Tests/CoralogixRumTests/BeforeSendInstrumentationDataTests.swift
@@ -430,13 +430,20 @@ final class BeforeSendInstrumentationDataTests: XCTestCase {
     }
 
     func test_fingerPrint_injectionIsIgnored() throws {
+        // fingerPrint is a UUID generated per CxRumBuilder via the keychain, which
+        // doesn't persist across separate CxSpan builds in this test env — so a
+        // probe-run pattern (like test_isSnapshotEvent) would compare two different
+        // SDK-generated UUIDs. Use XCTUnwrap to catch accidental removal, then
+        // XCTAssertNotEqual to catch the forgery.
         let result = try runSpan { cxRum in
             var edit = cxRum
             edit[Keys.fingerPrint.rawValue] = "FORGED-FINGERPRINT"
             return edit
         }
-        let fp = result.text[Keys.fingerPrint.rawValue] as? String
-        XCTAssertNotEqual(fp, "FORGED-FINGERPRINT", "fingerPrint must not be forgeable")
+        let fp = try XCTUnwrap(result.text[Keys.fingerPrint.rawValue] as? String,
+                               "fingerPrint must remain present after a callback that injects a forgery")
+        XCTAssertNotEqual(fp, "FORGED-FINGERPRINT",
+                          "fingerPrint must be restored from the original cx_rum, not the callback's injected value")
     }
 
     func test_sessionContext_replacedByNonDict_isRestoredWholesale() throws {
@@ -458,6 +465,9 @@ final class BeforeSendInstrumentationDataTests: XCTestCase {
     }
 
     func test_sessionId_injectionIsIgnored() throws {
+        // The mock span fixture sets sessionId = "session_001" — assert the SDK
+        // restored that value rather than just "not the forgery", which would
+        // pass vacuously if sessionId were nil.
         let result = try runSpan { cxRum in
             var edit = cxRum
             var session = (edit[Keys.sessionContext.rawValue] as? [String: Any]) ?? [:]
@@ -466,27 +476,44 @@ final class BeforeSendInstrumentationDataTests: XCTestCase {
             return edit
         }
         let sessionId = (result.text[Keys.sessionContext.rawValue] as? [String: Any])?[Keys.sessionId.rawValue] as? String
-        XCTAssertNotEqual(sessionId, "FORGED-SESSION", "sessionId must be restored from the original cx_rum")
+        XCTAssertEqual(sessionId, "session_001",
+                       "sessionId must be restored to the original mock value, not the forgery")
     }
 
     func test_platform_injectionIsIgnored() throws {
-        let result = try runSpan { cxRum in
+        // Probe the SDK-computed platform first, then assert the injection run
+        // produces the same value. NotEqual-against-"console" would pass vacuously
+        // if platform were nil — this catches both forgery AND accidental removal.
+        let probe = try runSpan(sessionManager: SessionManager()) { $0 }
+        let sdkPlatform = try XCTUnwrap(probe.text[Keys.platform.rawValue] as? String,
+                                        "Probe should produce a platform — regression in CxRumPayloadBuilder")
+
+        let result = try runSpan(sessionManager: SessionManager()) { cxRum in
             var edit = cxRum
             edit[Keys.platform.rawValue] = "console"
             return edit
         }
-        let platform = result.text[Keys.platform.rawValue] as? String
-        XCTAssertNotEqual(platform, "console", "platform must be restored from the original cx_rum")
+        XCTAssertEqual(result.text[Keys.platform.rawValue] as? String, sdkPlatform,
+                       "platform must be restored from the original cx_rum, not the callback's injected value")
     }
 
     func test_mobileSdk_injectionIsIgnored() throws {
-        let result = try runSpan { cxRum in
+        // Probe the SDK-emitted mobileSdk dict first, then assert the injection run
+        // preserves it. NotEqual-against-the-forgery would pass vacuously if the key
+        // were missing entirely — this catches both forgery AND accidental removal.
+        let probe = try runSpan(sessionManager: SessionManager()) { $0 }
+        let sdkMobileSdk = try XCTUnwrap(probe.text[Keys.mobileSdk.rawValue] as? [String: Any],
+                                         "Probe should produce a mobileSdk dict — regression in CxRumPayloadBuilder")
+
+        let result = try runSpan(sessionManager: SessionManager()) { cxRum in
             var edit = cxRum
             edit[Keys.mobileSdk.rawValue] = ["sdk_version": "9.9.9-forged"]
             return edit
         }
-        let injected = (result.text[Keys.mobileSdk.rawValue] as? [String: Any])?["sdk_version"] as? String
-        XCTAssertNotEqual(injected, "9.9.9-forged", "mobileSdk must be restored from the original cx_rum")
+        let restored = try XCTUnwrap(result.text[Keys.mobileSdk.rawValue] as? [String: Any],
+                                     "mobileSdk must remain a dict, not be replaced by the forged version")
+        XCTAssertEqual(NSDictionary(dictionary: restored), NSDictionary(dictionary: sdkMobileSdk),
+                       "mobileSdk must be restored from the original cx_rum, not the callback's injected value")
     }
 
     // MARK: - Baseline parity: no beforeSend → mirror still matches the cx_rum dict.

--- a/Tests/CoralogixRumTests/BeforeSendInstrumentationDataTests.swift
+++ b/Tests/CoralogixRumTests/BeforeSendInstrumentationDataTests.swift
@@ -427,6 +427,24 @@ final class BeforeSendInstrumentationDataTests: XCTestCase {
         XCTAssertNotEqual(fp, "FORGED-FINGERPRINT", "fingerPrint must not be forgeable")
     }
 
+    func test_sessionContext_replacedByNonDict_isRestoredWholesale() throws {
+        // Callback corrupts sessionContext into a non-dict value.
+        // The SDK must restore the entire original sessionContext so sessionId /
+        // sessionCreationDate (and downstream ingestion's structural assumptions)
+        // survive the malformed return.
+        let result = try runSpan { cxRum in
+            var edit = cxRum
+            edit[Keys.sessionContext.rawValue] = "haha"
+            return edit
+        }
+        let session = result.text[Keys.sessionContext.rawValue] as? [String: Any]
+        XCTAssertNotNil(session, "sessionContext must be restored to a dict, not left as the callback's string")
+        XCTAssertEqual(session?[Keys.sessionId.rawValue] as? String, "session_001",
+                       "sessionId must be restored from the original sessionContext after a non-dict corruption")
+        XCTAssertNotNil(session?[Keys.sessionCreationDate.rawValue],
+                        "sessionCreationDate must be restored after a non-dict corruption")
+    }
+
     func test_sessionId_injectionIsIgnored() throws {
         let result = try runSpan { cxRum in
             var edit = cxRum


### PR DESCRIPTION
# User description
## Summary

- `instrumentation_data.otelSpan.attributes` (the `cx_rum.*` mirror) was built in `CxSpan.init` from the pre-`beforeSend` `cxRum` struct, so it diverged from `text.cx_rum` whenever a customer modified a field in `beforeSend`. Two destinations of the same span carried different payloads (e.g. severity, user_email, error_message, network url).
- Rebuild the attribute map from the post-merge `cx_rum` dict in `addInstrumentationData(to:)` so both destinations carry the same final, beforeSend-modified values. **Gated on `beforeSend != nil`** — the dict variant is a lossy view of the struct (e.g. `error_context` is omitted for non-`.error` events by `CxRumPayloadBuilder`), so the no-`beforeSend` path keeps the init-time struct-built attrs to preserve those fields.
- Tighten the editable subset: `traceId`, `spanId`, `fingerPrint`, `prevSession`, `platform`, `isSnapshotEvent`, `mobileSdk`, `timestamp`, `snapshotContext` are stripped before `beforeSend` sees the dict, and restored from `originalCxRum` after merge so callback-injected forgeries are ignored. `sessionContext.session_id` / `session_creation_date` are similarly stripped and restored — including a wholesale restore if a callback returns `session_context` as a non-dict.

## Test plan

- [x] New `BeforeSendInstrumentationDataTests` — 27 cases, all green
  - 17 field-propagation tests — for each editable `cx_rum` field, assert the modification appears in BOTH `text.cx_rum` and `instrumentation_data.otelSpan.attributes`.
  - 9 read-only protection tests — subset doesn't expose identity/dedup/counter/runtime-constant fields, and injection attempts in the callback's return dict are ignored. Assertions use probe-then-equal or `XCTUnwrap` patterns rather than `XCTAssertNotEqual` against the forgery string (which would have passed vacuously if the key were `nil`).
  - 1 baseline-parity test — when no `beforeSend` is configured, the mirror still matches `text.cx_rum`.
- [x] Full test suite via `xcodebuild` on iPhone 17 / iOS 26.5 — all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)