### PR TITLE
Cx 44221 improve Agents instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,26 @@ If a public API or internal symbol is removed:
 - Don't add deprecation shims unless the user explicitly asks
 - The commit message and CHANGELOG explain the removal
 
+### 4.12 Content hygiene (🚫 BLOCK)
+
+The CHANGELOG and shipped code comments are read by customers. Anything internal that leaks here is a customer-facing leak. This is a high-priority rule — developers routinely leave ticket numbers in comments, commits, and the public CHANGELOG.
+
+**CHANGELOG (client-facing) — block on:**
+
+- Ticket numbers, issue IDs, or internal tracker references (e.g. `JIRA-1234`, `CX-44221`, `#4821`)
+- Long or rambling entries — each entry is one clear sentence describing the user-facing change
+- Internal jargon, team names, or links to internal tools
+
+Write in plain language: what changed and why it matters to the user.
+
+**Code comments — block on:**
+
+- Secrets of any kind: API keys, tokens, credentials, connection strings
+- Ticket numbers, issue IDs, or internal tracker references
+- Internal-only notes (private discussions, personal names, "ask X about this")
+
+Comments should be short and clear, added only when they earn their place — when intent or a trade-off isn't obvious from the code. Explain *why*, not *what*; if the code is self-explanatory, no comment.
+
 ## 5. Use the right skill
 
 When the diff matches one of these patterns, the PR author should use the registered skill rather than reinventing the flow:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,8 @@ Events carry context structs from `Coralogix/Sources/Model/Contexts/` (e.g., `De
 
 ## Rules
 
+The review rules in `AGENTS.md` apply **while writing code**, not only at PR time — read it and follow it as you work.
+
 - **Never use `assert`, `precondition`, or `fatalError` in SDK code.** An SDK must never crash the host app. Use early returns or `Log.e(...)` instead. (Commit `7d59641` was entirely dedicated to removing these.)
 
 - **Swizzling tests must restore original implementations in `tearDown`.** Swizzled state leaks between tests if not cleaned up — this caused a full test-isolation fix in `7d59641`.


### PR DESCRIPTION
# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update AGENTS instructions to block ticket numbers and require clear, customer-ready language for CHANGELOG entries and comments so browser-sdk docs stay polished. Reinforce via the CLAUDE guidance that AGENTS rules govern coding work continuously to prevent rule drift.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/225?tool=ast&topic=Content+hygiene>Content hygiene</a>
        </td><td>Describe the new <code>AGENTS</code> guidance that blocks internal references and enforces plain-language CHANGELOG entries plus short, intent-focused comments to prevent customer-facing leaks.<details><summary>Modified files (1)</summary><ul><li>AGENTS.md</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>stas.rudevitsky@coralo...</td><td>docs: update AGENTS.md...</td><td>June 17, 2026</td></tr>
<tr><td>tomer.haryoffi@coralog...</td><td>feat(CX-45216): add co...</td><td>June 10, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/225?tool=ast&topic=Review+skills>Review skills</a>
        </td><td>Reinforce that <code>AGENTS</code> rules are part of the development flow by reminding reviewers in <code>CLAUDE</code> that the guidance applies while writing code, not only at PR time.<details><summary>Modified files (1)</summary><ul><li>CLAUDE.md</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>stas.rudevitsky@coralo...</td><td>docs: update AGENTS.md...</td><td>June 17, 2026</td></tr>
<tr><td>tomer.haryoffi@coralog...</td><td>feat(CX-45216): add co...</td><td>June 10, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/coralogix/cx-ios-sdk/225?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>