### PR TITLE
CX-46601 fix(crash): omit Flutter-only native-crash error_context fields for React Native

### DIFF
--- a/Coralogix/Sources/Model/Contexts/ErrorContext.swift
+++ b/Coralogix/Sources/Model/Contexts/ErrorContext.swift
@@ -82,18 +82,24 @@ struct ErrorContext {
         var errorContext = [String: Any]()
 
         if let threads = self.threads, !threads.isEmpty {
-            errorContext[Keys.exceptionType.rawValue] = self.exceptionType
-            errorContext[Keys.crashTimestamp.rawValue] = self.crashTimestamp
-            errorContext[Keys.processName.rawValue] = self.processName
-            errorContext[Keys.applicationIdentifier.rawValue] = self.applicationIdentifier
-            errorContext[Keys.triggeredByThread.rawValue] = self.triggeredByThread
-            errorContext[Keys.baseAddress.rawValue] = self.baseAddress
-            errorContext[Keys.arch.rawValue] = self.arch
-            if let threads = self.threads {
-                errorContext[Keys.threads.rawValue] = threads
-            }
+            // A native crash. Every framework records the crash and its message.
             errorContext[Keys.isCrash.rawValue] = true
             errorContext[Keys.errorMessage.rawValue] = self.exceptionType
+
+            // The detailed native-crash fields are accepted by the RUM ingest
+            // schema for native iOS and Flutter, but rejected for React Native
+            // (HTTP 400 — see CX-46601). Attach them only when the framework
+            // allows it; otherwise the whole crash log is dropped at ingest.
+            if CoralogixRum.mobileSDK.sdkFramework.allowsNativeCrashContext {
+                errorContext[Keys.exceptionType.rawValue] = self.exceptionType
+                errorContext[Keys.crashTimestamp.rawValue] = self.crashTimestamp
+                errorContext[Keys.processName.rawValue] = self.processName
+                errorContext[Keys.applicationIdentifier.rawValue] = self.applicationIdentifier
+                errorContext[Keys.triggeredByThread.rawValue] = self.triggeredByThread
+                errorContext[Keys.baseAddress.rawValue] = self.baseAddress
+                errorContext[Keys.arch.rawValue] = self.arch
+                errorContext[Keys.threads.rawValue] = threads
+            }
         } else {
             if !self.domain.isEmpty {
                 errorContext[Keys.domain.rawValue] = self.domain

--- a/Coralogix/Sources/Model/SdkFramework.swift
+++ b/Coralogix/Sources/Model/SdkFramework.swift
@@ -28,6 +28,19 @@ public enum SdkFramework: Equatable {
             return false
         }
     }
+
+    /// Whether the RUM ingest schema accepts the detailed native-crash
+    /// `error_context` fields (threads, exception_type, arch, build_id, …) for
+    /// this framework. Allowed for native iOS and Flutter; rejected for
+    /// React Native (CX-46601), where they must be omitted to avoid an HTTP 400.
+    var allowsNativeCrashContext: Bool {
+        switch self {
+        case .swift, .flutter:
+            return true
+        case .reactNative:
+            return false
+        }
+    }
     
     var version: String {
         switch self {


### PR DESCRIPTION
# User description
## Summary
[CX-46601](https://coralogix.atlassian.net/browse/CX-46601) — Native iOS crashes from the **React Native** plugin are captured by PLCrashReporter, written to disk, and uploaded on the next launch correctly, but the RUM backend **rejects the upload with HTTP 400**, so RN native crashes never reach RUM.

## Root cause
`ErrorContext.getDictionary()` emits the detailed native-crash fields for **any** native crash (when `threads` is non-empty) with **no framework gating**:
```
HTTP 400: Fields stack_trace_type, arch, build_id ... only allowed when framework is 'flutter'.
application_identifier / exception_type / triggered_by_thread ... should not exist
```
The RUM ingest schema only permits these `error_context` fields for `mobile_sdk.framework == 'flutter'`, so the same payload tagged `react-native` is rejected and the whole crash log is dropped.

## Fix
- Add `SdkFramework.allowsNativeCrashContext` — an explicit, exhaustive switch: `true` for native iOS (`.swift`) + `.flutter`, `false` for `.reactNative`.
- In `ErrorContext.getDictionary()`, the shared crash fields (`is_crash`, `error_message`) are assigned once; the detailed native-crash fields are attached **only** when `allowsNativeCrashContext` is true.

| Framework | Native-crash output |
|---|---|
| `swift` (native iOS) | full detail — unchanged |
| `flutter` | full detail — unchanged |
| `reactNative` | `is_crash` + `error_message` (schema-safe) — now **ingests** instead of being dropped |

Flutter and native iOS behavior is unchanged.

## Verification
- iOS build (`xcodebuild -scheme Coralogix -destination 'generic/platform=iOS Simulator'`) → **BUILD SUCCEEDED**.
- Reproduced the original HTTP 400 on a physical iPhone via the RN example app (native crash → cold relaunch → `[SpanUploader] Backend rejected upload with HTTP 400`).

## Follow-up (not in this PR)
Full RN native-crash fidelity (threads/stack/arch) requires the **RUM ingest schema** to allow these `error_context` fields for `react-native`, as it does for `flutter`. Tracked in CX-46601; to be raised with the ingest/schema team.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[CX-46601]: https://coralogix.atlassian.net/browse/CX-46601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Prevent React Native crash uploads from being rejected by gating <code>ErrorContext</code>'s native crash fields so only schema-allowed data for that framework is emitted. Introduce <code>SdkFramework.allowsNativeCrashContext</code> to describe which runtimes can send detailed metadata while keeping Flutter and native iOS behavior unchanged.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>fix(crash): omit Flutt...</td><td>June 22, 2026</td></tr></table></details>
<sub><a href="https://baz.co/changes/coralogix/cx-ios-sdk/226?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>