### PR TITLE
fix(CX-45771): drop prewarmed/background-launch cold starts skewing AVG

### DIFF
--- a/.claude/rules/CODING_STANDARDS.md
+++ b/.claude/rules/CODING_STANDARDS.md
@@ -299,14 +299,14 @@ Default to writing no comments. Identifiers already say what the code does — c
 **Worth commenting:**
 
 - Subtle invariants ("this static is intentionally not synchronised because writers are serialised by …")
-- Workarounds for specific bugs ("this delay is here because URLSession on iOS 17.0 has a race that drops the first response — FB12345")
+- Workarounds for specific bugs ("this delay is here because URLSession on iOS 17.0 has a race that drops the first response")
 - Decisions that diverge from the obvious approach and why
-- References to a Jira ticket or a previous fix that explains the choice
 
 **Not worth commenting:**
 
 - What the code obviously does (`// increment counter`)
 - The fix you just shipped (belongs in the PR description)
 - Who used to call this function
+- **Ticket numbers** (`CX-XXXXX`, `BUGV2-XXXX`, etc.) in code comments *or* `CHANGELOG.md` entries — git blame, the commit, and the PR already carry them. Comment the *why* in prose so it stands on its own without the reference.
 
 If removing the comment wouldn't confuse a future reader, don't write it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Release-mechanics commits (version bumps, podspec/script tweaks, README edits) a
 omitted; the focus here is user-facing behavior changes. Tickets are referenced as
 `CX-XXXXX` (Jira) or `ALPH-XXXX` (legacy). Pull request numbers are in parentheses.
 
+## [2.9.1] - 2026-06-16
+
+### Fixed
+- Cold Start AVG reported multi-hour values. Prewarmed launches (iOS spawns the process in the background ahead of user intent, flagged by `ActivePrewarm`) and other background launches (push/fetch/location) were measured from kernel process birth time and counted as cold starts. Prewarmed launches are now skipped, and any cold-start duration beyond a 60s ceiling is dropped as a background-launch artifact.
+
 ## [2.9.0] - 2026-06-15
 
 ### Added

--- a/Coralogix.podspec
+++ b/Coralogix.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "Coralogix"
-  spec.version      = "2.9.0"
+  spec.version      = "2.9.1"
   spec.summary      = "Coralogix OpenTelemetry pod for iOS."
 
   spec.description  = <<-DESC
@@ -29,7 +29,7 @@ Pod::Spec.new do |spec|
 
   spec.static_framework = true
   spec.dependency 'PLCrashReporter', '~> 1.12'
-  spec.dependency 'CoralogixInternal', '2.9.0'
+  spec.dependency 'CoralogixInternal', '2.9.1'
 
   spec.test_spec 'Tests' do |test|
     test.source_files = 'Tests/CoralogixRumTests/**/*.swift'

--- a/Coralogix/Sources/Utils/MobileVitals/ColdDetector.swift
+++ b/Coralogix/Sources/Utils/MobileVitals/ColdDetector.swift
@@ -12,7 +12,7 @@ import UIKit
 final class ColdDetector {
     // Launches longer than this are background/prewarm artifacts (the process was spawned
     // long before the user foregrounded the app), not a user-perceived cold start. Dropping
-    // them keeps multi-hour bogus values out of the Cold Start AVG — CX-45771.
+    // them keeps multi-hour bogus values out of the Cold Start AVG.
     static let maxReasonableColdStartMs: Double = 60_000
 
     var launchStartTime: CFAbsoluteTime?

--- a/Coralogix/Sources/Utils/MobileVitals/ColdDetector.swift
+++ b/Coralogix/Sources/Utils/MobileVitals/ColdDetector.swift
@@ -10,9 +10,20 @@ import Foundation
 import UIKit
 
 final class ColdDetector {
+    // Launches longer than this are background/prewarm artifacts (the process was spawned
+    // long before the user foregrounded the app), not a user-perceived cold start. Dropping
+    // them keeps multi-hour bogus values out of the Cold Start AVG — CX-45771.
+    static let maxReasonableColdStartMs: Double = 60_000
+
     var launchStartTime: CFAbsoluteTime?
     var launchEndTime: CFAbsoluteTime?
     var handleColdClosure: (([String: Any]) -> Void)?
+
+    /// Whether iOS prewarmed (background-spawned) this process ahead of user intent.
+    /// In production it reads the OS `ActivePrewarm` env var; overridable in tests.
+    var isPrewarmedLaunch: () -> Bool = {
+        ProcessInfo.processInfo.environment["ActivePrewarm"] == "1"
+    }
 
     func startMonitoring() {
         // Use kernel process birth time for the most accurate cold-start start point.
@@ -43,9 +54,23 @@ final class ColdDetector {
         let launchEndTime = CFAbsoluteTimeGetCurrent()
         self.launchEndTime = launchEndTime
 
+        // A prewarmed process is spawned in the background before the user opens the app,
+        // so the kernel birth time → didBecomeActive delta isn't a real cold start. Skip it.
+        guard !isPrewarmedLaunch() else {
+            Log.d("ColdDetector: prewarmed launch — skipping cold-start metric")
+            return
+        }
+
         let epochStartTime = Helper.convertCFAbsoluteTimeToEpoch(launchStartTime)
         let epochEndTime = Helper.convertCFAbsoluteTimeToEpoch(launchEndTime)
         let duration = calculateTime(start: epochStartTime, stop: epochEndTime)
+
+        // Background launches (push, fetch, location) aren't flagged by ActivePrewarm but show
+        // the same multi-hour skew. Drop anything beyond the sane ceiling rather than emit it.
+        guard duration <= ColdDetector.maxReasonableColdStartMs else {
+            Log.d("ColdDetector: cold-start duration \(duration)ms exceeds cap — likely a background launch, dropping")
+            return
+        }
 
         let cold = [
             MobileVitalsType.cold.stringValue: [

--- a/CoralogixInternal.podspec
+++ b/CoralogixInternal.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "CoralogixInternal"
-  spec.version      = "2.9.0"
+  spec.version      = "2.9.1"
   spec.summary      = "Coralogix Internal Package. This module is not for public use."
 
   spec.description  = <<-DESC

--- a/CoralogixInternal/Sources/Utils.swift
+++ b/CoralogixInternal/Sources/Utils.swift
@@ -16,7 +16,7 @@ public enum ImageFormat {
 }
 
 public enum Global: String {
-    case sdk = "2.9.0"
+    case sdk = "2.9.1"
     case swiftVersion = "5.9"
     case coralogixPath = "/browser/v1beta/logs"
     case sessionReplayPath = "/browser/alpha/sessionrecording"

--- a/SessionReplay.podspec
+++ b/SessionReplay.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "SessionReplay"
-  spec.version      = "2.9.0"
+  spec.version      = "2.9.1"
   spec.summary      = "Coralogix Session-Replay pod for iOS."
 
   spec.description  = <<-DESC
@@ -23,7 +23,7 @@ Pod::Spec.new do |spec|
   spec.static_framework = true
 
   spec.source_files  = 'SessionReplay/Sources/**/*.swift'
-  spec.dependency 'CoralogixInternal', '2.9.0'
+  spec.dependency 'CoralogixInternal', '2.9.1'
   
     spec.test_spec 'Tests' do |test|
         test.source_files = 'Tests/SessionReplayTests/**/*.swift'

--- a/Tests/CoralogixRumTests/MobileVitalsTests/ColdDetectorTests.swift
+++ b/Tests/CoralogixRumTests/MobileVitalsTests/ColdDetectorTests.swift
@@ -173,6 +173,8 @@ class ColdDetectorTests: XCTestCase {
     func testDidBecomeActive_whenNotPrewarmed_reports() {
         sut.startMonitoring()
         sut.isPrewarmedLaunch = { false }
+        // Pin a recent start so the cap can't drop the report — isolates the prewarm path.
+        sut.launchStartTime = CFAbsoluteTimeGetCurrent() - 1
 
         var called = false
         sut.handleColdClosure = { _ in called = true }

--- a/Tests/CoralogixRumTests/MobileVitalsTests/ColdDetectorTests.swift
+++ b/Tests/CoralogixRumTests/MobileVitalsTests/ColdDetectorTests.swift
@@ -72,6 +72,9 @@ class ColdDetectorTests: XCTestCase {
     /// fires `handleColdClosure` with the correct dictionary structure and a positive duration.
     func testDidBecomeActive_afterStartMonitoring_reportsColdStart() {
         sut.startMonitoring()
+        // Pin a recent start so the duration is deterministic and under the cap regardless
+        // of how long the test process has been alive (kernel birth time could exceed it).
+        sut.launchStartTime = CFAbsoluteTimeGetCurrent() - 1
 
         var receivedMetric: [String: Any]?
         sut.handleColdClosure = { receivedMetric = $0 }
@@ -96,6 +99,8 @@ class ColdDetectorTests: XCTestCase {
     /// The observer is removed on first delivery so subsequent fires are ignored.
     func testDidBecomeActive_firesOnlyOnce() {
         sut.startMonitoring()
+        // Pin a recent start so the (single) report isn't dropped by the cap.
+        sut.launchStartTime = CFAbsoluteTimeGetCurrent() - 1
 
         var callCount = 0
         sut.handleColdClosure = { _ in callCount += 1 }
@@ -144,6 +149,75 @@ class ColdDetectorTests: XCTestCase {
         NotificationCenter.default.post(name: UIApplication.didBecomeActiveNotification, object: nil)
 
         XCTAssertNotNil(sut.launchEndTime, "launchEndTime must be set after cold start is reported")
+    }
+
+    // MARK: - Prewarm / background-launch filtering (CX-45771)
+
+    /// Verifies that a prewarmed launch (iOS spawns the process in the background ahead of
+    /// user intent) is dropped — the kernel-birth → didBecomeActive delta is not a real cold
+    /// start and would otherwise report multi-hour durations.
+    func testDidBecomeActive_whenPrewarmed_doesNotReport() {
+        sut.startMonitoring()
+        sut.isPrewarmedLaunch = { true }
+
+        var called = false
+        sut.handleColdClosure = { _ in called = true }
+
+        NotificationCenter.default.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+
+        XCTAssertFalse(called, "Prewarmed launch must not emit a cold-start metric")
+    }
+
+    /// Verifies a non-prewarmed launch still reports normally — proves the prewarm guard
+    /// doesn't suppress legitimate cold starts.
+    func testDidBecomeActive_whenNotPrewarmed_reports() {
+        sut.startMonitoring()
+        sut.isPrewarmedLaunch = { false }
+
+        var called = false
+        sut.handleColdClosure = { _ in called = true }
+
+        NotificationCenter.default.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+
+        XCTAssertTrue(called, "A normal (non-prewarmed) launch must emit a cold-start metric")
+    }
+
+    /// Verifies a launch whose duration exceeds the sane ceiling (background launch skew) is
+    /// dropped. `launchStartTime` is set far enough in the past to push the delta over the cap.
+    func testDidBecomeActive_whenDurationExceedsCap_doesNotReport() {
+        sut.startMonitoring()
+        // Start time well beyond the 60s cap (cap is ms; CFAbsoluteTime is seconds).
+        let secondsOverCap = (ColdDetector.maxReasonableColdStartMs / 1000) + 60
+        sut.launchStartTime = CFAbsoluteTimeGetCurrent() - secondsOverCap
+
+        var called = false
+        sut.handleColdClosure = { _ in called = true }
+
+        NotificationCenter.default.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+
+        XCTAssertFalse(called, "Cold-start durations beyond the cap must be dropped")
+    }
+
+    /// Verifies a launch just under the cap still reports — proves the cap doesn't drop
+    /// legitimate (if slow) cold starts.
+    func testDidBecomeActive_whenDurationUnderCap_reports() {
+        sut.startMonitoring()
+        // 1s ago → ~1000ms, comfortably under the cap.
+        sut.launchStartTime = CFAbsoluteTimeGetCurrent() - 1
+
+        var receivedDuration: Double?
+        sut.handleColdClosure = { dict in
+            let inner = dict[MobileVitalsType.cold.stringValue] as? [String: Any]
+            receivedDuration = inner?[Keys.value.rawValue] as? Double
+        }
+
+        NotificationCenter.default.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+
+        let duration = try? XCTUnwrap(receivedDuration)
+        XCTAssertNotNil(duration, "A sub-cap launch must emit a cold-start metric")
+        XCTAssertLessThanOrEqual(duration ?? .greatestFiniteMagnitude,
+                                 ColdDetector.maxReasonableColdStartMs,
+                                 "Reported duration must be within the cap")
     }
 
     // MARK: - calculateTime()

--- a/Tests/CoralogixRumTests/MobileVitalsTests/ColdDetectorTests.swift
+++ b/Tests/CoralogixRumTests/MobileVitalsTests/ColdDetectorTests.swift
@@ -151,7 +151,7 @@ class ColdDetectorTests: XCTestCase {
         XCTAssertNotNil(sut.launchEndTime, "launchEndTime must be set after cold start is reported")
     }
 
-    // MARK: - Prewarm / background-launch filtering (CX-45771)
+    // MARK: - Prewarm / background-launch filtering
 
     /// Verifies that a prewarmed launch (iOS spawns the process in the background ahead of
     /// user intent) is dropped — the kernel-birth → didBecomeActive delta is not a real cold


### PR DESCRIPTION
# User description
## What & why

iOS cold start is measured as kernel process-birth → `didBecomeActive`. For **prewarmed** (iOS 15+) and **background** launches (push, fetch, location) the process is spawned long before the user opens the app, so the delta balloons into minutes/hours — producing the multi-hour outliers reported in the Betsson production data (CX-45771).

## Changes

- **Skip prewarmed launches** — `ColdDetector` now checks Apple's `ActivePrewarm` env var and drops the metric when set.
- **Sanity cap** — durations beyond `maxReasonableColdStartMs` (60s) are dropped, catching background launches that aren't flagged as prewarm.
- Matches the standard iOS approach (Sentry/Firebase). Android's equivalent structural safeguard is noted as possible follow-up but is an accuracy refinement, not the cause of these outliers.

## Tests

- New: prewarm-skip, not-prewarmed-reports, over-cap-drop, under-cap-reports.
- Pinned `launchStartTime` in the existing/new reporting tests so the cap can't flake them when the suite runs >60s.
- `xcodebuild test -scheme Coralogix-Package -only-testing:CoralogixRumTests/ColdDetectorTests` → 14 passed, 0 failures.

## Note

Version bump + CHANGELOG are intentionally **not** in this PR — another PR is set to merge first and bump the version; this branch will be reconciled afterward to avoid version churn/conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Prevent multi-hour cold-start outliers by skipping <code>ColdDetector</code> reports when <code>ActivePrewarm</code> indicates a prewarmed launch and by capping durations at <code>maxReasonableColdStartMs</code>, while aligning SDK metadata and documentation so the release reflects the tighter metric safeguards. Harden the <code>ColdDetectorTests</code> alongside the 2.9.1 podspec bumps and changelog entry so the new filters and reporting behavior stay validated.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/224?tool=ast&topic=Release+%26+docs+updates>Release & docs updates</a>
        </td><td>Document and ship the guarded cold-start behavior by updating the 2.9.1 changelog entry, version numbers in all podspecs, the <code>Global.sdk</code> string, and the <code>ColdDetectorTests</code>, while also revising the coding standards guidance to avoid hardcoded ticket references in comments.<details><summary>Modified files (7)</summary><ul><li>.claude/rules/CODING_STANDARDS.md</li>
<li>CHANGELOG.md</li>
<li>Coralogix.podspec</li>
<li>CoralogixInternal.podspec</li>
<li>CoralogixInternal/Sources/Utils.swift</li>
<li>SessionReplay.podspec</li>
<li>Tests/CoralogixRumTests/MobileVitalsTests/ColdDetectorTests.swift</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>chore(CX-45771): bump ...</td><td>June 16, 2026</td></tr>
<tr><td>dan.gavrielov@coralogi...</td><td>BUGV2-6045 fix(session...</td><td>June 15, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/224?tool=ast&topic=Cold+start+filtering>Cold start filtering</a>
        </td><td>Filter out prewarmed and runaway background launches in <code>ColdDetector</code> so <code>MobileVitals</code> reports only user-perceived cold starts by reading <code>ActivePrewarm</code>, short-circuiting prewarmed sessions, and discarding durations exceeding the 60 s ceiling.<details><summary>Modified files (1)</summary><ul><li>Coralogix/Sources/Utils/MobileVitals/ColdDetector.swift</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>chore(CX-45771): drop ...</td><td>June 16, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/coralogix/cx-ios-sdk/224?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>