### PR TITLE
feat(CX-44687): emit view_number and isNavigationEvent at cx_rum top level

### DIFF
--- a/Coralogix/Sources/Model/CxRum.swift
+++ b/Coralogix/Sources/Model/CxRum.swift
@@ -31,4 +31,9 @@ struct CxRum {
     let internalContext: InternalContext?
     let measurementContext: MeasurementContext?
     let fingerPrint: String
+    // CX-44687: product-analytics fields at cx_rum top level.
+    // `isNavigationEvent` is always emitted; `viewNumber` is nil until the first
+    // view appears (early-launch spans omit it).
+    let isNavigationEvent: Bool
+    let viewNumber: Int?
 }

--- a/Coralogix/Sources/Model/CxRumBuilder.swift
+++ b/Coralogix/Sources/Model/CxRumBuilder.swift
@@ -89,7 +89,10 @@ class CxRumBuilder {
                      screenShotContext: ScreenshotContext(otel: otel),
                      internalContext: internalContext,
                      measurementContext: MeasurementContext(otel: otel),
-                     fingerPrint: FingerprintManager(using: KeychainManager()).fingerprint
+                     fingerPrint: FingerprintManager(using: KeychainManager()).fingerprint,
+                     // CX-44687: pure function of current event type — no cross-event state.
+                     isNavigationEvent: eventContext.type == .navigation,
+                     viewNumber: viewManager.getViewNumber()
         )
     }
     

--- a/Coralogix/Sources/Model/CxRumPayloadBuilder.swift
+++ b/Coralogix/Sources/Model/CxRumPayloadBuilder.swift
@@ -40,6 +40,7 @@ struct CxRumPayloadBuilder {
         addPlatform(to: &result)
         addDeviceContext(to: &result)
         addDeviceState(to: &result)
+        addProductAnalyticsFields(to: &result)
     }
     
     private mutating func addConditionalContexts(to result: inout [String: Any]) {
@@ -120,6 +121,17 @@ struct CxRumPayloadBuilder {
 
     private func addDeviceState(to result: inout [String: Any]) {
         result[Keys.deviceState.rawValue] = rum.deviceState.getDictionary()
+    }
+
+    // CX-44687: product-analytics fields at cx_rum top level.
+    // `isNavigationEvent` is always emitted (true/false). `view_number` is omitted
+    // entirely on spans fired before any view has appeared so consumers can
+    // distinguish "no view yet" from "view #0".
+    private func addProductAnalyticsFields(to result: inout [String: Any]) {
+        result[Keys.isNavigationEvent.rawValue] = rum.isNavigationEvent
+        if let viewNumber = rum.viewNumber {
+            result[Keys.viewNumber.rawValue] = viewNumber
+        }
     }
     
     private func addErrorContext(to result: inout [String: Any]) {

--- a/Coralogix/Sources/Model/CxSpan.swift
+++ b/Coralogix/Sources/Model/CxSpan.swift
@@ -245,6 +245,12 @@ public class CxSpan {
     // Restored from the original cx_rum after `mergeDictionaries` so a callback that
     // injects any of them in its return dict cannot tamper with span identity, dedup,
     // or SDK-owned counters.
+    //
+    // CX-44687: `view_number` is an SDK-owned sequence counter (per-session
+    // navigation step). Treated as read-only because a callback injecting a value
+    // would silently corrupt downstream funnel analysis. `isNavigationEvent` is
+    // NOT in this list: it derives from `event_context.type` which is already
+    // customer-editable, so the two must move together.
     static let readOnlyCxRumKeys: [String] = [
         Keys.snapshotContext.rawValue,
         Keys.isSnapshotEvent.rawValue,
@@ -254,7 +260,8 @@ public class CxSpan {
         Keys.spanId.rawValue,
         Keys.fingerPrint.rawValue,
         Keys.prevSession.rawValue,
-        Keys.platform.rawValue
+        Keys.platform.rawValue,
+        Keys.viewNumber.rawValue
     ]
 
     func createSubsetOfCxRum(from originalCxRum: [String: Any]) -> [String: Any] {

--- a/Coralogix/Sources/Model/CxSpan.swift
+++ b/Coralogix/Sources/Model/CxSpan.swift
@@ -344,6 +344,11 @@ public struct SessionMetadata {
         keychain.writeStringToKeychain(service: Keys.service.rawValue,
                                         key: Keys.pid.rawValue,
                                         value: String(newPid))
+        // CX-44687: companion to PID — uniquely identifies this process instance
+        // for PID-recycling detection (see ViewManager.init).
+        keychain.writeStringToKeychain(service: Keys.service.rawValue,
+                                        key: Keys.bootUUID.rawValue,
+                                        value: Global.processBootUUID)
         keychain.writeStringToKeychain(service: Keys.service.rawValue,
                                         key: Keys.keySessionId.rawValue,
                                         value: sessionId)

--- a/Coralogix/Sources/Model/CxSpan.swift
+++ b/Coralogix/Sources/Model/CxSpan.swift
@@ -97,6 +97,19 @@ public class CxSpan {
                     }
                 }
 
+                // CX-44687: isNavigationEvent is a pure function of event_context.type and
+                // has no independent identity — recompute from the post-merge type so the
+                // derived flag stays consistent no matter what the customer edited (type
+                // alone, flag alone, both, or neither). Treating it as read-only would only
+                // defeat direct forgery of the flag while leaving customer type-edits
+                // desynced; deriving it post-merge fixes both vectors. Both destinations
+                // (`text.cx_rum` and `otelSpan.attributes`) read this final value, so they
+                // stay in lockstep. Falls back to false when type is missing or non-string
+                // (e.g. customer corrupted event_context to a non-dict) — a span without a
+                // navigation type can't be a navigation event by any reasonable reading.
+                let mergedType = (mergedDict[Keys.eventContext.rawValue] as? [String: Any])?[Keys.type.rawValue] as? String
+                mergedDict[Keys.isNavigationEvent.rawValue] = (mergedType == CoralogixEventType.navigation.rawValue)
+
                 // Sync severity from editableCxRum to both the top-level field and
                 // mergedDict[eventContext][severity] so they remain consistent.
                 // parseSeverity accepts Int or numeric String (matching the OTEL init path)
@@ -249,8 +262,10 @@ public class CxSpan {
     // CX-44687: `view_number` is an SDK-owned sequence counter (per-session
     // navigation step). Treated as read-only because a callback injecting a value
     // would silently corrupt downstream funnel analysis. `isNavigationEvent` is
-    // NOT in this list: it derives from `event_context.type` which is already
-    // customer-editable, so the two must move together.
+    // deliberately NOT here: it's a pure function of `event_context.type` and is
+    // recomputed from the post-merge type in `getDictionary()` instead. Read-only
+    // treatment would only block direct forgery of the flag, leaving customer
+    // type-edits desynced; post-merge recompute handles both vectors uniformly.
     static let readOnlyCxRumKeys: [String] = [
         Keys.snapshotContext.rawValue,
         Keys.isSnapshotEvent.rawValue,

--- a/Coralogix/Sources/Model/CxSpan.swift
+++ b/Coralogix/Sources/Model/CxSpan.swift
@@ -97,19 +97,6 @@ public class CxSpan {
                     }
                 }
 
-                // CX-44687: isNavigationEvent is a pure function of event_context.type and
-                // has no independent identity — recompute from the post-merge type so the
-                // derived flag stays consistent no matter what the customer edited (type
-                // alone, flag alone, both, or neither). Treating it as read-only would only
-                // defeat direct forgery of the flag while leaving customer type-edits
-                // desynced; deriving it post-merge fixes both vectors. Both destinations
-                // (`text.cx_rum` and `otelSpan.attributes`) read this final value, so they
-                // stay in lockstep. Falls back to false when type is missing or non-string
-                // (e.g. customer corrupted event_context to a non-dict) — a span without a
-                // navigation type can't be a navigation event by any reasonable reading.
-                let mergedType = (mergedDict[Keys.eventContext.rawValue] as? [String: Any])?[Keys.type.rawValue] as? String
-                mergedDict[Keys.isNavigationEvent.rawValue] = (mergedType == CoralogixEventType.navigation.rawValue)
-
                 // Sync severity from editableCxRum to both the top-level field and
                 // mergedDict[eventContext][severity] so they remain consistent.
                 // parseSeverity accepts Int or numeric String (matching the OTEL init path)
@@ -263,14 +250,15 @@ public class CxSpan {
     // - `view_number` is an SDK-owned sequence counter (per-session navigation
     //   step); read-only because a callback injecting a value would silently
     //   corrupt downstream funnel analysis.
-    // - `isNavigationEvent` is a derived field (pure function of
-    //   `event_context.type`); read-only so it's stripped from the editable
-    //   subset the customer sees in `beforeSend(cxRum)` — exposing it would be
-    //   misleading API surface since the customer can't actually change it. The
-    //   post-merge recompute in `getDictionary()` is what keeps it in sync with
-    //   `event_context.type` when the customer edits the type itself; read-only
-    //   alone would restore the original/pre-edit flag value and leave the two
-    //   desynced.
+    // - `isNavigationEvent` records the SDK's observation at build time — "did
+    //   the SDK detect a navigation?". Read-only so the SDK's value survives
+    //   the merge regardless of what the customer does. Deliberately NOT
+    //   recomputed from the post-merge `event_context.type`: the flag is an
+    //   immutable historical fact about what the SDK saw, not a derived
+    //   property of the (possibly customer-relabeled) final type. If the
+    //   customer rewrites the type via `beforeSend`, the two fields can
+    //   diverge — that's by design (product-analytics consumers should filter
+    //   on the flag for "was this actually a navigation").
     static let readOnlyCxRumKeys: [String] = [
         Keys.snapshotContext.rawValue,
         Keys.isSnapshotEvent.rawValue,

--- a/Coralogix/Sources/Model/CxSpan.swift
+++ b/Coralogix/Sources/Model/CxSpan.swift
@@ -308,6 +308,12 @@ public struct VersionMetadata {
 protocol KeyChainProtocol: AnyObject {
     func readStringFromKeychain(service: String, key: String) -> String?
     func writeStringToKeychain(service: String, key: String, value: String)
+    /// CX-44687: removes the entry entirely. Use when an optional value transitions
+    /// to nil — writing an empty-string sentinel is fragile (a future presence-check
+    /// caller would mistake "" for a real value, and a protocol impl that no-ops on
+    /// empty writes would leave stale data behind). Implementations must treat
+    /// "entry not found" as success (the post-condition is "entry absent").
+    func deleteFromKeychain(service: String, key: String)
 }
 
 public struct SessionMetadata {

--- a/Coralogix/Sources/Model/CxSpan.swift
+++ b/Coralogix/Sources/Model/CxSpan.swift
@@ -259,13 +259,18 @@ public class CxSpan {
     // injects any of them in its return dict cannot tamper with span identity, dedup,
     // or SDK-owned counters.
     //
-    // CX-44687: `view_number` is an SDK-owned sequence counter (per-session
-    // navigation step). Treated as read-only because a callback injecting a value
-    // would silently corrupt downstream funnel analysis. `isNavigationEvent` is
-    // deliberately NOT here: it's a pure function of `event_context.type` and is
-    // recomputed from the post-merge type in `getDictionary()` instead. Read-only
-    // treatment would only block direct forgery of the flag, leaving customer
-    // type-edits desynced; post-merge recompute handles both vectors uniformly.
+    // CX-44687:
+    // - `view_number` is an SDK-owned sequence counter (per-session navigation
+    //   step); read-only because a callback injecting a value would silently
+    //   corrupt downstream funnel analysis.
+    // - `isNavigationEvent` is a derived field (pure function of
+    //   `event_context.type`); read-only so it's stripped from the editable
+    //   subset the customer sees in `beforeSend(cxRum)` — exposing it would be
+    //   misleading API surface since the customer can't actually change it. The
+    //   post-merge recompute in `getDictionary()` is what keeps it in sync with
+    //   `event_context.type` when the customer edits the type itself; read-only
+    //   alone would restore the original/pre-edit flag value and leave the two
+    //   desynced.
     static let readOnlyCxRumKeys: [String] = [
         Keys.snapshotContext.rawValue,
         Keys.isSnapshotEvent.rawValue,
@@ -276,7 +281,8 @@ public class CxSpan {
         Keys.fingerPrint.rawValue,
         Keys.prevSession.rawValue,
         Keys.platform.rawValue,
-        Keys.viewNumber.rawValue
+        Keys.viewNumber.rawValue,
+        Keys.isNavigationEvent.rawValue
     ]
 
     func createSubsetOfCxRum(from originalCxRum: [String: Any]) -> [String: Any] {

--- a/Coralogix/Sources/Model/InstrumentationData.swift
+++ b/Coralogix/Sources/Model/InstrumentationData.swift
@@ -117,6 +117,13 @@ struct OtelSpan {
         static let networkResponsePayload    = "cx_rum.network_request_context.response_payload"
         static let pageUrl                   = "cx_rum.page_context.page_url"
         static let pageFragments             = "cx_rum.page_context.page_fragments"
+        // CX-44687: product-analytics fields. Snake-case under `cx_rum.*` per the
+        // AttrKey convention — the matching cx_rum top-level wire key for
+        // `isNavigationEvent` is camelCase (Browser parity, see Keys.swift), but
+        // the otelSpan.attributes mirror follows the snake-case convention used
+        // by every other entry in this enum.
+        static let isNavigationEvent         = "cx_rum.is_navigation_event"
+        static let viewNumber                = "cx_rum.view_number"
     }
 
     // Mirrors the web SDK's buildRumContextAttributes(), using cx_rum.* prefixed keys.
@@ -191,6 +198,16 @@ struct OtelSpan {
         if let pageUrl = viewManager?.getDictionary()[Keys.view.rawValue] as? String, !pageUrl.isEmpty {
             attrs[AttrKey.pageUrl]       = pageUrl
             attrs[AttrKey.pageFragments] = pageUrl
+        }
+
+        // CX-44687: mirror product-analytics fields from the post-`beforeSend`
+        // cx_rum dict. Reads use the wire keys (camelCase / snake_case mix
+        // matching `Keys.isNavigationEvent` / `Keys.viewNumber`).
+        if let v = cxRumDict[Keys.isNavigationEvent.rawValue] as? Bool {
+            attrs[AttrKey.isNavigationEvent] = v
+        }
+        if let v = cxRumDict[Keys.viewNumber.rawValue] as? Int {
+            attrs[AttrKey.viewNumber] = v
         }
 
         return attrs
@@ -269,6 +286,13 @@ struct OtelSpan {
            !pageUrl.isEmpty {
             attrs[AttrKey.pageUrl]       = pageUrl
             attrs[AttrKey.pageFragments] = pageUrl
+        }
+
+        // CX-44687: product-analytics fields. `isNavigationEvent` is always emitted;
+        // `view_number` is omitted on spans fired before any view has appeared.
+        attrs[AttrKey.isNavigationEvent] = cxRum.isNavigationEvent
+        if let viewNumber = cxRum.viewNumber {
+            attrs[AttrKey.viewNumber] = viewNumber
         }
 
         return attrs

--- a/Coralogix/Sources/Utils/KeychainManager.swift
+++ b/Coralogix/Sources/Utils/KeychainManager.swift
@@ -58,4 +58,19 @@ class KeychainManager: KeyChainProtocol {
             Log.e("Failed to save data to Keychain")
         }
     }
+
+    // CX-44687: see KeyChainProtocol.deleteFromKeychain. Treats "not found" as
+    // success — the post-condition is "entry absent", and an entry that was
+    // never there satisfies that already.
+    func deleteFromKeychain(service: String, key: String) {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key
+        ]
+        let status = SecItemDelete(query as CFDictionary)
+        if status != errSecSuccess && status != errSecItemNotFound {
+            Log.e("Failed to delete data from Keychain")
+        }
+    }
 }

--- a/Coralogix/Sources/Utils/ViewManager.swift
+++ b/Coralogix/Sources/Utils/ViewManager.swift
@@ -109,11 +109,20 @@ public class ViewManager {
         return syncSafe { self.viewNumber }
     }
 
+    // CX-44687: nil → delete the keychain entry, non-nil → write the value. Avoids
+    // the empty-string-as-nil sentinel that would (a) collide with a future presence-
+    // check caller and (b) leave stale data if the protocol impl ever no-ops on
+    // empty-string writes. PRECONDITION: caller holds the syncQueue barrier (true
+    // for set/reset/shutdown — all three execute inside async(flags: .barrier)).
     private func persistViewNumber() {
-        let value = self.viewNumber.map(String.init) ?? ""
-        self.keyChain?.writeStringToKeychain(service: Keys.service.rawValue,
-                                             key: Keys.keyViewNumber.rawValue,
-                                             value: value)
+        if let viewNumber = self.viewNumber {
+            self.keyChain?.writeStringToKeychain(service: Keys.service.rawValue,
+                                                 key: Keys.keyViewNumber.rawValue,
+                                                 value: String(viewNumber))
+        } else {
+            self.keyChain?.deleteFromKeychain(service: Keys.service.rawValue,
+                                              key: Keys.keyViewNumber.rawValue)
+        }
     }
     
     func getDictionary() -> [String: Any] {

--- a/Coralogix/Sources/Utils/ViewManager.swift
+++ b/Coralogix/Sources/Utils/ViewManager.swift
@@ -38,20 +38,24 @@ public class ViewManager {
         if let viewName = keyChain?.readStringFromKeychain(service: Keys.service.rawValue, key: Keys.view.rawValue) {
             self.prevViewName = viewName
         }
-        // CX-44687: only restore view_number when the persisted PID matches the
-        // current process — i.e. the SDK is being re-initialized in-process and
-        // SessionContext will roll back to the previous session via pid match.
+        // CX-44687: only restore view_number when BOTH discriminators agree the
+        // keychain entry came from this same process instance — PID alone can
+        // yield a false positive after PID recycling (iOS reuses low PIDs after
+        // reboot), so we pair it with a per-process UUID that cannot collide.
         // Ordering note: stored-property initializers run before CoralogixRum.init's
-        // body, so SessionMetadata has not yet written getpid() to the keychain when
-        // we read it here. On a fresh cold launch the keychain still holds the OLD
-        // process's PID, which won't match getpid() — and we correctly skip the
-        // restore so the first event of the new session doesn't carry a stale
-        // counter (sessionEndedCallback does NOT fire on first-init: see
+        // body, so SessionMetadata has not yet written its identity record to the
+        // keychain when we read it here. On a fresh cold launch the keychain still
+        // holds the OLD process's identity, neither field matches, and we correctly
+        // skip the restore (sessionEndedCallback does NOT fire on first-init: see
         // SessionManager.fireRotationCallbacks gating on priorExisted).
         let currentPid = String(getpid())
+        let currentBootUUID = Global.processBootUUID
         let storedPid = keyChain?.readStringFromKeychain(service: Keys.service.rawValue,
                                                           key: Keys.pid.rawValue)
+        let storedBootUUID = keyChain?.readStringFromKeychain(service: Keys.service.rawValue,
+                                                                key: Keys.bootUUID.rawValue)
         if storedPid == currentPid,
+           storedBootUUID == currentBootUUID,
            let persisted = keyChain?.readStringFromKeychain(service: Keys.service.rawValue,
                                                              key: Keys.keyViewNumber.rawValue),
            let value = Int(persisted) {

--- a/Coralogix/Sources/Utils/ViewManager.swift
+++ b/Coralogix/Sources/Utils/ViewManager.swift
@@ -38,7 +38,21 @@ public class ViewManager {
         if let viewName = keyChain?.readStringFromKeychain(service: Keys.service.rawValue, key: Keys.view.rawValue) {
             self.prevViewName = viewName
         }
-        if let persisted = keyChain?.readStringFromKeychain(service: Keys.service.rawValue,
+        // CX-44687: only restore view_number when the persisted PID matches the
+        // current process — i.e. the SDK is being re-initialized in-process and
+        // SessionContext will roll back to the previous session via pid match.
+        // Ordering note: stored-property initializers run before CoralogixRum.init's
+        // body, so SessionMetadata has not yet written getpid() to the keychain when
+        // we read it here. On a fresh cold launch the keychain still holds the OLD
+        // process's PID, which won't match getpid() — and we correctly skip the
+        // restore so the first event of the new session doesn't carry a stale
+        // counter (sessionEndedCallback does NOT fire on first-init: see
+        // SessionManager.fireRotationCallbacks gating on priorExisted).
+        let currentPid = String(getpid())
+        let storedPid = keyChain?.readStringFromKeychain(service: Keys.service.rawValue,
+                                                          key: Keys.pid.rawValue)
+        if storedPid == currentPid,
+           let persisted = keyChain?.readStringFromKeychain(service: Keys.service.rawValue,
                                                              key: Keys.keyViewNumber.rawValue),
            let value = Int(persisted) {
             self.viewNumber = value

--- a/Coralogix/Sources/Utils/ViewManager.swift
+++ b/Coralogix/Sources/Utils/ViewManager.swift
@@ -16,10 +16,17 @@ public class ViewManager {
     var prevViewName: String?
     var visibleView: CXView?
     var uniqueViewsPerSession: Set<String>
-    
+    // CX-44687: sequence index of the active view within the current session.
+    // Starts nil (omitted on events fired before any view appears). The first
+    // appearance sets it to 0; subsequent name-differing appearances increment.
+    // Persisted to Keychain so a same-session restore (in-process re-init where
+    // SessionContext rolls back to the previous session via pid match) recovers
+    // the counter rather than starting over.
+    private var viewNumber: Int?
+
     private let queueKey = DispatchSpecificKey<Void>()
     private let syncQueue: DispatchQueue
-    
+
     init(keyChain: KeyChainProtocol?) {
         self.keyChain = keyChain
         self.uniqueViewsPerSession = Set<String>()
@@ -27,9 +34,14 @@ public class ViewManager {
         let queue = DispatchQueue(label: Keys.queueViewManagerQueue.rawValue, attributes: .concurrent)
         queue.setSpecific(key: queueKey, value: ())
         self.syncQueue = queue
-        
+
         if let viewName = keyChain?.readStringFromKeychain(service: Keys.service.rawValue, key: Keys.view.rawValue) {
             self.prevViewName = viewName
+        }
+        if let persisted = keyChain?.readStringFromKeychain(service: Keys.service.rawValue,
+                                                             key: Keys.keyViewNumber.rawValue),
+           let value = Int(persisted) {
+            self.viewNumber = value
         }
     }
     
@@ -53,19 +65,37 @@ public class ViewManager {
                 if self.visibleView?.name == view.name {
                     return
                 }
-                
+
                 if view.state == .notifyOnAppear {
                     if self.isUniqueView(name: view.name) {
                         self.uniqueViewsPerSession.insert(view.name)
                     }
+                    // CX-44687: every name-differing appearance is a navigation step.
+                    // First-ever: nil → 0. Subsequent: previous + 1. Revisits count
+                    // as new steps per spec (A→B→C→A ⇒ 0,1,2,3).
+                    self.viewNumber = (self.viewNumber ?? -1) + 1
+                    self.persistViewNumber()
                 }
-                
+
                 self.keyChain?.writeStringToKeychain(service: Keys.service.rawValue,
                                                      key: Keys.view.rawValue,
                                                      value: view.name)
             }
             self.visibleView = cxView
         }
+    }
+
+    /// CX-44687: returns the current sequence index, or nil if no view has appeared yet
+    /// (events fired before the first view must omit `view_number`).
+    public func getViewNumber() -> Int? {
+        return syncSafe { self.viewNumber }
+    }
+
+    private func persistViewNumber() {
+        let value = self.viewNumber.map(String.init) ?? ""
+        self.keyChain?.writeStringToKeychain(service: Keys.service.rawValue,
+                                             key: Keys.keyViewNumber.rawValue,
+                                             value: value)
     }
     
     func getDictionary() -> [String: Any] {
@@ -93,10 +123,15 @@ public class ViewManager {
             self.uniqueViewsPerSession.removeAll()
             if let currentView = self.visibleView {
                 self.uniqueViewsPerSession.insert(currentView.name)
+                // CX-44687: the current view is view #0 of the new session.
+                self.viewNumber = 0
+            } else {
+                self.viewNumber = nil
             }
+            self.persistViewNumber()
         }
     }
-    
+
     func shutdown() {
         syncQueue.async(flags: .barrier) { [weak self] in
             guard let self = self else { return }
@@ -104,6 +139,8 @@ public class ViewManager {
             self.visibleView = nil
             self.prevViewName = nil
             self.uniqueViewsPerSession.removeAll()
+            self.viewNumber = nil
+            self.persistViewNumber()
         }
     }
     

--- a/Coralogix/Sources/Utils/ViewManager.swift
+++ b/Coralogix/Sources/Utils/ViewManager.swift
@@ -57,7 +57,7 @@ public class ViewManager {
         if storedPid == currentPid,
            storedBootUUID == currentBootUUID,
            let persisted = keyChain?.readStringFromKeychain(service: Keys.service.rawValue,
-                                                             key: Keys.keyViewNumber.rawValue),
+                                                             key: Keys.storedViewNumber.rawValue),
            let value = Int(persisted) {
             self.viewNumber = value
         }
@@ -117,11 +117,11 @@ public class ViewManager {
     private func persistViewNumber() {
         if let viewNumber = self.viewNumber {
             self.keyChain?.writeStringToKeychain(service: Keys.service.rawValue,
-                                                 key: Keys.keyViewNumber.rawValue,
+                                                 key: Keys.storedViewNumber.rawValue,
                                                  value: String(viewNumber))
         } else {
             self.keyChain?.deleteFromKeychain(service: Keys.service.rawValue,
-                                              key: Keys.keyViewNumber.rawValue)
+                                              key: Keys.storedViewNumber.rawValue)
         }
     }
     

--- a/CoralogixInternal/Sources/Keys.swift
+++ b/CoralogixInternal/Sources/Keys.swift
@@ -103,6 +103,10 @@ public enum Keys: String {
     case data
     case logContext = "log_context"
     case pid
+    // CX-44687: keychain slot for the per-process boot UUID written alongside
+    // `pid` in SessionMetadata.loadPrevSession. Used by ViewManager.init as a
+    // PID-recycling defense — see Global.processBootUUID.
+    case bootUUID
     case frameNumber = "frame_number"
     case binary
     case functionAddressCalled = "function_address_called"

--- a/CoralogixInternal/Sources/Keys.swift
+++ b/CoralogixInternal/Sources/Keys.swift
@@ -138,7 +138,11 @@ public enum Keys: String {
     //   - isNavigationEvent → camelCase
     case viewNumber = "view_number"
     case isNavigationEvent
-    case keyViewNumber = "viewNumber"
+    // Keychain slot (NOT a wire key). The rawValue "viewNumber" is the SecItem
+    // account name we read/write — distinct from `Keys.viewNumber` above whose
+    // rawValue is "view_number". Confusing them at a callsite would silently
+    // store the counter under the wrong slot and break the restore path.
+    case storedViewNumber = "viewNumber"
     case threads
     case httpResponseBodySize = "http_response_body_size"
     case stackTrace

--- a/CoralogixInternal/Sources/Keys.swift
+++ b/CoralogixInternal/Sources/Keys.swift
@@ -128,6 +128,13 @@ public enum Keys: String {
     case actionCount
     case isViewUnique
     case isSnapshotEvent
+    // CX-44687: product-analytics fields at the cx_rum top level.
+    // Per-field naming chosen to match Browser's wire shape (Daniel, 2026-06-08):
+    //   - view_number  → snake_case
+    //   - isNavigationEvent → camelCase
+    case viewNumber = "view_number"
+    case isNavigationEvent
+    case keyViewNumber = "viewNumber"
     case threads
     case httpResponseBodySize = "http_response_body_size"
     case stackTrace

--- a/CoralogixInternal/Sources/Utils.swift
+++ b/CoralogixInternal/Sources/Utils.swift
@@ -30,6 +30,14 @@ public enum Global: String {
         Global.coralogixPath.rawValue,
         Global.sessionReplayPath.rawValue
     ]
+
+    /// CX-44687: per-process unique identifier, generated exactly once per process
+    /// via Swift's `static let` initialization semantics. Used alongside `getpid()`
+    /// as a defense-in-depth discriminator for in-process SDK re-init detection —
+    /// iOS/macOS recycle PIDs across cold launches, so PID alone can yield a false
+    /// "same process" match if the new process happens to receive the dead one's PID.
+    /// A UUID generated in-memory at first access cannot collide.
+    public static let processBootUUID: String = UUID().uuidString
     
     // Function to check if the URL contains any monitored path
     public static func containsMonitoredPath(_ urlString: String) -> Bool {

--- a/Tests/CoralogixRumTests/BeforeSendInstrumentationDataTests.swift
+++ b/Tests/CoralogixRumTests/BeforeSendInstrumentationDataTests.swift
@@ -558,31 +558,34 @@ final class BeforeSendInstrumentationDataTests: XCTestCase {
                      "view_number must not leak into otelSpan.attributes when the SDK emitted no value")
     }
 
-    // CX-44687: isNavigationEvent is a pure function of event_context.type, recomputed
-    // from the post-merge type in CxSpan.getDictionary(). The four tests below pin the
-    // four edit shapes a customer can produce — direct forgery, type-only edit toward
-    // navigation, type-only edit away from navigation, and contradictory edits to both
-    // — and assert that text.cx_rum and otelSpan.attributes always end up consistent
-    // with the final event_context.type.
+    // CX-44687: isNavigationEvent records the SDK's build-time observation of
+    // whether the event was a navigation. Read-only; preserved across every
+    // customer edit shape. The flag is NOT derived from the (possibly
+    // customer-relabeled) final event_context.type — it's an immutable
+    // historical fact about what the SDK saw. The four tests below pin that
+    // contract across direct flag forgery, type-edit toward navigation,
+    // type-edit away from navigation, and contradictory edits to both.
 
     func test_isNavigationEvent_directInjection_isIgnored() throws {
-        // Customer flips only the flag; original type was "network-request". The
-        // post-merge derivation must override the forgery in BOTH destinations.
+        // Customer flips only the flag; SDK original type was "network-request"
+        // (→ original flag = false). The read-only restore loop must put the
+        // SDK's original value back.
         let result = try runSpan { cxRum in
             var edit = cxRum
             edit[Keys.isNavigationEvent.rawValue] = true
             return edit
         }
         XCTAssertEqual(result.text[Keys.isNavigationEvent.rawValue] as? Bool, false,
-                       "direct forgery of isNavigationEvent must be overridden by the recompute from event_context.type")
+                       "direct forgery of isNavigationEvent must be overridden by the readOnly restore — SDK's original value wins")
         XCTAssertEqual(result.otel["cx_rum.is_navigation_event"] as? Bool, false,
-                       "otelSpan.attributes mirror must reflect the recomputed (not forged) value")
+                       "otelSpan.attributes mirror must reflect the SDK's original value, not the forgery")
     }
 
-    func test_isNavigationEvent_followsTypeEdit_towardNavigation() throws {
-        // Customer rewrites event_context.type to "navigation" without touching the
-        // flag. The flag must be recomputed to true in both destinations — without
-        // the post-merge derivation it would stay at the SDK-original `false`.
+    func test_isNavigationEvent_isPreservedAcrossTypeEdit_toNavigation() throws {
+        // Customer rewrites event_context.type to "navigation" without touching
+        // the flag. SDK original type was "network-request" (→ original flag =
+        // false). The flag must STAY false: it records what the SDK saw, not
+        // what the customer relabeled the payload to.
         let result = try runSpan { cxRum in
             var edit = cxRum
             if var ec = edit[Keys.eventContext.rawValue] as? [String: Any] {
@@ -591,20 +594,24 @@ final class BeforeSendInstrumentationDataTests: XCTestCase {
             }
             return edit
         }
-        XCTAssertEqual(result.text[Keys.isNavigationEvent.rawValue] as? Bool, true,
-                       "isNavigationEvent must follow a customer edit to event_context.type → navigation")
-        XCTAssertEqual(result.otel["cx_rum.is_navigation_event"] as? Bool, true,
-                       "otelSpan.attributes mirror must reflect the post-merge derivation")
+        XCTAssertEqual(result.text[Keys.isNavigationEvent.rawValue] as? Bool, false,
+                       "isNavigationEvent must NOT follow a customer type-edit — it records the SDK's original observation, not the relabeled final type")
+        XCTAssertEqual(result.otel["cx_rum.is_navigation_event"] as? Bool, false,
+                       "otelSpan.attributes mirror must reflect the SDK's original value")
+        // Sanity: the customer's type edit IS still visible in event_context.type.
+        XCTAssertEqual(
+            (result.text[Keys.eventContext.rawValue] as? [String: Any])?[Keys.type.rawValue] as? String,
+            CoralogixEventType.navigation.rawValue,
+            "the customer's type edit must propagate (we're not locking type — only the flag)"
+        )
     }
 
-    func test_isNavigationEvent_followsTypeEdit_awayFromNavigation() throws {
-        // Inverse direction: customer rewrites a navigation event to "log" without
-        // touching the flag. The flag must flip to false in text.cx_rum.
+    func test_isNavigationEvent_isPreservedAcrossTypeEdit_awayFromNavigation() throws {
+        // Inverse direction: SDK original type = "navigation" (→ original flag
+        // = true). Customer rewrites to "log". Flag must STAY true.
+        //
         // Navigation spans don't carry `instrumentation_data` (only network-request
-        // and custom-span do — see CxSpan.init), so we bypass the runSpan helper
-        // and assert text-only. The otelSpan.attributes mirror direction is already
-        // covered by the toward-navigation / direct-injection / contradictory tests
-        // on the network-request fixture.
+        // and custom-span do — see CxSpan.init), so bypass runSpan and assert text-only.
         let navSpan = MockSpanData(
             attributes: [
                 Keys.severity.rawValue: AttributeValue("3"),
@@ -647,13 +654,20 @@ final class BeforeSendInstrumentationDataTests: XCTestCase {
         let dict = try XCTUnwrap(cxSpan.getDictionary())
         let textCxRum = try XCTUnwrap((dict[Keys.text.rawValue] as? [String: Any])?[Keys.cxRum.rawValue] as? [String: Any])
 
-        XCTAssertEqual(textCxRum[Keys.isNavigationEvent.rawValue] as? Bool, false,
-                       "isNavigationEvent must follow a customer edit to event_context.type → log (was navigation)")
+        XCTAssertEqual(textCxRum[Keys.isNavigationEvent.rawValue] as? Bool, true,
+                       "isNavigationEvent must STAY true — SDK saw a navigation; customer relabeling the type to 'log' doesn't change that historical fact")
+        // Sanity: the customer's type edit IS still visible.
+        XCTAssertEqual(
+            (textCxRum[Keys.eventContext.rawValue] as? [String: Any])?[Keys.type.rawValue] as? String,
+            CoralogixEventType.log.rawValue,
+            "the customer's type edit must propagate (we're not locking type — only the flag)"
+        )
     }
 
-    func test_isNavigationEvent_contradictoryEdits_typeWins() throws {
-        // Customer sets type="log" AND isNavigationEvent=true. The derived field
-        // is determined by the final type, so isNavigationEvent must be false.
+    func test_isNavigationEvent_isPreservedAcrossBothEdits() throws {
+        // Customer edits type to "log" AND injects isNavigationEvent=true. SDK
+        // original type was "network-request" (→ original flag = false). Neither
+        // edit affects the flag: it stays at the SDK's original value.
         let result = try runSpan { cxRum in
             var edit = cxRum
             if var ec = edit[Keys.eventContext.rawValue] as? [String: Any] {
@@ -664,9 +678,9 @@ final class BeforeSendInstrumentationDataTests: XCTestCase {
             return edit
         }
         XCTAssertEqual(result.text[Keys.isNavigationEvent.rawValue] as? Bool, false,
-                       "event_context.type is the source of truth — contradictory flag edit must lose")
+                       "neither type-edit nor flag-injection moves isNavigationEvent — SDK's original observation wins")
         XCTAssertEqual(result.otel["cx_rum.is_navigation_event"] as? Bool, false,
-                       "otelSpan.attributes mirror must reflect the type-derived value, not the flag forgery")
+                       "otelSpan.attributes mirror must reflect the SDK's original value")
     }
 
     // MARK: - Baseline parity: no beforeSend → mirror still matches the cx_rum dict.

--- a/Tests/CoralogixRumTests/BeforeSendInstrumentationDataTests.swift
+++ b/Tests/CoralogixRumTests/BeforeSendInstrumentationDataTests.swift
@@ -382,6 +382,7 @@ final class BeforeSendInstrumentationDataTests: XCTestCase {
         XCTAssertNil(captured[Keys.mobileSdk.rawValue], "mobileSdk must not be editable")
         XCTAssertNil(captured[Keys.timestamp.rawValue], "timestamp must not be editable")
         XCTAssertNil(captured[Keys.viewNumber.rawValue], "view_number must not be editable")
+        XCTAssertNil(captured[Keys.isNavigationEvent.rawValue], "isNavigationEvent must not be editable")
 
         if let session = captured[Keys.sessionContext.rawValue] as? [String: Any] {
             XCTAssertNil(session[Keys.sessionId.rawValue], "sessionContext.sessionId must not be editable")

--- a/Tests/CoralogixRumTests/BeforeSendInstrumentationDataTests.swift
+++ b/Tests/CoralogixRumTests/BeforeSendInstrumentationDataTests.swift
@@ -545,5 +545,16 @@ final class BeforeSendInstrumentationDataTests: XCTestCase {
 
         let textUrl = (cxRum[Keys.networkRequestContext.rawValue] as? [String: Any])?[Keys.url.rawValue] as? String
         XCTAssertEqual(attrs["cx_rum.network_request_context.url"] as? String, textUrl)
+
+        // CX-44687: product-analytics fields must mirror through the post-`beforeSend`
+        // dict path. `is_navigation_event` is always present on both sides;
+        // `view_number` is present on both or absent on both (omitted before any view).
+        let textIsNav = cxRum[Keys.isNavigationEvent.rawValue] as? Bool
+        XCTAssertEqual(attrs["cx_rum.is_navigation_event"] as? Bool, textIsNav,
+                       "is_navigation_event must mirror cx_rum → instrumentation_data.otelSpan.attributes")
+
+        let textViewNumber = cxRum[Keys.viewNumber.rawValue] as? Int
+        XCTAssertEqual(attrs["cx_rum.view_number"] as? Int, textViewNumber,
+                       "view_number must mirror cx_rum → otelSpan.attributes when present, and be absent on both sides when not")
     }
 }

--- a/Tests/CoralogixRumTests/BeforeSendInstrumentationDataTests.swift
+++ b/Tests/CoralogixRumTests/BeforeSendInstrumentationDataTests.swift
@@ -557,26 +557,115 @@ final class BeforeSendInstrumentationDataTests: XCTestCase {
                      "view_number must not leak into otelSpan.attributes when the SDK emitted no value")
     }
 
-    // CX-44687: pin that `isNavigationEvent` is NOT in readOnlyCxRumKeys. It
-    // derives from `event_context.type` which is already customer-editable, so
-    // the two must move together. A future PR that accidentally tightens this
-    // (by adding `isNavigationEvent` to the read-only list) will fail here.
-    func test_isNavigationEvent_isEditableByBeforeSend() throws {
-        // Probe the SDK-emitted value first so the forgery is unambiguously distinct.
-        let probe = try runSpan { $0 }
-        let sdkValue = probe.text[Keys.isNavigationEvent.rawValue] as? Bool
-        XCTAssertEqual(sdkValue, false,
-                       "Network-request fixture is not a navigation event — probe regression in CxRumBuilder")
+    // CX-44687: isNavigationEvent is a pure function of event_context.type, recomputed
+    // from the post-merge type in CxSpan.getDictionary(). The four tests below pin the
+    // four edit shapes a customer can produce — direct forgery, type-only edit toward
+    // navigation, type-only edit away from navigation, and contradictory edits to both
+    // — and assert that text.cx_rum and otelSpan.attributes always end up consistent
+    // with the final event_context.type.
 
+    func test_isNavigationEvent_directInjection_isIgnored() throws {
+        // Customer flips only the flag; original type was "network-request". The
+        // post-merge derivation must override the forgery in BOTH destinations.
         let result = try runSpan { cxRum in
             var edit = cxRum
             edit[Keys.isNavigationEvent.rawValue] = true
             return edit
         }
+        XCTAssertEqual(result.text[Keys.isNavigationEvent.rawValue] as? Bool, false,
+                       "direct forgery of isNavigationEvent must be overridden by the recompute from event_context.type")
+        XCTAssertEqual(result.otel["cx_rum.is_navigation_event"] as? Bool, false,
+                       "otelSpan.attributes mirror must reflect the recomputed (not forged) value")
+    }
+
+    func test_isNavigationEvent_followsTypeEdit_towardNavigation() throws {
+        // Customer rewrites event_context.type to "navigation" without touching the
+        // flag. The flag must be recomputed to true in both destinations — without
+        // the post-merge derivation it would stay at the SDK-original `false`.
+        let result = try runSpan { cxRum in
+            var edit = cxRum
+            if var ec = edit[Keys.eventContext.rawValue] as? [String: Any] {
+                ec[Keys.type.rawValue] = CoralogixEventType.navigation.rawValue
+                edit[Keys.eventContext.rawValue] = ec
+            }
+            return edit
+        }
         XCTAssertEqual(result.text[Keys.isNavigationEvent.rawValue] as? Bool, true,
-                       "isNavigationEvent must remain customer-editable via beforeSend (parity with event_context.type)")
+                       "isNavigationEvent must follow a customer edit to event_context.type → navigation")
         XCTAssertEqual(result.otel["cx_rum.is_navigation_event"] as? Bool, true,
-                       "the otelSpan.attributes mirror must reflect the customer's edit")
+                       "otelSpan.attributes mirror must reflect the post-merge derivation")
+    }
+
+    func test_isNavigationEvent_followsTypeEdit_awayFromNavigation() throws {
+        // Inverse direction: customer rewrites a navigation event to "log" without
+        // touching the flag. The flag must flip to false in text.cx_rum.
+        // Navigation spans don't carry `instrumentation_data` (only network-request
+        // and custom-span do — see CxSpan.init), so we bypass the runSpan helper
+        // and assert text-only. The otelSpan.attributes mirror direction is already
+        // covered by the toward-navigation / direct-injection / contradictory tests
+        // on the network-request fixture.
+        let navSpan = MockSpanData(
+            attributes: [
+                Keys.severity.rawValue: AttributeValue("3"),
+                Keys.eventType.rawValue: AttributeValue(CoralogixEventType.navigation.rawValue),
+                Keys.source.rawValue: AttributeValue("user"),
+                Keys.environment.rawValue: AttributeValue("PROD"),
+                Keys.userId.rawValue: AttributeValue("user-orig"),
+                Keys.userName.rawValue: AttributeValue("Original Name"),
+                Keys.userEmail.rawValue: AttributeValue("orig@example.com"),
+                Keys.sessionId.rawValue: AttributeValue("session_001"),
+                Keys.sessionCreationDate.rawValue: AttributeValue(1609459200)
+            ],
+            startTime: Date(),
+            endTime: Date(),
+            spanId: "20",
+            traceId: "30",
+            name: "testSpan",
+            kind: 2,
+            statusCode: ["status": "ok"],
+            resources: [:]
+        )
+        let options = makeOptions(beforeSend: { cxRum in
+            var edit = cxRum
+            if var ec = edit[Keys.eventContext.rawValue] as? [String: Any] {
+                ec[Keys.type.rawValue] = CoralogixEventType.log.rawValue
+                edit[Keys.eventContext.rawValue] = ec
+            }
+            return edit
+        })
+        guard let cxSpan = CxSpan(
+            otel: navSpan,
+            versionMetadata: mockVersionMetadata,
+            sessionManager: mockSessionManager,
+            networkManager: mockNetworkManager,
+            viewManager: mockViewManager,
+            metricsManager: mockMetricsManager,
+            options: options
+        ) else { return XCTFail("CxSpan init failed") }
+
+        let dict = try XCTUnwrap(cxSpan.getDictionary())
+        let textCxRum = try XCTUnwrap((dict[Keys.text.rawValue] as? [String: Any])?[Keys.cxRum.rawValue] as? [String: Any])
+
+        XCTAssertEqual(textCxRum[Keys.isNavigationEvent.rawValue] as? Bool, false,
+                       "isNavigationEvent must follow a customer edit to event_context.type → log (was navigation)")
+    }
+
+    func test_isNavigationEvent_contradictoryEdits_typeWins() throws {
+        // Customer sets type="log" AND isNavigationEvent=true. The derived field
+        // is determined by the final type, so isNavigationEvent must be false.
+        let result = try runSpan { cxRum in
+            var edit = cxRum
+            if var ec = edit[Keys.eventContext.rawValue] as? [String: Any] {
+                ec[Keys.type.rawValue] = CoralogixEventType.log.rawValue
+                edit[Keys.eventContext.rawValue] = ec
+            }
+            edit[Keys.isNavigationEvent.rawValue] = true
+            return edit
+        }
+        XCTAssertEqual(result.text[Keys.isNavigationEvent.rawValue] as? Bool, false,
+                       "event_context.type is the source of truth — contradictory flag edit must lose")
+        XCTAssertEqual(result.otel["cx_rum.is_navigation_event"] as? Bool, false,
+                       "otelSpan.attributes mirror must reflect the type-derived value, not the flag forgery")
     }
 
     // MARK: - Baseline parity: no beforeSend → mirror still matches the cx_rum dict.

--- a/Tests/CoralogixRumTests/BeforeSendInstrumentationDataTests.swift
+++ b/Tests/CoralogixRumTests/BeforeSendInstrumentationDataTests.swift
@@ -360,6 +360,11 @@ final class BeforeSendInstrumentationDataTests: XCTestCase {
     // through to the final payload.
 
     func test_subset_doesNotContainReadOnlyFields() throws {
+        // Drive the viewManager so the SDK emits a real view_number. Without this,
+        // the SDK omits the field entirely and the view_number assertion below
+        // would trivially pass even if the key were missing from readOnlyCxRumKeys.
+        mockViewManager.set(cxView: CXView(state: .notifyOnAppear, name: "Home"))
+
         // Capture the subset by spying through a no-op beforeSend.
         var captured: [String: Any] = [:]
         _ = try runSpan { cxRum in
@@ -376,6 +381,7 @@ final class BeforeSendInstrumentationDataTests: XCTestCase {
         XCTAssertNil(captured[Keys.snapshotContext.rawValue], "snapshotContext must not be editable")
         XCTAssertNil(captured[Keys.mobileSdk.rawValue], "mobileSdk must not be editable")
         XCTAssertNil(captured[Keys.timestamp.rawValue], "timestamp must not be editable")
+        XCTAssertNil(captured[Keys.viewNumber.rawValue], "view_number must not be editable")
 
         if let session = captured[Keys.sessionContext.rawValue] as? [String: Any] {
             XCTAssertNil(session[Keys.sessionId.rawValue], "sessionContext.sessionId must not be editable")
@@ -514,6 +520,63 @@ final class BeforeSendInstrumentationDataTests: XCTestCase {
                                      "mobileSdk must remain a dict, not be replaced by the forged version")
         XCTAssertEqual(NSDictionary(dictionary: restored), NSDictionary(dictionary: sdkMobileSdk),
                        "mobileSdk must be restored from the original cx_rum, not the callback's injected value")
+    }
+
+    // CX-44687: view_number is an SDK-owned navigation-step counter. A customer
+    // callback injecting a value (e.g. `view_number: 999` on every span) would
+    // silently corrupt downstream funnel analysis — protect like other counters.
+    func test_viewNumber_injectionIsIgnored() throws {
+        // Drive the SDK to emit a known view_number (first appearance → 0).
+        mockViewManager.set(cxView: CXView(state: .notifyOnAppear, name: "Home"))
+
+        let result = try runSpan { cxRum in
+            var edit = cxRum
+            edit[Keys.viewNumber.rawValue] = 999
+            return edit
+        }
+        XCTAssertEqual(result.text[Keys.viewNumber.rawValue] as? Int, 0,
+                       "view_number must be restored from the original cx_rum, not the callback's injected value")
+        // The cx_rum.* attribute mirror must also reflect the restored SDK value.
+        XCTAssertEqual(result.otel["cx_rum.view_number"] as? Int, 0,
+                       "view_number mirror in otelSpan.attributes must reflect the SDK-restored value")
+    }
+
+    // The "no view yet → omit" contract must survive forgery: if the SDK didn't
+    // emit view_number, a callback injecting one must NOT leak it into either
+    // destination. CxSpan's restore loop removes keys whose original was nil.
+    func test_viewNumber_injectionIsRemoved_whenNoViewEmitted() throws {
+        // mockViewManager has never had a view set → SDK omits view_number.
+        let result = try runSpan { cxRum in
+            var edit = cxRum
+            edit[Keys.viewNumber.rawValue] = 999
+            return edit
+        }
+        XCTAssertNil(result.text[Keys.viewNumber.rawValue],
+                     "view_number must be removed from text.cx_rum when the SDK emitted no value, even if the callback injects one")
+        XCTAssertNil(result.otel["cx_rum.view_number"],
+                     "view_number must not leak into otelSpan.attributes when the SDK emitted no value")
+    }
+
+    // CX-44687: pin that `isNavigationEvent` is NOT in readOnlyCxRumKeys. It
+    // derives from `event_context.type` which is already customer-editable, so
+    // the two must move together. A future PR that accidentally tightens this
+    // (by adding `isNavigationEvent` to the read-only list) will fail here.
+    func test_isNavigationEvent_isEditableByBeforeSend() throws {
+        // Probe the SDK-emitted value first so the forgery is unambiguously distinct.
+        let probe = try runSpan { $0 }
+        let sdkValue = probe.text[Keys.isNavigationEvent.rawValue] as? Bool
+        XCTAssertEqual(sdkValue, false,
+                       "Network-request fixture is not a navigation event — probe regression in CxRumBuilder")
+
+        let result = try runSpan { cxRum in
+            var edit = cxRum
+            edit[Keys.isNavigationEvent.rawValue] = true
+            return edit
+        }
+        XCTAssertEqual(result.text[Keys.isNavigationEvent.rawValue] as? Bool, true,
+                       "isNavigationEvent must remain customer-editable via beforeSend (parity with event_context.type)")
+        XCTAssertEqual(result.otel["cx_rum.is_navigation_event"] as? Bool, true,
+                       "the otelSpan.attributes mirror must reflect the customer's edit")
     }
 
     // MARK: - Baseline parity: no beforeSend → mirror still matches the cx_rum dict.

--- a/Tests/CoralogixRumTests/CxRumBuilderTests.swift
+++ b/Tests/CoralogixRumTests/CxRumBuilderTests.swift
@@ -227,4 +227,155 @@ class CxRumBuilderTests: XCTestCase {
         ])
         return EventContext(otel: mockSpanData)
     }
+
+    // MARK: - CX-44687: isNavigationEvent + viewNumber wire emission
+
+    func test_build_isNavigationEvent_trueForNavigationType() {
+        guard let cxRum = makeSUT(currentTime: Date(), eventType: "navigation")?.build() else {
+            return XCTFail("build() returned nil for navigation event")
+        }
+        XCTAssertTrue(cxRum.isNavigationEvent)
+    }
+
+    func test_build_isNavigationEvent_falseForLog() {
+        guard let cxRum = makeSUT(currentTime: Date(), eventType: "log")?.build() else {
+            return XCTFail("build() returned nil for log event")
+        }
+        XCTAssertFalse(cxRum.isNavigationEvent)
+    }
+
+    func test_build_isNavigationEvent_falseForError() {
+        guard let cxRum = makeSUT(currentTime: Date(), eventType: "error")?.build() else {
+            return XCTFail("build() returned nil for error event")
+        }
+        XCTAssertFalse(cxRum.isNavigationEvent)
+    }
+
+    func test_build_isNavigationEvent_falseForNetworkRequest() {
+        guard let cxRum = makeSUT(currentTime: Date(), eventType: "network-request")?.build() else {
+            return XCTFail("build() returned nil for network-request event")
+        }
+        XCTAssertFalse(cxRum.isNavigationEvent)
+    }
+
+    func test_build_viewNumber_nilBeforeAnyView() {
+        // ViewManager fresh — no view has been set.
+        mockViewManager = MockViewManager(keyChain: MockKeyChain())
+        guard let cxRum = makeSUT(currentTime: Date(), eventType: "log")?.build() else {
+            return XCTFail("build() returned nil")
+        }
+        XCTAssertNil(cxRum.viewNumber,
+                     "events fired before any view appears must omit view_number")
+    }
+
+    func test_build_viewNumber_propagatesFromViewManager() {
+        // Drive ViewManager through 3 distinct appearances → expect view_number = 2.
+        mockViewManager = MockViewManager(keyChain: MockKeyChain())
+        mockViewManager.set(cxView: CXView(state: .notifyOnAppear, name: "A"))
+        mockViewManager.set(cxView: CXView(state: .notifyOnAppear, name: "B"))
+        mockViewManager.set(cxView: CXView(state: .notifyOnAppear, name: "C"))
+
+        guard let cxRum = makeSUT(currentTime: Date(), eventType: "log")?.build() else {
+            return XCTFail("build() returned nil")
+        }
+        XCTAssertEqual(cxRum.viewNumber, 2)
+    }
+
+    func test_payload_emitsIsNavigationEventAtTopLevel() {
+        guard let cxRum = makeSUT(currentTime: Date(), eventType: "log")?.build() else {
+            return XCTFail("build() returned nil")
+        }
+        var builder = CxRumPayloadBuilder(rum: cxRum, viewManager: mockViewManager)
+        let payload = builder.build()
+
+        // Must appear at cx_rum top level, NOT inside view_context / event_context.
+        XCTAssertNotNil(payload[Keys.isNavigationEvent.rawValue],
+                        "isNavigationEvent must be emitted at the cx_rum top level on every event")
+        XCTAssertEqual(payload[Keys.isNavigationEvent.rawValue] as? Bool, false)
+
+        // Confirm it's NOT nested under event_context.
+        let ec = payload[Keys.eventContext.rawValue] as? [String: Any]
+        XCTAssertNil(ec?[Keys.isNavigationEvent.rawValue],
+                     "isNavigationEvent must not be nested under event_context")
+    }
+
+    func test_payload_emitsViewNumberAtTopLevelWhenPresent() {
+        mockViewManager = MockViewManager(keyChain: MockKeyChain())
+        mockViewManager.set(cxView: CXView(state: .notifyOnAppear, name: "Home"))
+        mockViewManager.set(cxView: CXView(state: .notifyOnAppear, name: "Settings"))
+
+        guard let cxRum = makeSUT(currentTime: Date(), eventType: "log")?.build() else {
+            return XCTFail("build() returned nil")
+        }
+        var builder = CxRumPayloadBuilder(rum: cxRum, viewManager: mockViewManager)
+        let payload = builder.build()
+
+        XCTAssertEqual(payload[Keys.viewNumber.rawValue] as? Int, 1)
+
+        // Must NOT be nested under view_context.
+        let vc = payload[Keys.viewContext.rawValue] as? [String: Any]
+        XCTAssertNil(vc?[Keys.viewNumber.rawValue],
+                     "view_number must not be nested under view_context")
+    }
+
+    func test_payload_omitsViewNumberWhenNoViewYet() {
+        mockViewManager = MockViewManager(keyChain: MockKeyChain())
+        // No views set — viewNumber should be nil.
+
+        guard let cxRum = makeSUT(currentTime: Date(), eventType: "log")?.build() else {
+            return XCTFail("build() returned nil")
+        }
+        var builder = CxRumPayloadBuilder(rum: cxRum, viewManager: mockViewManager)
+        let payload = builder.build()
+
+        XCTAssertNil(payload[Keys.viewNumber.rawValue],
+                     "view_number must be entirely absent from the payload when no view has appeared yet")
+    }
+
+    // Convenience overload that lets the new tests vary event type without touching the
+    // original makeSUT() / its existing callers (which pin a "log" event for snapshot tests).
+    private func makeSUT(currentTime: Date, eventType: String) -> CxRumBuilder? {
+        let endTime = Date()
+        self.mockOtel = MockSpanData(attributes: [Keys.severity.rawValue: AttributeValue("3"),
+                                                  Keys.eventType.rawValue: AttributeValue(eventType),
+                                                  Keys.source.rawValue: AttributeValue("console"),
+                                                  Keys.environment.rawValue: AttributeValue("prod"),
+                                                  Keys.userId.rawValue: AttributeValue("12345"),
+                                                  Keys.userName.rawValue: AttributeValue("John Doe"),
+                                                  Keys.userEmail.rawValue: AttributeValue("john.doe@example.com"),
+                                                  Keys.sessionId.rawValue: AttributeValue("session_001"),
+                                                  Keys.sessionCreationDate.rawValue: AttributeValue(1609459200)],
+                                     startTime: currentTime,
+                                     endTime: endTime,
+                                     spanId: "20",
+                                     traceId: "30",
+                                     name: "testSpan",
+                                     kind: 1,
+                                     statusCode: ["status": "ok"],
+                                     resources: [:])
+
+        let userContext = UserContext(userId: "12345",
+                                      userName: "John Doe",
+                                      userEmail: "john.doe@example.com",
+                                      userMetadata: ["userId": "12345"])
+
+        options = CoralogixExporterOptions(coralogixDomain: CoralogixDomain.US2,
+                                           userContext: userContext,
+                                           environment: "PROD",
+                                           application: "TestApp-iOS",
+                                           version: "1.0",
+                                           publicKey: "token",
+                                           ignoreUrls: [],
+                                           ignoreErrors: [],
+                                           labels: ["key": "value"],
+                                           debug: true)
+        guard let options = options else { return nil }
+
+        return CxRumBuilder(otel: mockOtel,
+                            versionMetadata: VersionMetadata(appName: "Test", appVersion: "1.0"),
+                            sessionManager: mockSessionManager,
+                            viewManager: mockViewManager,
+                            networkManager: NetworkManager(),
+                            options: options)
+    }
 }

--- a/Tests/CoralogixRumTests/FingerprintManagerTests.swift
+++ b/Tests/CoralogixRumTests/FingerprintManagerTests.swift
@@ -131,6 +131,10 @@ final class FakeKeychain: KeyChainProtocol {
         lock.unlock()
     }
 
+    func deleteFromKeychain(service: String, key: String) {
+        lock.lock(); value = nil; lock.unlock()
+    }
+
     // Helpers for tests
     func setStoredValue(_ v: String?) {
         lock.lock(); value = v; lock.unlock()

--- a/Tests/CoralogixRumTests/InstrumentationDataTests.swift
+++ b/Tests/CoralogixRumTests/InstrumentationDataTests.swift
@@ -317,6 +317,40 @@ final class InstrumentationDataTests: XCTestCase {
         XCTAssertNil(attrs["cx_rum.error_context.error_message"])
     }
 
+    // MARK: - CX-44687: product-analytics fields mirror to otelSpan.attributes
+    //
+    // Pins the contract that `isNavigationEvent` / `view_number` reach
+    // `instrumentation_data.otelSpan.attributes` (and not only `text.cx_rum`),
+    // matching the centralised AttrKey mapping established in CX-44686.
+
+    func testBuildRumContextAttributes_isNavigationEvent_truePropagates() {
+        let cxRum = makeCxRum(isNavigationEvent: true)
+        let attrs = OtelSpan(otel: mockSpan, cxRum: cxRum, viewManager: nil).attributes
+        XCTAssertEqual(attrs["cx_rum.is_navigation_event"] as? Bool, true)
+    }
+
+    func testBuildRumContextAttributes_isNavigationEvent_falseStillEmitted() {
+        // The flag must be present (true/false) on every span — never absent.
+        let cxRum = makeCxRum(isNavigationEvent: false)
+        let attrs = OtelSpan(otel: mockSpan, cxRum: cxRum, viewManager: nil).attributes
+        XCTAssertNotNil(attrs["cx_rum.is_navigation_event"],
+                        "cx_rum.is_navigation_event must be emitted unconditionally, including when false")
+        XCTAssertEqual(attrs["cx_rum.is_navigation_event"] as? Bool, false)
+    }
+
+    func testBuildRumContextAttributes_viewNumber_presentWhenSet() {
+        let cxRum = makeCxRum(viewNumber: 3)
+        let attrs = OtelSpan(otel: mockSpan, cxRum: cxRum, viewManager: nil).attributes
+        XCTAssertEqual(attrs["cx_rum.view_number"] as? Int, 3)
+    }
+
+    func testBuildRumContextAttributes_viewNumber_absentWhenNil() {
+        let cxRum = makeCxRum(viewNumber: nil)
+        let attrs = OtelSpan(otel: mockSpan, cxRum: cxRum, viewManager: nil).attributes
+        XCTAssertNil(attrs["cx_rum.view_number"],
+                     "view_number must be omitted from otelSpan.attributes when no view has appeared yet")
+    }
+
     // MARK: - OTLP serialization regression tests (fix: network spans 422)
     // Backend requires i32 for status.code and kind — string enum names cause HTTP 422.
 
@@ -401,7 +435,9 @@ final class InstrumentationDataTests: XCTestCase {
         labels: [String: Any]? = nil,
         errorType: String = "",
         errorMessage: String = "",
-        hasRecording: Bool = false
+        hasRecording: Bool = false,
+        isNavigationEvent: Bool = false,
+        viewNumber: Int? = nil
     ) -> CxRum {
         let eventSpan = MockSpanData(attributes: [
             Keys.eventType.rawValue: AttributeValue(eventType.rawValue),
@@ -457,8 +493,8 @@ final class InstrumentationDataTests: XCTestCase {
             internalContext: nil,
             measurementContext: nil,
             fingerPrint: "test-fingerprint",
-            isNavigationEvent: false,
-            viewNumber: nil
+            isNavigationEvent: isNavigationEvent,
+            viewNumber: viewNumber
         )
     }
 }

--- a/Tests/CoralogixRumTests/InstrumentationDataTests.swift
+++ b/Tests/CoralogixRumTests/InstrumentationDataTests.swift
@@ -456,7 +456,9 @@ final class InstrumentationDataTests: XCTestCase {
             screenShotContext: nil,
             internalContext: nil,
             measurementContext: nil,
-            fingerPrint: "test-fingerprint"
+            fingerPrint: "test-fingerprint",
+            isNavigationEvent: false,
+            viewNumber: nil
         )
     }
 }

--- a/Tests/CoralogixRumTests/Utils.swift
+++ b/Tests/CoralogixRumTests/Utils.swift
@@ -127,6 +127,16 @@ class MockKeyschainManager: KeyChainProtocol {
             self.sessionTimeInterval = value
         }
     }
+
+    func deleteFromKeychain(service: String, key: String) {
+        if key == "pid" {
+            self.pid = ""
+        } else if key == "sessionId" {
+            self.sessionId = ""
+        } else if key == "sessionTimeInterval" {
+            self.sessionTimeInterval = ""
+        }
+    }
 }
 
 class MockNetworkManager: NetworkProtocol {

--- a/Tests/CoralogixRumTests/ViewManagerTests.swift
+++ b/Tests/CoralogixRumTests/ViewManagerTests.swift
@@ -109,6 +109,17 @@ final class ViewManagerTests: XCTestCase {
 
     // MARK: - CX-44687: view_number sequence
 
+    /// Pre-seeds the mock keychain with the current process's PID so that
+    /// `ViewManager.init` treats a restored counter as in-process-continuation.
+    /// In production, `SessionMetadata.loadPrevSession` writes `getpid()` to the
+    /// same key during normal init; tests that exercise restore behavior must
+    /// stage that state explicitly.
+    private func seedKeychainWithCurrentPid() {
+        mockKeyChain.writeStringToKeychain(service: Keys.service.rawValue,
+                                            key: Keys.pid.rawValue,
+                                            value: String(getpid()))
+    }
+
     func testViewNumber_isNilBeforeAnyView() {
         XCTAssertNil(viewManager.getViewNumber(),
                      "view_number must be nil until the first view appears")
@@ -149,6 +160,7 @@ final class ViewManagerTests: XCTestCase {
         // We avoid reading the mock dict directly because that race-conditions with
         // the syncQueue barrier writes — the production restore path goes through
         // `readStringFromKeychain` and is what we actually ship.
+        seedKeychainWithCurrentPid()  // simulates in-process continuation
         viewManager.set(cxView: CXView(state: .notifyOnAppear, name: "A"))
         viewManager.set(cxView: CXView(state: .notifyOnAppear, name: "B"))
         viewManager.set(cxView: CXView(state: .notifyOnAppear, name: "C"))
@@ -158,16 +170,33 @@ final class ViewManagerTests: XCTestCase {
 
         let restored = ViewManager(keyChain: mockKeyChain)
         XCTAssertEqual(restored.getViewNumber(), 2,
-                       "every increment must be persisted; a fresh ViewManager built from the same keychain restores the latest value")
+                       "every increment must be persisted; a fresh ViewManager built from the same keychain restores the latest value when the PID matches")
     }
 
     func testViewNumber_restoresFromKeychainOnInit() {
+        seedKeychainWithCurrentPid()  // simulates in-process continuation
         mockKeyChain.writeStringToKeychain(service: Keys.service.rawValue,
                                             key: Keys.keyViewNumber.rawValue,
                                             value: "7")
         let restored = ViewManager(keyChain: mockKeyChain)
         XCTAssertEqual(restored.getViewNumber(), 7,
-                       "ViewManager init must restore view_number from keychain so a same-session restore keeps the sequence intact")
+                       "ViewManager init must restore view_number from keychain so a same-process restore keeps the sequence intact")
+    }
+
+    func testViewNumber_isNotRestored_whenPidDoesNotMatch() {
+        // CX-44687 regression guard: stale Keychain values from a previous process
+        // must NOT leak into a new session. SessionEndedCallback does NOT fire on
+        // first-init (SessionManager.fireRotationCallbacks gates on priorExisted),
+        // so the gating MUST happen at the ViewManager.init restore step.
+        mockKeyChain.writeStringToKeychain(service: Keys.service.rawValue,
+                                            key: Keys.pid.rawValue,
+                                            value: "PID_FROM_PREVIOUS_PROCESS")
+        mockKeyChain.writeStringToKeychain(service: Keys.service.rawValue,
+                                            key: Keys.keyViewNumber.rawValue,
+                                            value: "5")
+        let restored = ViewManager(keyChain: mockKeyChain)
+        XCTAssertNil(restored.getViewNumber(),
+                     "view_number must NOT be restored when the persisted PID doesn't match the current process — the previous session is over and the stored counter is stale")
     }
 
     func testViewNumber_initWithoutPersistedValue_isNil() {
@@ -176,6 +205,7 @@ final class ViewManagerTests: XCTestCase {
     }
 
     func testViewNumber_reset_withVisibleView_setsToZero() {
+        seedKeychainWithCurrentPid()  // restored ViewManager below must be treated as in-process
         viewManager.set(cxView: CXView(state: .notifyOnAppear, name: "A"))
         viewManager.set(cxView: CXView(state: .notifyOnAppear, name: "B"))
         XCTAssertEqual(viewManager.getViewNumber(), 1)
@@ -191,6 +221,7 @@ final class ViewManagerTests: XCTestCase {
 
     func testViewNumber_reset_withoutVisibleView_clearsToNil() {
         // No view ever set → reset should leave the counter nil and clear the keychain entry.
+        seedKeychainWithCurrentPid()  // probe ViewManager below must be treated as in-process
         mockKeyChain.writeStringToKeychain(service: Keys.service.rawValue,
                                             key: Keys.keyViewNumber.rawValue,
                                             value: "5")
@@ -206,6 +237,7 @@ final class ViewManagerTests: XCTestCase {
     }
 
     func testViewNumber_shutdown_clears() {
+        seedKeychainWithCurrentPid()
         viewManager.set(cxView: CXView(state: .notifyOnAppear, name: "Home"))
         XCTAssertEqual(viewManager.getViewNumber(), 0)
 

--- a/Tests/CoralogixRumTests/ViewManagerTests.swift
+++ b/Tests/CoralogixRumTests/ViewManagerTests.swift
@@ -102,9 +102,130 @@ final class ViewManagerTests: XCTestCase {
         let view = CXView(state: .notifyOnAppear, name: "Dashboard")
         manager.set(cxView: view)
         manager.set(cxView: view)  // setting same view again
-        
+
         XCTAssertEqual(manager.getUniqueViewCount(), 1)
         XCTAssertEqual(mockKeychain.readStringFromKeychain(service: "service", key: "view"), "Dashboard")
+    }
+
+    // MARK: - CX-44687: view_number sequence
+
+    func testViewNumber_isNilBeforeAnyView() {
+        XCTAssertNil(viewManager.getViewNumber(),
+                     "view_number must be nil until the first view appears")
+    }
+
+    func testViewNumber_firstAppearance_isZero() {
+        viewManager.set(cxView: CXView(state: .notifyOnAppear, name: "Home"))
+        XCTAssertEqual(viewManager.getViewNumber(), 0)
+    }
+
+    func testViewNumber_increments_onDifferentName() {
+        viewManager.set(cxView: CXView(state: .notifyOnAppear, name: "A"))
+        viewManager.set(cxView: CXView(state: .notifyOnAppear, name: "B"))
+        viewManager.set(cxView: CXView(state: .notifyOnAppear, name: "C"))
+        XCTAssertEqual(viewManager.getViewNumber(), 2)
+    }
+
+    func testViewNumber_revisitCountsAsNewStep() {
+        // Spec example: A → B → C → A ⇒ 0, 1, 2, 3 (revisits MUST increment).
+        viewManager.set(cxView: CXView(state: .notifyOnAppear, name: "A"))
+        viewManager.set(cxView: CXView(state: .notifyOnAppear, name: "B"))
+        viewManager.set(cxView: CXView(state: .notifyOnAppear, name: "C"))
+        viewManager.set(cxView: CXView(state: .notifyOnAppear, name: "A"))
+        XCTAssertEqual(viewManager.getViewNumber(), 3)
+    }
+
+    func testViewNumber_doesNotIncrement_onSameName() {
+        viewManager.set(cxView: CXView(state: .notifyOnAppear, name: "A"))
+        viewManager.set(cxView: CXView(state: .notifyOnAppear, name: "A"))  // duplicate
+        viewManager.set(cxView: CXView(state: .notifyOnAppear, name: "A"))
+        XCTAssertEqual(viewManager.getViewNumber(), 0,
+                       "setting the same view repeatedly must not bump the counter")
+    }
+
+    func testViewNumber_persistsToKeychainOnEveryIncrement() {
+        // Verify persistence end-to-end: after a sequence of appearances, a fresh
+        // ViewManager built from the same keychain must restore the latest counter.
+        // We avoid reading the mock dict directly because that race-conditions with
+        // the syncQueue barrier writes — the production restore path goes through
+        // `readStringFromKeychain` and is what we actually ship.
+        viewManager.set(cxView: CXView(state: .notifyOnAppear, name: "A"))
+        viewManager.set(cxView: CXView(state: .notifyOnAppear, name: "B"))
+        viewManager.set(cxView: CXView(state: .notifyOnAppear, name: "C"))
+        // Sync-flush via the production read path before we hand the keychain to a
+        // restored instance — guarantees the barrier writes are complete.
+        XCTAssertEqual(viewManager.getViewNumber(), 2)
+
+        let restored = ViewManager(keyChain: mockKeyChain)
+        XCTAssertEqual(restored.getViewNumber(), 2,
+                       "every increment must be persisted; a fresh ViewManager built from the same keychain restores the latest value")
+    }
+
+    func testViewNumber_restoresFromKeychainOnInit() {
+        mockKeyChain.writeStringToKeychain(service: Keys.service.rawValue,
+                                            key: Keys.keyViewNumber.rawValue,
+                                            value: "7")
+        let restored = ViewManager(keyChain: mockKeyChain)
+        XCTAssertEqual(restored.getViewNumber(), 7,
+                       "ViewManager init must restore view_number from keychain so a same-session restore keeps the sequence intact")
+    }
+
+    func testViewNumber_initWithoutPersistedValue_isNil() {
+        let fresh = ViewManager(keyChain: MockKeyChain())
+        XCTAssertNil(fresh.getViewNumber())
+    }
+
+    func testViewNumber_reset_withVisibleView_setsToZero() {
+        viewManager.set(cxView: CXView(state: .notifyOnAppear, name: "A"))
+        viewManager.set(cxView: CXView(state: .notifyOnAppear, name: "B"))
+        XCTAssertEqual(viewManager.getViewNumber(), 1)
+
+        viewManager.reset()
+        XCTAssertEqual(viewManager.getViewNumber(), 0,
+                       "the current view is view #0 of the new session after rotation")
+        // End-to-end persistence check: a restored ViewManager sees view #0.
+        let restored = ViewManager(keyChain: mockKeyChain)
+        XCTAssertEqual(restored.getViewNumber(), 0,
+                       "reset must persist the new counter so a same-process restore reflects the rotation")
+    }
+
+    func testViewNumber_reset_withoutVisibleView_clearsToNil() {
+        // No view ever set → reset should leave the counter nil and clear the keychain entry.
+        mockKeyChain.writeStringToKeychain(service: Keys.service.rawValue,
+                                            key: Keys.keyViewNumber.rawValue,
+                                            value: "5")
+        let manager = ViewManager(keyChain: mockKeyChain)
+        XCTAssertEqual(manager.getViewNumber(), 5)
+
+        manager.reset()
+        XCTAssertNil(manager.getViewNumber())
+        // End-to-end: a restored ViewManager sees nil (the persisted "" parses to nil).
+        let restored = ViewManager(keyChain: mockKeyChain)
+        XCTAssertNil(restored.getViewNumber(),
+                     "reset with no visible view must clear the persisted counter")
+    }
+
+    func testViewNumber_shutdown_clears() {
+        viewManager.set(cxView: CXView(state: .notifyOnAppear, name: "Home"))
+        XCTAssertEqual(viewManager.getViewNumber(), 0)
+
+        viewManager.shutdown()
+        XCTAssertNil(viewManager.getViewNumber())
+        // End-to-end persistence check.
+        let restored = ViewManager(keyChain: mockKeyChain)
+        XCTAssertNil(restored.getViewNumber(),
+                     "shutdown must clear the persisted counter")
+    }
+
+    func testViewNumber_disappearEvent_doesNotIncrement() {
+        viewManager.set(cxView: CXView(state: .notifyOnAppear, name: "A"))
+        XCTAssertEqual(viewManager.getViewNumber(), 0)
+
+        // notifyOnDisappear-state events must NOT bump the counter — only appearances do.
+        // Use a different name to bypass the same-name early-return so we exercise the
+        // state check rather than coincidentally passing on the name guard.
+        viewManager.set(cxView: CXView(state: .notifyOnDisappear, name: "B"))
+        XCTAssertEqual(viewManager.getViewNumber(), 0)
     }
 }
 

--- a/Tests/CoralogixRumTests/ViewManagerTests.swift
+++ b/Tests/CoralogixRumTests/ViewManagerTests.swift
@@ -180,7 +180,7 @@ final class ViewManagerTests: XCTestCase {
     func testViewNumber_restoresFromKeychainOnInit() {
         seedKeychainWithCurrentPid()  // simulates in-process continuation
         mockKeyChain.writeStringToKeychain(service: Keys.service.rawValue,
-                                            key: Keys.keyViewNumber.rawValue,
+                                            key: Keys.storedViewNumber.rawValue,
                                             value: "7")
         let restored = ViewManager(keyChain: mockKeyChain)
         XCTAssertEqual(restored.getViewNumber(), 7,
@@ -199,7 +199,7 @@ final class ViewManagerTests: XCTestCase {
                                             key: Keys.bootUUID.rawValue,
                                             value: "BOOT_UUID_FROM_PREVIOUS_PROCESS")
         mockKeyChain.writeStringToKeychain(service: Keys.service.rawValue,
-                                            key: Keys.keyViewNumber.rawValue,
+                                            key: Keys.storedViewNumber.rawValue,
                                             value: "5")
         let restored = ViewManager(keyChain: mockKeyChain)
         XCTAssertNil(restored.getViewNumber(),
@@ -220,7 +220,7 @@ final class ViewManagerTests: XCTestCase {
                                             key: Keys.bootUUID.rawValue,
                                             value: "BOOT_UUID_FROM_PREVIOUS_PROCESS")
         mockKeyChain.writeStringToKeychain(service: Keys.service.rawValue,
-                                            key: Keys.keyViewNumber.rawValue,
+                                            key: Keys.storedViewNumber.rawValue,
                                             value: "5")
         let restored = ViewManager(keyChain: mockKeyChain)
         XCTAssertNil(restored.getViewNumber(),
@@ -252,7 +252,7 @@ final class ViewManagerTests: XCTestCase {
         // keychain entry entirely (not write "" — see CX-44687 / Dan's review).
         seedKeychainWithCurrentPid()  // probe ViewManager below must be treated as in-process
         mockKeyChain.writeStringToKeychain(service: Keys.service.rawValue,
-                                            key: Keys.keyViewNumber.rawValue,
+                                            key: Keys.storedViewNumber.rawValue,
                                             value: "5")
         let manager = ViewManager(keyChain: mockKeyChain)
         XCTAssertEqual(manager.getViewNumber(), 5)
@@ -260,7 +260,7 @@ final class ViewManagerTests: XCTestCase {
         manager.reset()
         XCTAssertNil(manager.getViewNumber())
         // Keychain entry must be ABSENT, not present-with-empty-string.
-        XCTAssertNil(mockKeyChain.storage[Keys.keyViewNumber.rawValue],
+        XCTAssertNil(mockKeyChain.storage[Keys.storedViewNumber.rawValue],
                      "reset with no visible view must DELETE the keychain entry, not write \"\"")
         // End-to-end: a restored ViewManager sees nil because the entry is gone.
         let restored = ViewManager(keyChain: mockKeyChain)
@@ -276,7 +276,7 @@ final class ViewManagerTests: XCTestCase {
         viewManager.shutdown()
         XCTAssertNil(viewManager.getViewNumber())
         // Keychain entry must be ABSENT after shutdown — CX-44687 / Dan's review.
-        XCTAssertNil(mockKeyChain.storage[Keys.keyViewNumber.rawValue],
+        XCTAssertNil(mockKeyChain.storage[Keys.storedViewNumber.rawValue],
                      "shutdown must DELETE the keychain entry, not write \"\"")
         // End-to-end persistence check.
         let restored = ViewManager(keyChain: mockKeyChain)

--- a/Tests/CoralogixRumTests/ViewManagerTests.swift
+++ b/Tests/CoralogixRumTests/ViewManagerTests.swift
@@ -248,7 +248,8 @@ final class ViewManagerTests: XCTestCase {
     }
 
     func testViewNumber_reset_withoutVisibleView_clearsToNil() {
-        // No view ever set → reset should leave the counter nil and clear the keychain entry.
+        // No view ever set → reset should leave the counter nil and delete the
+        // keychain entry entirely (not write "" — see CX-44687 / Dan's review).
         seedKeychainWithCurrentPid()  // probe ViewManager below must be treated as in-process
         mockKeyChain.writeStringToKeychain(service: Keys.service.rawValue,
                                             key: Keys.keyViewNumber.rawValue,
@@ -258,7 +259,10 @@ final class ViewManagerTests: XCTestCase {
 
         manager.reset()
         XCTAssertNil(manager.getViewNumber())
-        // End-to-end: a restored ViewManager sees nil (the persisted "" parses to nil).
+        // Keychain entry must be ABSENT, not present-with-empty-string.
+        XCTAssertNil(mockKeyChain.storage[Keys.keyViewNumber.rawValue],
+                     "reset with no visible view must DELETE the keychain entry, not write \"\"")
+        // End-to-end: a restored ViewManager sees nil because the entry is gone.
         let restored = ViewManager(keyChain: mockKeyChain)
         XCTAssertNil(restored.getViewNumber(),
                      "reset with no visible view must clear the persisted counter")
@@ -271,6 +275,9 @@ final class ViewManagerTests: XCTestCase {
 
         viewManager.shutdown()
         XCTAssertNil(viewManager.getViewNumber())
+        // Keychain entry must be ABSENT after shutdown — CX-44687 / Dan's review.
+        XCTAssertNil(mockKeyChain.storage[Keys.keyViewNumber.rawValue],
+                     "shutdown must DELETE the keychain entry, not write \"\"")
         // End-to-end persistence check.
         let restored = ViewManager(keyChain: mockKeyChain)
         XCTAssertNil(restored.getViewNumber(),
@@ -291,12 +298,16 @@ final class ViewManagerTests: XCTestCase {
 
 class MockKeyChain: KeyChainProtocol {
     var storage: [String: String] = [:]
-    
+
     func readStringFromKeychain(service: String, key: String) -> String? {
         return storage[key]
     }
-    
+
     func writeStringToKeychain(service: String, key: String, value: String) {
         storage[key] = value
+    }
+
+    func deleteFromKeychain(service: String, key: String) {
+        storage.removeValue(forKey: key)
     }
 }

--- a/Tests/CoralogixRumTests/ViewManagerTests.swift
+++ b/Tests/CoralogixRumTests/ViewManagerTests.swift
@@ -109,15 +109,19 @@ final class ViewManagerTests: XCTestCase {
 
     // MARK: - CX-44687: view_number sequence
 
-    /// Pre-seeds the mock keychain with the current process's PID so that
-    /// `ViewManager.init` treats a restored counter as in-process-continuation.
-    /// In production, `SessionMetadata.loadPrevSession` writes `getpid()` to the
-    /// same key during normal init; tests that exercise restore behavior must
-    /// stage that state explicitly.
+    /// Pre-seeds the mock keychain with the current process's identity (PID +
+    /// boot UUID) so that `ViewManager.init` treats a restored counter as
+    /// in-process-continuation. In production, `SessionMetadata.loadPrevSession`
+    /// writes both during normal init; tests that exercise restore behavior must
+    /// stage that state explicitly. Both fields are checked — PID alone is not
+    /// enough (see CX-44687 / Dan's PR feedback on PID recycling).
     private func seedKeychainWithCurrentPid() {
         mockKeyChain.writeStringToKeychain(service: Keys.service.rawValue,
                                             key: Keys.pid.rawValue,
                                             value: String(getpid()))
+        mockKeyChain.writeStringToKeychain(service: Keys.service.rawValue,
+                                            key: Keys.bootUUID.rawValue,
+                                            value: Global.processBootUUID)
     }
 
     func testViewNumber_isNilBeforeAnyView() {
@@ -192,11 +196,35 @@ final class ViewManagerTests: XCTestCase {
                                             key: Keys.pid.rawValue,
                                             value: "PID_FROM_PREVIOUS_PROCESS")
         mockKeyChain.writeStringToKeychain(service: Keys.service.rawValue,
+                                            key: Keys.bootUUID.rawValue,
+                                            value: "BOOT_UUID_FROM_PREVIOUS_PROCESS")
+        mockKeyChain.writeStringToKeychain(service: Keys.service.rawValue,
                                             key: Keys.keyViewNumber.rawValue,
                                             value: "5")
         let restored = ViewManager(keyChain: mockKeyChain)
         XCTAssertNil(restored.getViewNumber(),
                      "view_number must NOT be restored when the persisted PID doesn't match the current process — the previous session is over and the stored counter is stale")
+    }
+
+    func testViewNumber_isNotRestored_whenBootUUIDDoesNotMatch_evenIfPidCollides() {
+        // CX-44687 / Dan's PR review: PID alone isn't enough — iOS recycles PIDs
+        // across cold launches and a new process can receive a previously-stored
+        // PID by coincidence. The per-process boot UUID is the defense.
+        // Simulate the worst case: PID happens to match the current process
+        // (recycling collision) but the boot UUID still belongs to the previous
+        // process. Restore must be skipped.
+        mockKeyChain.writeStringToKeychain(service: Keys.service.rawValue,
+                                            key: Keys.pid.rawValue,
+                                            value: String(getpid()))
+        mockKeyChain.writeStringToKeychain(service: Keys.service.rawValue,
+                                            key: Keys.bootUUID.rawValue,
+                                            value: "BOOT_UUID_FROM_PREVIOUS_PROCESS")
+        mockKeyChain.writeStringToKeychain(service: Keys.service.rawValue,
+                                            key: Keys.keyViewNumber.rawValue,
+                                            value: "5")
+        let restored = ViewManager(keyChain: mockKeyChain)
+        XCTAssertNil(restored.getViewNumber(),
+                     "view_number must NOT be restored on PID collision — the boot UUID is the defense-in-depth discriminator that catches PID recycling")
     }
 
     func testViewNumber_initWithoutPersistedValue_isNil() {


### PR DESCRIPTION
# User description
## Status: Ready for review

Backend schema rollout is complete — the previous HTTP 400 (`property isNavigationEvent should not exist`) is gone. Verified end-to-end on iPhone 17 / iOS 26.5 with `proxyUrl: Envs.PROXY_URL.rawValue` pointed at the schema-validator proxy: 6 spans uploaded across 2 launches, **zero `Backend rejected` / zero HTTP 4xx-5xx**, `isNavigationEvent` lands at cx_rum top level, `view_number: 0` once the first view appears, `cx_rum.*` keys mirrored into `instrumentation_data.otelSpan.attributes`.

## Summary

Adds two product-analytics fields at the `cx_rum` top level, per [CX-44687](https://coralogix.atlassian.net/browse/CX-44687):

- **`view_number`** (Int, snake_case wire key) — sequence index of the active view within the current session. Starts at `0` on the first appearance and increments on every name-differing appearance, including revisits (`A → B → C → A ⇒ 0, 1, 2, 3`). Omitted entirely before the first view appears. Persisted to Keychain so a same-session restore (in-process re-init via PID + boot-UUID match) recovers the counter instead of starting over. Resets on `session_id` change via the existing `CoralogixExporter.sessionEndedCallback → ViewManager.reset()` wiring.
- **`isNavigationEvent`** (Bool, camelCase wire key) — always emitted. Records the SDK's build-time observation: "did the SDK detect a navigation?" Read-only; preserved across all customer edits via `beforeSend`. The flag is *not* derived from the (possibly customer-relabeled) final `event_context.type` — it's an immutable historical fact about what the SDK saw. If the customer rewrites the type, the two fields can diverge by design; product-analytics consumers should filter on the flag for "was this actually a navigation".

Per-field wire naming matches Browser's shape (Daniel, 2026-06-08): Browser already uses `isNavigationEvent` (camelCase) for the navigation flag.

## Cross-cutting hardening

These were added on top of the bare feature emission, all under CX-44687:

- **`instrumentation_data.otelSpan.attributes` mirror.** Per the CX-44686 contract (`text.cx_rum` ↔ `otelSpan.attributes.cx_rum.*` parity), the new fields reach both destinations. Added `cx_rum.is_navigation_event` and `cx_rum.view_number` to the centralised `AttrKey` mapping (snake_case under `cx_rum.*` per the internal Swift convention, even though the wire key for `isNavigationEvent` is camelCase). Mirrored in both the live happy-path and the post-`beforeSend` dict variant.
- **`view_number` forgery protection.** Added to `readOnlyCxRumKeys` — a customer callback returning a constant `view_number` on every span would silently corrupt downstream funnel analytics with no compile-time or runtime signal. Same pattern as `traceId`, `spanId`, `fingerPrint`, `isSnapshotEvent`.
- **`isNavigationEvent` read-only / SDK-observation semantics** (final design after PR review iterations with Daniel). Added to `readOnlyCxRumKeys`: stripped from the editable subset the customer sees in `beforeSend(cxRum)`, and any customer-supplied value in the return dict is restored to the SDK's original value after merge. The flag records what the SDK detected at build time — not a derived property of the post-merge type. If the customer rewrites `event_context.type`, the flag stays at the SDK's original value (commit `801ccc8`). An earlier iteration recomputed the flag from the post-merge type (commit `c008159`); that approach was reverted because the flag's semantic is "SDK observation", not "current type label".
- **PID-recycling defense for `view_number` restore.** iOS/macOS recycle PIDs across cold launches — PID alone is a fragile process-identity discriminator. Added `Global.processBootUUID` (per-process UUID via Swift's `static let` init semantics) as a second discriminator written alongside the PID in `SessionMetadata.loadPrevSession`. `ViewManager.init` now requires both to match before restoring the counter. Addresses Dan's PR feedback.
- **Keychain delete vs empty-string sentinel.** `persistViewNumber()` now deletes the keychain entry when `viewNumber` is nil (on `shutdown()` / `reset()`-without-view) instead of writing `""`. Added `deleteFromKeychain(service:key:)` to `KeyChainProtocol` with implementations in `KeychainManager` (via `SecItemDelete`, `errSecItemNotFound` treated as success) and all three test mocks. Addresses Dan's PR feedback.
- **`Keys.keyViewNumber` → `Keys.storedViewNumber` rename.** The pre-rename name's rawValue (`"viewNumber"`) and the wire key `Keys.viewNumber`'s rawValue (`"view_number"`) sat one line apart and differed only by underscore — a callsite footgun. Renamed (rawValue unchanged → no keychain compat break) with an explicit comment identifying it as a SecItem account name. Addresses Dan's PR feedback.
- **Android coordination.** Sibling ticket [CX-44684](https://coralogix.atlassian.net/browse/CX-44684) has been flagged to mirror both treatments (read-only `view_number`, read-only `isNavigationEvent` with SDK-observation semantics — *not* recomputed) and the PID-recycling defense.

## Files changed

| File | Change |
|---|---|
| `CoralogixInternal/Sources/Keys.swift` | Added `viewNumber = "view_number"`, `isNavigationEvent`, `bootUUID`, `storedViewNumber = "viewNumber"` (keychain slot, renamed from `keyViewNumber` for clarity) |
| `CoralogixInternal/Sources/Utils.swift` | Added `Global.processBootUUID: String` — per-process UUID via `static let` for PID-recycling defense |
| `Coralogix/Sources/Model/CxRum.swift` | Added `isNavigationEvent: Bool` and `viewNumber: Int?` |
| `Coralogix/Sources/Utils/ViewManager.swift` | Counter storage guarded by `syncQueue`; PID + bootUUID-gated restore; `persistViewNumber` deletes when nil instead of writing `""`; reset/shutdown semantics |
| `Coralogix/Sources/Model/CxRumBuilder.swift` | Pass `eventContext.type == .navigation` and `viewManager.getViewNumber()` into `CxRum` (the SDK's build-time observation that becomes `isNavigationEvent`) |
| `Coralogix/Sources/Model/CxRumPayloadBuilder.swift` | New `addProductAnalyticsFields` emits both at the `cx_rum` top level (`view_number` only when non-nil) |
| `Coralogix/Sources/Model/InstrumentationData.swift` | Added `AttrKey.isNavigationEvent` / `AttrKey.viewNumber`; mirror in both `buildRumContextAttributes` variants (live + post-`beforeSend`) |
| `Coralogix/Sources/Model/CxSpan.swift` | Added `viewNumber` AND `isNavigationEvent` to `readOnlyCxRumKeys`; bootUUID write alongside PID in `loadPrevSession`; added `deleteFromKeychain` to `KeyChainProtocol` |
| `Coralogix/Sources/Utils/KeychainManager.swift` | Implements `deleteFromKeychain` via `SecItemDelete` |
| `Tests/CoralogixRumTests/ViewManagerTests.swift` | +12 tests: counter behaviour, end-to-end persistence, reset/shutdown (with keychain-absence assertions), PID-mismatch gating, bootUUID-mismatch / PID-collision gating, disappear-doesn't-increment |
| `Tests/CoralogixRumTests/CxRumBuilderTests.swift` | +8 tests: `isNavigationEvent` truth table, `view_number` propagation, top-level payload placement |
| `Tests/CoralogixRumTests/InstrumentationDataTests.swift` | Updated `CxRum(...)` fixture; +4 attribute-presence tests for the otelSpan.attributes mirror |
| `Tests/CoralogixRumTests/BeforeSendInstrumentationDataTests.swift` | +6 tests: `view_number` forgery-ignored / omit-when-no-view; `isNavigationEvent` direct-injection-ignored, isPreserved-acrossTypeEdit-toNavigation, isPreserved-acrossTypeEdit-awayFromNavigation, isPreserved-acrossBothEdits; subset-stripping assertions extended for both new read-only keys; extended baseline-parity check |
| `Tests/CoralogixRumTests/Utils.swift`, `FingerprintManagerTests.swift` | `MockKeyschainManager` / `FakeKeychain` implement `deleteFromKeychain` |

## Test plan

- [x] **All affected suites pass: 103/103** on iPhone 17 / iOS 26.5 via `xcodebuild test -scheme Coralogix-Package -only-testing:CoralogixRumTests/{ViewManagerTests,CxRumBuilderTests,InstrumentationDataTests,BeforeSendInstrumentationDataTests}`.
- [x] `view_number` starts at 0, increments on name-differing appearances, revisits count (`A→B→C→A ⇒ 0,1,2,3`), omitted before first view.
- [x] `view_number` persists to Keychain on every change and restores on a fresh `ViewManager` from the same keychain.
- [x] `view_number` is NOT restored when the persisted PID doesn't match — basic cold-launch isolation.
- [x] `view_number` is NOT restored when bootUUID doesn't match, **even if the PID happens to collide** — defense against PID recycling.
- [x] `view_number` keychain entry is DELETED (not present-with-`""`) after `shutdown()` and `reset()`-without-view.
- [x] `reset()` with a visible view → `view_number = 0`; without one → nil. Both end-to-end persisted (or deleted).
- [x] `isNavigationEvent` is `true` only when the SDK observed a navigation at build time (`eventContext.type == .navigation`).
- [x] Both fields land at the `cx_rum` top level — not nested under `view_context` or `event_context`.
- [x] Both fields appear in `instrumentation_data.otelSpan.attributes` (`cx_rum.is_navigation_event` always, `cx_rum.view_number` when set).
- [x] `view_number` AND `isNavigationEvent` are absent from the editable subset that `beforeSend(cxRum)` receives.
- [x] `view_number` customer forgery via `beforeSend` (injecting in return dict) is ignored — SDK value restored in both `text.cx_rum` and `otelSpan.attributes`.
- [x] `view_number` customer injection when no view has appeared is REMOVED (not left dangling).
- [x] `isNavigationEvent` direct forgery via `beforeSend` is ignored — restored to SDK's original value.
- [x] **Customer edit `event_context.type → "navigation"` (without touching the flag)** → `isNavigationEvent` STAYS at SDK's original value (e.g. `false` for a network-request span). Type and flag can diverge by design.
- [x] **Customer edit `event_context.type → "log"` on an originally-navigation span** → `isNavigationEvent` STAYS at `true` (SDK saw a navigation).
- [x] **Contradictory edits** (type → `"log"` AND `isNavigationEvent = true` injected) → flag stays at SDK's original value, neither edit moves it.
- [x] **End-to-end against schema-validator proxy on iPhone 17 simulator** — 0 `Backend rejected`, 0 HTTP 4xx/5xx across 2 launches × 6 spans uploaded. `isNavigationEvent: false` and `view_number: 0` observed in cx_rum top level; `cx_rum.*` keys observed in `instrumentation_data.otelSpan.attributes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CX-44687]: https://coralogix.atlassian.net/browse/CX-44687?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Emit navigation analytics metadata from <code>CxRumBuilder</code>/<code>CxRumPayloadBuilder</code> so <code>CxRum</code> and instrumentation attributes propagate <code>isNavigationEvent</code> and optionally <code>view_number</code> at the <code>cx_rum</code> level, matching Browser wire keys for analytics ingestion. Persist and reset <code>ViewManager</code>'s navigation counter via Keychain-backed tracking so <code>view_number</code> starts at zero on the first visible view, increments on new view names, and clears when sessions rotate.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/221?tool=ast&topic=View+Sequence>View Sequence</a>
        </td><td>Track <code>ViewManager</code>'s session-aligned view counter, persisting/restoring it only for same-process continuations, resetting it on rotations/shutdowns, and validating increments/resets via dedicated tests so <code>view_number</code> behaves per spec.<details><summary>Modified files (2)</summary><ul><li>Coralogix/Sources/Utils/ViewManager.swift</li>
<li>Tests/CoralogixRumTests/ViewManagerTests.swift</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>fix(CX-44687): gate vi...</td><td>June 09, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/221?tool=ast&topic=Product+Analytics>Product Analytics</a>
        </td><td>Emit <code>isNavigationEvent</code> and optional <code>view_number</code> at <code>cx_rum</code> top level via <code>CxRumBuilder</code>, <code>CxRumPayloadBuilder</code>, and instrumentation mirroring while guarding <code>view_number</code> as read-only and covering the behavior with builder/beforeSend tests.<details><summary>Modified files (9)</summary><ul><li>Coralogix/Sources/Model/CxRum.swift</li>
<li>Coralogix/Sources/Model/CxRumBuilder.swift</li>
<li>Coralogix/Sources/Model/CxRumPayloadBuilder.swift</li>
<li>Coralogix/Sources/Model/CxSpan.swift</li>
<li>Coralogix/Sources/Model/InstrumentationData.swift</li>
<li>CoralogixInternal/Sources/Keys.swift</li>
<li>Tests/CoralogixRumTests/BeforeSendInstrumentationDataTests.swift</li>
<li>Tests/CoralogixRumTests/CxRumBuilderTests.swift</li>
<li>Tests/CoralogixRumTests/InstrumentationDataTests.swift</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>feat(CX-44687): emit v...</td><td>June 08, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/coralogix/cx-ios-sdk/221?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>

[CX-44684]: https://coralogix.atlassian.net/browse/CX-44684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ