### PR TITLE
feat(CX-44984): emit session_replay_init internal log with config snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ omitted; the focus here is user-facing behavior changes. Tickets are referenced 
 ## [2.9.0] - 2026-06-15
 
 ### Added
-- Session-replay init log (CX-44984): when Session Replay comes up, the SDK now emits a one-shot internal event capturing the `SessionReplayOptions` configuration — mirroring the existing SDK init log and the Android counterpart (CX-44992) so the backend ingests one cross-platform schema. The event carries `event_context.type = "internal"` and an `internal_context` of `{ event: "session_replay_init", data: <snapshot> }`. The snapshot includes `recordingType`, `captureScale`, `captureCompressQuality`, `sessionRecordingSampleRate`, `autoStartSessionRecording`, `textsToMask`, `maskAllImages`, `maskOnlyCreditCards`, `maskFaces`, `creditCardPredicate`, and `hasFlutterViewBitmapProvider` (a presence flag — the closure is never serialised); the deprecated `captureTimeInterval` is excluded. The log fires only when the session was not dropped by `sessionRecordingSampleRate` and the subsystem actually initialised, and is isolated from auto-start so a diagnostic-log failure can never disable recording.
+- Session Replay now emits a one-shot init log capturing its configuration when recording starts, so the active Session Replay settings are visible in the backend.
 
 ## [2.8.0] - 2026-06-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Release-mechanics commits (version bumps, podspec/script tweaks, README edits) a
 omitted; the focus here is user-facing behavior changes. Tickets are referenced as
 `CX-XXXXX` (Jira) or `ALPH-XXXX` (legacy). Pull request numbers are in parentheses.
 
+## [2.9.0] - 2026-06-15
+
+### Added
+- Session-replay init log (CX-44984): when Session Replay comes up, the SDK now emits a one-shot internal event capturing the `SessionReplayOptions` configuration — mirroring the existing SDK init log and the Android counterpart (CX-44992) so the backend ingests one cross-platform schema. The event carries `event_context.type = "internal"` and an `internal_context` of `{ event: "session_replay_init", data: <snapshot> }`. The snapshot includes `recordingType`, `captureScale`, `captureCompressQuality`, `sessionRecordingSampleRate`, `autoStartSessionRecording`, `textsToMask`, `maskAllImages`, `maskOnlyCreditCards`, `maskFaces`, `creditCardPredicate`, and `hasFlutterViewBitmapProvider` (a presence flag — the closure is never serialised); the deprecated `captureTimeInterval` is excluded. The log fires only when the session was not dropped by `sessionRecordingSampleRate` and the subsystem actually initialised, and is isolated from auto-start so a diagnostic-log failure can never disable recording.
+
 ## [2.8.0] - 2026-06-11
 
 ### Fixed

--- a/Coralogix.podspec
+++ b/Coralogix.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "Coralogix"
-  spec.version      = "2.8.0"
+  spec.version      = "2.9.0"
   spec.summary      = "Coralogix OpenTelemetry pod for iOS."
 
   spec.description  = <<-DESC
@@ -29,7 +29,7 @@ Pod::Spec.new do |spec|
 
   spec.static_framework = true
   spec.dependency 'PLCrashReporter', '~> 1.12'
-  spec.dependency 'CoralogixInternal', '2.8.0'
+  spec.dependency 'CoralogixInternal', '2.9.0'
 
   spec.test_spec 'Tests' do |test|
     test.source_files = 'Tests/CoralogixRumTests/**/*.swift'

--- a/Coralogix/Sources/Instrumentation/InternalInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/InternalInstrumentation.swift
@@ -13,4 +13,14 @@ extension CoralogixRum {
         let span = makeSpan(event: .internalKey, source: .console, severity: .info)
         span.end()
     }
+
+    /// Emits the session-replay init log (CX-44984). The snapshot rides on the span as a JSON
+    /// string and is decoded back into `internal_context` in `CxRumBuilder.buildInternalContext`.
+    internal func createSessionReplayInitSpan(snapshot: [String: Any]) {
+        var span = makeSpan(event: .internalKey, source: .console, severity: .info)
+        span.setAttribute(key: Keys.internalEventType.rawValue, value: Keys.sessionReplayInit.rawValue)
+        span.setAttribute(key: Keys.internalEventData.rawValue,
+                          value: Helper.convertDictionaryToJsonString(dict: snapshot))
+        span.end()
+    }
 }

--- a/Coralogix/Sources/Model/Contexts/InternalContext.swift
+++ b/Coralogix/Sources/Model/Contexts/InternalContext.swift
@@ -7,12 +7,12 @@
 
 struct InternalContext {
     let eventName: String
-    let options: CoralogixExporterOptions
+    let data: [String: Any]
 
     func getDictionary() -> [String: Any] {
         var result: [String: Any] = [:]
         result[Keys.event.rawValue] = eventName
-        result[Keys.data.rawValue] = options.getInitData()
+        result[Keys.data.rawValue] = data
         return result
     }
 }

--- a/Coralogix/Sources/Model/CxRumBuilder.swift
+++ b/Coralogix/Sources/Model/CxRumBuilder.swift
@@ -103,10 +103,20 @@ class CxRumBuilder {
     }
     
     private func buildInternalContext(for eventContext: EventContext) -> InternalContext? {
-        if eventContext.type == .internalKey {
-            return InternalContext(eventName: Keys.initKey.rawValue, options: options)
+        guard eventContext.type == .internalKey else { return nil }
+
+        // session_replay_init carries its own snapshot as a span attribute (it lives in the
+        // SessionReplay module, which the exporter can't reach). The SDK-init log carries no
+        // sub-type attribute and reconstructs its payload from the live exporter options.
+        // CX-44984 lesson #1: without this branch the span has the right attributes but
+        // internal_context never lands on the wire.
+        if let internalEventType = otel.getAttribute(forKey: Keys.internalEventType.rawValue) as? String,
+           internalEventType == Keys.sessionReplayInit.rawValue {
+            let data = (otel.getAttribute(forKey: Keys.internalEventData.rawValue) as? String)
+                .flatMap { Helper.convertJsonStringToDict(jsonString: $0) } ?? [:]
+            return InternalContext(eventName: internalEventType, data: data)
         }
-        return nil
+        return InternalContext(eventName: Keys.initKey.rawValue, data: options.getInitData())
     }
     
     internal func buildSnapshotContextIfNeeded(for eventContext: EventContext) -> SnapshotContext? {

--- a/Coralogix/Sources/SessionReplay/SessionReplayInstrumentation.swift
+++ b/Coralogix/Sources/SessionReplay/SessionReplayInstrumentation.swift
@@ -125,4 +125,8 @@ extension CoralogixRum: CoralogixInterface {
     public func revertScreenshotCounter() {
         self.coralogixExporter?.getScreenshotManager().revertScreenshotCounter()
     }
+
+    public func reportSessionReplayInit(snapshot: [String: Any]) {
+        self.createSessionReplayInitSpan(snapshot: snapshot)
+    }
 }

--- a/CoralogixInternal.podspec
+++ b/CoralogixInternal.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "CoralogixInternal"
-  spec.version      = "2.8.0"
+  spec.version      = "2.9.0"
   spec.summary      = "Coralogix Internal Package. This module is not for public use."
 
   spec.description  = <<-DESC

--- a/CoralogixInternal/Sources/Keys.swift
+++ b/CoralogixInternal/Sources/Keys.swift
@@ -253,6 +253,27 @@ public enum Keys: String {
     case fingerPrint
     case event
     case initKey = "init"
+    case sessionReplayInit = "session_replay_init"
+    // Span attributes carrying an internal event's sub-type and its JSON payload, decoded back
+    // into `internal_context` at export. The SDK-init log omits these — its payload is
+    // reconstructed from the live exporter options instead (see CxRumBuilder.buildInternalContext).
+    case internalEventType = "internal_event_type"
+    case internalEventData = "internal_event_data"
+    // SessionReplayOptions init-log snapshot fields (CX-44984). camelCase rawValues deliberately
+    // match the Android (CX-44992) payload keys so the backend ingests one cross-platform schema.
+    case srRecordingType = "recordingType"
+    case srCaptureScale = "captureScale"
+    case srCaptureCompressQuality = "captureCompressQuality"
+    case srSessionRecordingSampleRate = "sessionRecordingSampleRate"
+    case srAutoStartSessionRecording = "autoStartSessionRecording"
+    case srTextsToMask = "textsToMask"
+    case srMaskAllImages = "maskAllImages"
+    case srMaskOnlyCreditCards = "maskOnlyCreditCards"
+    case srMaskFaces = "maskFaces"
+    case srCreditCardPredicate = "creditCardPredicate"
+    case srHasFlutterViewBitmapProvider = "hasFlutterViewBitmapProvider"
+    case image
+    case video
     case version
     case instrumentations
     case ignoreUrls

--- a/CoralogixInternal/Sources/SdkManager.swift
+++ b/CoralogixInternal/Sources/SdkManager.swift
@@ -36,6 +36,11 @@ public protocol CoralogixInterface {
     
     /// Reverts the screenshot counter when a capture is skipped.
     func revertScreenshotCounter()
+
+    /// Emits the one-shot session-replay init log carrying the SessionReplayOptions snapshot.
+    /// SessionReplay builds the snapshot (it owns the options type) and passes it as a dictionary,
+    /// since the Coralogix module can't reference SessionReplayOptions.
+    func reportSessionReplayInit(snapshot: [String: Any])
 }
 
 public protocol SessionReplayInterface {

--- a/CoralogixInternal/Sources/Utils.swift
+++ b/CoralogixInternal/Sources/Utils.swift
@@ -16,7 +16,7 @@ public enum ImageFormat {
 }
 
 public enum Global: String {
-    case sdk = "2.8.0"
+    case sdk = "2.9.0"
     case swiftVersion = "5.9"
     case coralogixPath = "/browser/v1beta/logs"
     case sessionReplayPath = "/browser/alpha/sessionrecording"

--- a/SessionReplay.podspec
+++ b/SessionReplay.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "SessionReplay"
-  spec.version      = "2.8.0"
+  spec.version      = "2.9.0"
   spec.summary      = "Coralogix Session-Replay pod for iOS."
 
   spec.description  = <<-DESC
@@ -23,7 +23,7 @@ Pod::Spec.new do |spec|
   spec.static_framework = true
 
   spec.source_files  = 'SessionReplay/Sources/**/*.swift'
-  spec.dependency 'CoralogixInternal', '2.8.0'
+  spec.dependency 'CoralogixInternal', '2.9.0'
   
     spec.test_spec 'Tests' do |test|
         test.source_files = 'Tests/SessionReplayTests/**/*.swift'

--- a/SessionReplay/Sources/SessionReplay.swift
+++ b/SessionReplay/Sources/SessionReplay.swift
@@ -148,6 +148,12 @@ public class SessionReplay: SessionReplayInterface {
         let sessionId = coralogixSdk.getSessionID()
         self.update(sessionId: sessionId)
 
+        // CX-44984: emit the init log now that the subsystem is up. This runs only for the real
+        // instance — the sampled-out dummy path (sessionRecordingSampleRate) never reaches here.
+        // Kept ahead of and independent from the auto-start dispatch below so a diagnostic-log
+        // issue can never disable recording (lesson #4 from Android CX-44992).
+        coralogixSdk.reportSessionReplayInit(snapshot: sessionReplayOptions.toSessionReplayInitLogSnapshot())
+
         if sessionReplayOptions.autoStartSessionRecording {
             DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
                 self.startRecording()

--- a/SessionReplay/Sources/SessionReplayOptions+InitLogSnapshot.swift
+++ b/SessionReplay/Sources/SessionReplayOptions+InitLogSnapshot.swift
@@ -1,0 +1,37 @@
+//
+//  SessionReplayOptions+InitLogSnapshot.swift
+//  SessionReplay
+//
+//  CX-44984: single source of truth for the session-replay init-log payload.
+//
+
+import Foundation
+import CoralogixInternal
+
+extension SessionReplayOptions {
+    /// Builds the `internal_event_data` payload for the session-replay init log.
+    ///
+    /// Keys mirror the Android (CX-44992) snapshot so the backend ingests one cross-platform
+    /// schema. The `flutterViewBitmapProvider` closure is reduced to a presence flag — never
+    /// serialised. `captureTimeInterval` is excluded: it is deprecated and not user-tunable.
+    ///
+    /// iOS divergence (follow-up to align Android): iOS has no `maskAllTexts` boolean or
+    /// `maskInputFieldsOfTypes` — text masking is expressed solely via `maskText`, emitted here
+    /// as `textsToMask`. iOS-only fields (`recordingType`, `maskOnlyCreditCards`, `maskFaces`,
+    /// `creditCardPredicate`) are included and should be added to the Android payload.
+    func toSessionReplayInitLogSnapshot() -> [String: Any] {
+        return [
+            Keys.srRecordingType.rawValue: recordingType == .video ? Keys.video.rawValue : Keys.image.rawValue,
+            Keys.srCaptureScale.rawValue: Double(captureScale),
+            Keys.srCaptureCompressQuality.rawValue: Double(captureCompressionQuality),
+            Keys.srSessionRecordingSampleRate.rawValue: sessionRecordingSampleRate,
+            Keys.srAutoStartSessionRecording.rawValue: autoStartSessionRecording,
+            Keys.srTextsToMask.rawValue: maskText ?? [],
+            Keys.srMaskAllImages.rawValue: maskAllImages,
+            Keys.srMaskOnlyCreditCards.rawValue: maskOnlyCreditCards,
+            Keys.srMaskFaces.rawValue: maskFaces,
+            Keys.srCreditCardPredicate.rawValue: creditCardPredicate ?? [],
+            Keys.srHasFlutterViewBitmapProvider.rawValue: flutterViewBitmapProvider != nil
+        ]
+    }
+}

--- a/Tests/CoralogixRumTests/SessionReplayInitLogTests.swift
+++ b/Tests/CoralogixRumTests/SessionReplayInitLogTests.swift
@@ -1,0 +1,133 @@
+//
+//  SessionReplayInitLogTests.swift
+//
+//  End-to-end coverage for the session-replay init log (CX-44984). Drives a span carrying the
+//  `internal_event_type` / `internal_event_data` attributes through `CoralogixExporter.export()`
+//  and asserts the decoded payload lands on the wire under `text.cx_rum.internal_context` —
+//  the exact gap that silently dropped the payload on Android (CX-44992, lesson #1).
+//
+//  Asserts on the uploaded wire dict (not `beforeSend`, which on Android could not see
+//  internal_context — lesson #2), via a capturing `SpanUploading` mock.
+//
+
+import XCTest
+import CoralogixInternal
+@testable import Coralogix
+
+final class SessionReplayInitLogTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        CoralogixRum.isInitialized = false
+    }
+
+    func testSessionReplayInit_landsInternalContextOnWire() throws {
+        let uploader = CapturingSpanUploader()
+        let rum = CoralogixRum(options: makeSamplingOptions(sampleRate: 100, exclude: []))
+        defer { rum.shutdown() }
+
+        let exporter = try XCTUnwrap(rum.coralogixExporter, "Exporter must exist after init.")
+        exporter.spanUploader = uploader
+
+        let snapshot: [String: Any] = [
+            Keys.srRecordingType.rawValue: Keys.image.rawValue,
+            Keys.srCaptureScale.rawValue: 2.0,
+            Keys.srCaptureCompressQuality.rawValue: 0.8,
+            Keys.srSessionRecordingSampleRate.rawValue: 100,
+            Keys.srAutoStartSessionRecording.rawValue: true,
+            Keys.srTextsToMask.rawValue: ["password"],
+            Keys.srMaskAllImages.rawValue: true,
+            Keys.srMaskOnlyCreditCards.rawValue: false,
+            Keys.srMaskFaces.rawValue: false,
+            Keys.srCreditCardPredicate.rawValue: [],
+            Keys.srHasFlutterViewBitmapProvider.rawValue: false
+        ]
+
+        _ = exporter.export(spans: [makeSessionReplayInitSpan(snapshot: snapshot)], explicitTimeout: nil)
+
+        let internalContext = try XCTUnwrap(uploader.firstInternalContext(),
+                                            "internal_context must land on the wire for a session_replay_init span.")
+
+        XCTAssertEqual(internalContext[Keys.event.rawValue] as? String, Keys.sessionReplayInit.rawValue,
+                       "internal_context.event must carry the session_replay_init discriminator.")
+
+        let data = try XCTUnwrap(internalContext[Keys.data.rawValue] as? [String: Any],
+                                 "internal_context.data must carry the snapshot.")
+        XCTAssertEqual(data[Keys.srCaptureScale.rawValue] as? Double, 2.0)
+        XCTAssertEqual(data[Keys.srCaptureCompressQuality.rawValue] as? Double, 0.8)
+        XCTAssertEqual(data[Keys.srSessionRecordingSampleRate.rawValue] as? Int, 100)
+        XCTAssertEqual(data[Keys.srAutoStartSessionRecording.rawValue] as? Bool, true)
+        XCTAssertEqual(data[Keys.srTextsToMask.rawValue] as? [String], ["password"])
+        XCTAssertEqual(data[Keys.srMaskAllImages.rawValue] as? Bool, true)
+        XCTAssertEqual(data[Keys.srHasFlutterViewBitmapProvider.rawValue] as? Bool, false)
+    }
+
+    func testSdkInit_stillEmitsInitEventName() throws {
+        // The shared internal-context branch must not regress the existing SDK-init log: a span
+        // with no internal_event_type attribute still resolves to event "init".
+        let uploader = CapturingSpanUploader()
+        let rum = CoralogixRum(options: makeSamplingOptions(sampleRate: 100, exclude: []))
+        defer { rum.shutdown() }
+
+        let exporter = try XCTUnwrap(rum.coralogixExporter)
+        exporter.spanUploader = uploader
+
+        _ = exporter.export(spans: [makeSamplingSpan(eventType: .internalKey)], explicitTimeout: nil)
+
+        let internalContext = try XCTUnwrap(uploader.firstInternalContext())
+        XCTAssertEqual(internalContext[Keys.event.rawValue] as? String, Keys.initKey.rawValue,
+                       "SDK-init log must still resolve to the \"init\" event name.")
+    }
+
+    // MARK: - Helpers
+
+    private func makeSessionReplayInitSpan(snapshot: [String: Any]) -> SpanData {
+        let attributes: [String: AttributeValue] = [
+            Keys.eventType.rawValue: AttributeValue(CoralogixEventType.internalKey.rawValue),
+            Keys.internalEventType.rawValue: AttributeValue(Keys.sessionReplayInit.rawValue),
+            Keys.internalEventData.rawValue: AttributeValue(Helper.convertDictionaryToJsonString(dict: snapshot)),
+            Keys.severity.rawValue: AttributeValue("3"),
+            Keys.source.rawValue: AttributeValue("console"),
+            Keys.environment.rawValue: AttributeValue("test"),
+            Keys.userId.rawValue: AttributeValue("uid"),
+            Keys.userName.rawValue: AttributeValue("Test User"),
+            Keys.userEmail.rawValue: AttributeValue("test@example.com"),
+            Keys.sessionId.rawValue: AttributeValue("session_001"),
+            Keys.sessionCreationDate.rawValue: AttributeValue("1609459200")
+        ]
+        return SpanData(traceId: TraceId.random(),
+                        spanId: SpanId.random(),
+                        name: "sessionReplayInitSpan",
+                        kind: .client,
+                        startTime: Date(),
+                        attributes: attributes,
+                        endTime: Date(),
+                        hasEnded: true)
+    }
+}
+
+/// Test-only `SpanUploading` that captures the encoded wire dicts so tests can assert on the
+/// final `text.cx_rum.*` payload (the actual ingest shape), without network I/O.
+final class CapturingSpanUploader: SpanUploading {
+    private let lock = NSLock()
+    private var uploaded: [[String: Any]] = []
+
+    func upload(_ spans: [[String: Any]], endPoint: String) -> SpanExporterResultCode {
+        lock.lock(); defer { lock.unlock() }
+        uploaded.append(contentsOf: spans)
+        return .success
+    }
+
+    func firstInternalContext() -> [String: Any]? {
+        lock.lock(); defer { lock.unlock() }
+        for span in uploaded {
+            guard let text = span[Keys.text.rawValue] as? [String: Any],
+                  let cxRum = text[Keys.cxRum.rawValue] as? [String: Any],
+                  let internalContext = cxRum[Keys.internalContext.rawValue] as? [String: Any] else {
+                continue
+            }
+            return internalContext
+        }
+        return nil
+    }
+}

--- a/Tests/SessionReplayTests/SRNetworkManagerTests.swift
+++ b/Tests/SessionReplayTests/SRNetworkManagerTests.swift
@@ -307,7 +307,8 @@ class MockCoralogix: CoralogixInterface {
     var idle: Bool = false
     var reportedErrors: [String] = []
     var periodicallyCaptureEventCalled = false
-    
+    var reportedSessionReplayInitSnapshots: [[String: Any]] = []
+
     func periodicallyCaptureEventTriggered() {
         periodicallyCaptureEventCalled = true
     }
@@ -365,6 +366,10 @@ class MockCoralogix: CoralogixInterface {
     
     func revertScreenshotCounter() {
         // No-op for mock
+    }
+
+    func reportSessionReplayInit(snapshot: [String: Any]) {
+        reportedSessionReplayInitSnapshots.append(snapshot)
     }
 }
 

--- a/Tests/SessionReplayTests/SessionReplayInitLogSnapshotTests.swift
+++ b/Tests/SessionReplayTests/SessionReplayInitLogSnapshotTests.swift
@@ -1,0 +1,79 @@
+//
+//  SessionReplayInitLogSnapshotTests.swift
+//
+//  Locks down the session-replay init-log snapshot (CX-44984): every user-configurable field,
+//  defaults and custom values, the closure reduced to a presence flag, and the deprecated
+//  capture interval excluded. Adding a SessionReplayOptions field should force a change here.
+//
+
+import XCTest
+@testable import CoralogixInternal
+@testable import SessionReplay
+
+final class SessionReplayInitLogSnapshotTests: XCTestCase {
+
+    func testSnapshot_defaults() {
+        let snapshot = SessionReplayOptions().toSessionReplayInitLogSnapshot()
+
+        XCTAssertEqual(snapshot[Keys.srRecordingType.rawValue] as? String, Keys.image.rawValue)
+        XCTAssertEqual(snapshot[Keys.srCaptureScale.rawValue] as? Double, 2.0)
+        XCTAssertEqual(snapshot[Keys.srCaptureCompressQuality.rawValue] as? Double, 1.0)
+        XCTAssertEqual(snapshot[Keys.srSessionRecordingSampleRate.rawValue] as? Int, 100)
+        XCTAssertEqual(snapshot[Keys.srAutoStartSessionRecording.rawValue] as? Bool, false)
+        XCTAssertEqual(snapshot[Keys.srTextsToMask.rawValue] as? [String], [])
+        XCTAssertEqual(snapshot[Keys.srMaskAllImages.rawValue] as? Bool, true)
+        XCTAssertEqual(snapshot[Keys.srMaskOnlyCreditCards.rawValue] as? Bool, false)
+        XCTAssertEqual(snapshot[Keys.srMaskFaces.rawValue] as? Bool, false)
+        XCTAssertEqual(snapshot[Keys.srCreditCardPredicate.rawValue] as? [String], [])
+        XCTAssertEqual(snapshot[Keys.srHasFlutterViewBitmapProvider.rawValue] as? Bool, false)
+    }
+
+    func testSnapshot_customValues() {
+        let options = SessionReplayOptions(
+            recordingType: .video,
+            captureScale: 1.0,
+            captureCompressionQuality: 0.5,
+            sessionRecordingSampleRate: 42,
+            maskText: ["password", "ssn"],
+            maskOnlyCreditCards: true,
+            maskAllImages: false,
+            maskFaces: true,
+            creditCardPredicate: ["card"],
+            autoStartSessionRecording: true,
+            flutterViewBitmapProvider: { _, _, completion in completion(nil) }
+        )
+
+        let snapshot = options.toSessionReplayInitLogSnapshot()
+
+        XCTAssertEqual(snapshot[Keys.srRecordingType.rawValue] as? String, Keys.video.rawValue)
+        XCTAssertEqual(snapshot[Keys.srCaptureScale.rawValue] as? Double, 1.0)
+        XCTAssertEqual(snapshot[Keys.srCaptureCompressQuality.rawValue] as? Double, 0.5)
+        XCTAssertEqual(snapshot[Keys.srSessionRecordingSampleRate.rawValue] as? Int, 42)
+        XCTAssertEqual(snapshot[Keys.srAutoStartSessionRecording.rawValue] as? Bool, true)
+        XCTAssertEqual(snapshot[Keys.srTextsToMask.rawValue] as? [String], ["password", "ssn"])
+        XCTAssertEqual(snapshot[Keys.srMaskAllImages.rawValue] as? Bool, false)
+        XCTAssertEqual(snapshot[Keys.srMaskOnlyCreditCards.rawValue] as? Bool, true)
+        XCTAssertEqual(snapshot[Keys.srMaskFaces.rawValue] as? Bool, true)
+        XCTAssertEqual(snapshot[Keys.srCreditCardPredicate.rawValue] as? [String], ["card"])
+    }
+
+    func testSnapshot_flutterProviderReducedToPresenceFlag() {
+        let withProvider = SessionReplayOptions(flutterViewBitmapProvider: { _, _, completion in completion(nil) })
+            .toSessionReplayInitLogSnapshot()
+        XCTAssertEqual(withProvider[Keys.srHasFlutterViewBitmapProvider.rawValue] as? Bool, true)
+
+        // The closure itself must never be serialised — only the boolean presence flag.
+        XCTAssertTrue(JSONSerialization.isValidJSONObject(withProvider),
+                      "Snapshot must be JSON-serialisable — no closures or non-JSON types leak in.")
+    }
+
+    func testSnapshot_excludesDeprecatedCaptureInterval() {
+        // captureTimeInterval is deprecated and not user-tunable — it must never appear in the payload,
+        // even when an old caller sets it via the deprecated initializer.
+        let options = SessionReplayOptions(captureTimeInterval: 5.0)
+        let snapshot = options.toSessionReplayInitLogSnapshot()
+
+        XCTAssertFalse(snapshot.keys.contains("captureTimeInterval"))
+        XCTAssertFalse(snapshot.values.contains { ($0 as? Double) == 5.0 })
+    }
+}


### PR DESCRIPTION
# User description
## What & why

Implements **[CX-44984](https://coralogix.atlassian.net/browse/CX-44984)** — emit a one-shot **session-replay init log** capturing the `SessionReplayOptions` configuration when Session Replay comes up, parallel to the existing SDK-init log. Mirrors the merged Android counterpart **CX-44992** so the backend ingests one cross-platform schema.

**Wire shape:** `event_context.type = "internal"` and
`internal_context = { event: "session_replay_init", data: <snapshot> }`.

The log fires **only** when the session was not dropped by `sessionRecordingSampleRate` and the subsystem actually initialised, and is isolated from auto-start so a diagnostic-log failure can never disable recording.

## How

- **`SessionReplayOptions.toSessionReplayInitLogSnapshot()`** — single source of truth for the payload. The `flutterViewBitmapProvider` closure is reduced to a `hasFlutterViewBitmapProvider` presence flag (never serialised); the deprecated `captureTimeInterval` is excluded.
- **Cross-module bridge:** SessionReplay owns the options type and builds the snapshot, then passes it through a new `CoralogixInterface.reportSessionReplayInit(snapshot:)` — the Coralogix module can't reference `SessionReplayOptions`. `CoralogixRum` emits the span via `createSessionReplayInitSpan(snapshot:)`, carrying the snapshot as a JSON-string span attribute.
- **`CxRumBuilder.buildInternalContext`** branches on `internal_event_type` so the payload lands on the wire (Android **lesson #1**: the span carried the right attributes but `internal_context` was silently dropped). The SDK-init path is unchanged.
- **`InternalContext`** flattened from `{ eventName, options }` to `{ eventName, data }`, decoupling it from `CoralogixExporterOptions`.

### iOS divergence (noted in-code for an Android-alignment follow-up)
- `textsToMask` only — iOS has no `maskAllTexts` boolean or `maskInputFieldsOfTypes`.
- iOS-only fields included: `recordingType`, `maskOnlyCreditCards`, `maskFaces`, `creditCardPredicate` — should be added to the Android payload.

## Tests
- **Unit** (`SessionReplayInitLogSnapshotTests`): every field at defaults + custom values, closure→presence-flag, JSON-serialisability, deprecated knob excluded.
- **E2E** (`SessionReplayInitLogTests`): drives a span through `CoralogixExporter.export()` and asserts `internal_context.event`/`.data` land on the **uploaded wire dict** (not `beforeSend` — Android **lesson #2**), plus an SDK-init regression guard.
- Existing `LogSamplingDecouplingTests` still pass (the `InternalContext` refactor doesn't regress the export pipeline).

Verified: `xcodebuild test` on iPhone 17 Pro sim — new tests (6) + sampling pipeline (7) all pass.

## Version & changelog
Minor bump **2.8.0 → 2.9.0** (new internal product signal) across `Global.sdk` and the three podspecs; `CHANGELOG.md` updated. No demo button (the log fires automatically at SR init; manual re-fire would need an SR reinit path and risks the Android "lying-toast" trap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[CX-44984]: https://coralogix.atlassian.net/browse/CX-44984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Emit a <code>session_replay_init</code> internal log by snapshotting <code>SessionReplayOptions</code> and routing it through the Coralogix bridge so the backend sees the subsystem configuration when Session Replay initializes. Bump <code>Global.sdk</code> and each podspec to 2.9.0 and update the exporter’s <code>InternalContext</code> path so the JSON payload built by the snapshot extension is serialized, versioned, and delivered along with the existing init signal.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/223?tool=ast&topic=Other>Other</a>
        </td><td>Other files<details><summary>Modified files (1)</summary><ul><li>Coralogix/Sources/SessionReplay/SessionReplayInstrumentation.swift</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>feat(CX-44984): emit s...</td><td>June 15, 2026</td></tr>
<tr><td>dan.gavrielov@coralogi...</td><td>BUGV2-6045 fix(session...</td><td>June 15, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/223?tool=ast&topic=Export%2BRelease>Export+Release</a>
        </td><td>Align the exporter and release metadata so the init-context change reaches the wire and the next SDK version ships with the new signal and tests for the <code>session_replay_init</code> branch. Update <code>CxRumBuilder</code>/<code>InternalContext</code> to consume the span attributes, add an end-to-end <code>SessionReplayInitLogTests</code>, and bump the SDK version across <code>Global.sdk</code>, all podspecs, and <code>CHANGELOG.md</code>.<details><summary>Modified files (8)</summary><ul><li>CHANGELOG.md</li>
<li>Coralogix.podspec</li>
<li>Coralogix/Sources/Model/Contexts/InternalContext.swift</li>
<li>Coralogix/Sources/Model/CxRumBuilder.swift</li>
<li>CoralogixInternal.podspec</li>
<li>CoralogixInternal/Sources/Utils.swift</li>
<li>SessionReplay.podspec</li>
<li>Tests/CoralogixRumTests/SessionReplayInitLogTests.swift</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>docs(CX-44984): trim s...</td><td>June 16, 2026</td></tr>
<tr><td>dan.gavrielov@coralogi...</td><td>BUGV2-6045 fix(session...</td><td>June 15, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/223?tool=ast&topic=Session+Replay+Init>Session Replay Init</a>
        </td><td>Emit the session-replay init log by snapshotting <code>SessionReplayOptions</code>, adding the <code>sessionReplayInit</code> metadata keys, and reporting the payload through <code>reportSessionReplayInit</code> so the configuration snapshot fires whenever Session Replay really starts. Include <code>SessionReplayInstrumentation</code>, <code>SdkManager</code>, and the SR network mock to surface the new log, and cover the snapshot builder and serializer via dedicated unit tests.<details><summary>Modified files (7)</summary><ul><li>Coralogix/Sources/Instrumentation/InternalInstrumentation.swift</li>
<li>CoralogixInternal/Sources/Keys.swift</li>
<li>CoralogixInternal/Sources/SdkManager.swift</li>
<li>SessionReplay/Sources/SessionReplay.swift</li>
<li>SessionReplay/Sources/SessionReplayOptions+InitLogSnapshot.swift</li>
<li>Tests/SessionReplayTests/SRNetworkManagerTests.swift</li>
<li>Tests/SessionReplayTests/SessionReplayInitLogSnapshotTests.swift</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>feat(CX-44984): emit s...</td><td>June 15, 2026</td></tr>
<tr><td>dan.gavrielov@coralogi...</td><td>BUGV2-6045 fix(session...</td><td>June 15, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/coralogix/cx-ios-sdk/223?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>