### PR TITLE
fix(CX-46400): rebuild otelSpan attributes on the hybrid beforeSend path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Release-mechanics commits (version bumps, podspec/script tweaks, README edits) a
 omitted; the focus here is user-facing behavior changes. Tickets are referenced as
 `CX-XXXXX` (Jira) or `ALPH-XXXX` (legacy). Pull request numbers are in parentheses.
 
+## [2.9.2] - 2026-06-24
+
+### Fixed
+- On the hybrid (React Native / Flutter) path, a `beforeSend` edit to an editable `cx_rum` field (e.g. redacting `session_context.user_email`, or rewriting `labels`) was reflected in `text.cx_rum` but not in `instrumentation_data.otelSpan.attributes`: the encoded spans were uploaded verbatim after the callback, so the tracing mirror stayed stale and a redacted value still leaked through tracing. The OTEL attributes are now rebuilt from the edited `cx_rum` before upload — the same rebuild the native single-event path performs — so both destinations carry identical values.
+
 ## [2.9.1] - 2026-06-16
 
 ### Fixed

--- a/Coralogix.podspec
+++ b/Coralogix.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "Coralogix"
-  spec.version      = "2.9.1"
+  spec.version      = "2.9.2"
   spec.summary      = "Coralogix OpenTelemetry pod for iOS."
 
   spec.description  = <<-DESC
@@ -29,7 +29,7 @@ Pod::Spec.new do |spec|
 
   spec.static_framework = true
   spec.dependency 'PLCrashReporter', '~> 1.12'
-  spec.dependency 'CoralogixInternal', '2.9.1'
+  spec.dependency 'CoralogixInternal', '2.9.2'
 
   spec.test_spec 'Tests' do |test|
     test.source_files = 'Tests/CoralogixRumTests/**/*.swift'

--- a/Coralogix/Sources/Exporter/CoralogixExporter.swift
+++ b/Coralogix/Sources/Exporter/CoralogixExporter.swift
@@ -108,7 +108,37 @@ public class CoralogixExporter: SpanExporter {
     }
     
     internal func sendBeforeSendData(data: [[String: Any]]) {
-        self.spanUploader.upload(data, endPoint: self.endPoint)
+        let rebuilt = data.map { self.rebuildOtelSpanAttributes(in: $0) }
+        self.spanUploader.upload(rebuilt, endPoint: self.endPoint)
+    }
+
+    /// Hybrid (`beforeSendCallBack`) path: spans are encoded *before* the JS edit and the
+    /// edited batch is handed back here to upload verbatim, so `otelSpan.attributes` would
+    /// otherwise stay stale while `text.cx_rum` reflects the edit. Rebuild the attributes from
+    /// the final (edited) `cx_rum` — the same call the native single-event path makes in
+    /// `CxSpan.getDictionary()` — so both destinations of a span carry identical values.
+    ///
+    /// Rebuilding from the `cx_rum` dict (a lossy view of the `CxRum` struct, e.g.
+    /// `CxRumPayloadBuilder` omits `error_context` for non-error events) intentionally matches
+    /// what `text.cx_rum` carries: the hybrid path is always "edit in play," so consistency
+    /// between the two destinations is the goal, not preserving struct-only fields.
+    /// Events without `instrumentation_data` (anything but network-request / custom-span) are
+    /// returned unchanged.
+    private func rebuildOtelSpanAttributes(in event: [String: Any]) -> [String: Any] {
+        guard var instrumentationData = event[Keys.instrumentationData.rawValue] as? [String: Any],
+              var otelSpan = instrumentationData[Keys.otelSpan.rawValue] as? [String: Any],
+              let cxRum = (event[Keys.text.rawValue] as? [String: Any])?[Keys.cxRum.rawValue] as? [String: Any] else {
+            return event
+        }
+        otelSpan[Keys.attributes.rawValue] = OtelSpan.buildRumContextAttributes(
+            fromCxRumDict: cxRum,
+            viewManager: self.viewManager,
+            mobileSdkVersion: CoralogixRum.mobileSDK.sdkFramework.version
+        )
+        instrumentationData[Keys.otelSpan.rawValue] = otelSpan
+        var result = event
+        result[Keys.instrumentationData.rawValue] = instrumentationData
+        return result
     }
     
     #if DEBUG

--- a/Coralogix/Sources/Exporter/CoralogixExporter.swift
+++ b/Coralogix/Sources/Exporter/CoralogixExporter.swift
@@ -122,6 +122,10 @@ public class CoralogixExporter: SpanExporter {
     /// `CxRumPayloadBuilder` omits `error_context` for non-error events) intentionally matches
     /// what `text.cx_rum` carries: the hybrid path is always "edit in play," so consistency
     /// between the two destinations is the goal, not preserving struct-only fields.
+    ///
+    /// `page_url`/`page_fragments` are re-read from the live `viewManager` here (not the frozen
+    /// dict); hybrid hosts render in a single native view controller, so it stays stable between
+    /// encode and this callback.
     /// Events without `instrumentation_data` (anything but network-request / custom-span) are
     /// returned unchanged.
     private func rebuildOtelSpanAttributes(in event: [String: Any]) -> [String: Any] {

--- a/Coralogix/Sources/Exporter/CoralogixExporter.swift
+++ b/Coralogix/Sources/Exporter/CoralogixExporter.swift
@@ -123,9 +123,10 @@ public class CoralogixExporter: SpanExporter {
     /// what `text.cx_rum` carries: the hybrid path is always "edit in play," so consistency
     /// between the two destinations is the goal, not preserving struct-only fields.
     ///
-    /// `page_url`/`page_fragments` are re-read from the live `viewManager` here (not the frozen
-    /// dict); hybrid hosts render in a single native view controller, so it stays stable between
-    /// encode and this callback.
+    /// `page_url`/`page_fragments` are preserved from the encode-time attributes rather than
+    /// re-derived from the live `viewManager`: the span belongs to the view active when it was
+    /// created, and re-reading here could drift if the native view advanced during the bridge
+    /// round-trip.
     /// Events without `instrumentation_data` (anything but network-request / custom-span) are
     /// returned unchanged.
     private func rebuildOtelSpanAttributes(in event: [String: Any]) -> [String: Any] {
@@ -134,9 +135,10 @@ public class CoralogixExporter: SpanExporter {
               let cxRum = (event[Keys.text.rawValue] as? [String: Any])?[Keys.cxRum.rawValue] as? [String: Any] else {
             return event
         }
-        otelSpan[Keys.attributes.rawValue] = OtelSpan.buildRumContextAttributes(
+        let previousAttributes = otelSpan[Keys.attributes.rawValue] as? [String: Any] ?? [:]
+        otelSpan[Keys.attributes.rawValue] = OtelSpan.rebuiltAttributes(
             fromCxRumDict: cxRum,
-            viewManager: self.viewManager,
+            preservingPageFrom: previousAttributes,
             mobileSdkVersion: CoralogixRum.mobileSDK.sdkFramework.version
         )
         instrumentationData[Keys.otelSpan.rawValue] = otelSpan

--- a/Coralogix/Sources/Model/InstrumentationData.swift
+++ b/Coralogix/Sources/Model/InstrumentationData.swift
@@ -213,6 +213,28 @@ struct OtelSpan {
         return attrs
     }
 
+    /// Hybrid (`beforeSendCallBack`) rebuild: produce `otelSpan.attributes` from the edited
+    /// `cx_rum` dict, but keep the encode-time `page_url`/`page_fragments` carried in
+    /// `previousAttributes`. A span belongs to the view that was active when it was created —
+    /// the same snapshot `text.cx_rum.view_context` froze — so the page is taken from the
+    /// original attributes rather than the live `viewManager`, which could advance during the
+    /// bridge round-trip (e.g. a host using native navigation) and make the two destinations
+    /// disagree on the page.
+    internal static func rebuiltAttributes(fromCxRumDict cxRumDict: [String: Any],
+                                           preservingPageFrom previousAttributes: [String: Any],
+                                           mobileSdkVersion: String) -> [String: Any] {
+        var attrs = buildRumContextAttributes(fromCxRumDict: cxRumDict,
+                                              viewManager: nil,
+                                              mobileSdkVersion: mobileSdkVersion)
+        if let pageUrl = previousAttributes[AttrKey.pageUrl] {
+            attrs[AttrKey.pageUrl] = pageUrl
+        }
+        if let pageFragments = previousAttributes[AttrKey.pageFragments] {
+            attrs[AttrKey.pageFragments] = pageFragments
+        }
+        return attrs
+    }
+
     private static func buildRumContextAttributes(cxRum: CxRum, viewManager: ViewManager?) -> [String: Any] {
         var attrs = [String: Any]()
 

--- a/CoralogixInternal.podspec
+++ b/CoralogixInternal.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "CoralogixInternal"
-  spec.version      = "2.9.1"
+  spec.version      = "2.9.2"
   spec.summary      = "Coralogix Internal Package. This module is not for public use."
 
   spec.description  = <<-DESC

--- a/CoralogixInternal/Sources/Utils.swift
+++ b/CoralogixInternal/Sources/Utils.swift
@@ -16,7 +16,7 @@ public enum ImageFormat {
 }
 
 public enum Global: String {
-    case sdk = "2.9.1"
+    case sdk = "2.9.2"
     case swiftVersion = "5.9"
     case coralogixPath = "/browser/v1beta/logs"
     case sessionReplayPath = "/browser/alpha/sessionrecording"

--- a/SessionReplay.podspec
+++ b/SessionReplay.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "SessionReplay"
-  spec.version      = "2.9.1"
+  spec.version      = "2.9.2"
   spec.summary      = "Coralogix Session-Replay pod for iOS."
 
   spec.description  = <<-DESC
@@ -23,7 +23,7 @@ Pod::Spec.new do |spec|
   spec.static_framework = true
 
   spec.source_files  = 'SessionReplay/Sources/**/*.swift'
-  spec.dependency 'CoralogixInternal', '2.9.1'
+  spec.dependency 'CoralogixInternal', '2.9.2'
   
     spec.test_spec 'Tests' do |test|
         test.source_files = 'Tests/SessionReplayTests/**/*.swift'

--- a/Tests/CoralogixRumTests/HybridBeforeSendInstrumentationDataTests.swift
+++ b/Tests/CoralogixRumTests/HybridBeforeSendInstrumentationDataTests.swift
@@ -165,6 +165,45 @@ final class HybridBeforeSendInstrumentationDataTests: XCTestCase {
                        "custom-span otelSpan.attributes must be rebuilt from the edited cx_rum")
     }
 
+    /// `page_url` reflects the view active when the span was created. If the native view
+    /// advances between encode and the bridge callback (e.g. a host using native navigation),
+    /// the rebuild must keep the encode-time page — not the live view — so otelSpan.attributes
+    /// stays consistent with the span's origin instead of drifting to wherever the user landed.
+    func test_hybridPath_pageUrl_preservedFromEncodeTime_notLiveView() throws {
+        var captured: [[String: Any]] = []
+        coralogixRum = makeHybridRum { captured = $0 }
+        let exporter = try XCTUnwrap(coralogixRum.coralogixExporter)
+        let uploader = CapturingUploader()
+        exporter.spanUploader = uploader
+
+        // Span is created while "ScreenA" is visible → encode-time page_url == "ScreenA".
+        exporter.set(cxView: CXView(state: .notifyOnAppear, name: "ScreenA"))
+        _ = exporter.export(spans: [makeHybridSpan(eventType: .networkRequest)], explicitTimeout: nil)
+        XCTAssertEqual(captured.count, 1)
+        let preEdit = try otelAttributes(of: captured[0])
+        XCTAssertEqual(preEdit["cx_rum.page_context.page_url"] as? String, "ScreenA", "encode-time page must be ScreenA")
+
+        // User navigates to "ScreenB" during the JS round-trip, then the bridge edits and
+        // calls back. The rebuilt attributes must still carry ScreenA, not the live ScreenB.
+        exporter.set(cxView: CXView(state: .notifyOnAppear, name: "ScreenB"))
+        let edited = try editingCxRum(captured[0]) { cxRum in
+            var c = cxRum
+            var session = (c[Keys.sessionContext.rawValue] as? [String: Any]) ?? [:]
+            session[Keys.userEmail.rawValue] = "redacted@coralogix.com"
+            c[Keys.sessionContext.rawValue] = session
+            return c
+        }
+        exporter.sendBeforeSendData(data: [edited])
+
+        let attrs = try otelAttributes(of: try XCTUnwrap(uploader.uploaded?.first))
+        XCTAssertEqual(attrs["cx_rum.page_context.page_url"] as? String, "ScreenA",
+                       "page_url must be preserved from encode time, not re-read from the live viewManager")
+        XCTAssertEqual(attrs["cx_rum.page_context.page_fragments"] as? String, "ScreenA",
+                       "page_fragments must be preserved from encode time")
+        // The edit itself still propagates — preservation is scoped to page fields only.
+        XCTAssertEqual(attrs["cx_rum.session_context.user_email"] as? String, "redacted@coralogix.com")
+    }
+
     /// Events without instrumentation_data (anything but network-request / custom-span) must
     /// pass through sendBeforeSendData unchanged — no otelSpan section to rebuild, and the
     /// edited text must be uploaded verbatim.

--- a/Tests/CoralogixRumTests/HybridBeforeSendInstrumentationDataTests.swift
+++ b/Tests/CoralogixRumTests/HybridBeforeSendInstrumentationDataTests.swift
@@ -1,0 +1,194 @@
+//
+//  HybridBeforeSendInstrumentationDataTests.swift
+//
+//  Hybrid (`beforeSendCallBack`) path: spans are encoded *before* the JS edit and the
+//  edited batch is handed back through `sendBeforeSendData` to upload. An edit to an
+//  editable `cx_rum` field must land in BOTH `text.cx_rum` AND
+//  `instrumentation_data.otelSpan.attributes` — the same parity the native single-event
+//  `beforeSend` path guarantees (see `BeforeSendInstrumentationDataTests`).
+//
+
+import XCTest
+import CoralogixInternal
+import Foundation
+
+@testable import Coralogix
+
+final class HybridBeforeSendInstrumentationDataTests: XCTestCase {
+
+    private var coralogixRum: CoralogixRum!
+
+    override func tearDownWithError() throws {
+        coralogixRum?.shutdown()
+        coralogixRum = nil
+    }
+
+    // MARK: - Fixtures
+
+    /// Test-only `SpanUploading` that records the final payload handed to upload without
+    /// network I/O. `sendBeforeSendData` routes through `spanUploader.upload`, so this
+    /// captures exactly what the hybrid path would POST.
+    private final class CapturingUploader: SpanUploading {
+        private(set) var uploaded: [[String: Any]]?
+        func upload(_ spans: [[String: Any]], endPoint: String) -> SpanExporterResultCode {
+            uploaded = spans
+            return .success
+        }
+    }
+
+    /// A real `SpanData` (the `export()` path consumes `[SpanData]`) of the given event type,
+    /// carrying the session + http attributes the cx_rum.* mirror reads. network-request /
+    /// custom-span are the two types that emit `instrumentation_data`.
+    private func makeHybridSpan(eventType: CoralogixEventType) -> SpanData {
+        let attributes: [String: AttributeValue] = [
+            Keys.eventType.rawValue: AttributeValue(eventType.rawValue),
+            Keys.severity.rawValue: AttributeValue("3"),
+            Keys.source.rawValue: AttributeValue("fetch"),
+            Keys.environment.rawValue: AttributeValue("test"),
+            Keys.userId.rawValue: AttributeValue("uid"),
+            Keys.userName.rawValue: AttributeValue("Test User"),
+            Keys.userEmail.rawValue: AttributeValue("test@example.com"),
+            Keys.sessionId.rawValue: AttributeValue("session_001"),
+            Keys.sessionCreationDate.rawValue: AttributeValue("1609459200"),
+            SemanticAttributes.httpUrl.rawValue: AttributeValue("https://example.com/orig"),
+            SemanticAttributes.httpMethod.rawValue: AttributeValue("GET"),
+            SemanticAttributes.httpStatusCode.rawValue: AttributeValue("200")
+        ]
+        return SpanData(traceId: TraceId.random(),
+                        spanId: SpanId.random(),
+                        name: "testSpan_\(eventType.rawValue)",
+                        kind: .client,
+                        startTime: Date(),
+                        attributes: attributes,
+                        endTime: Date(),
+                        hasEnded: true)
+    }
+
+    private func makeHybridRum(captureBatchInto sink: @escaping ([[String: Any]]) -> Void) -> CoralogixRum {
+        var opts = makeSamplingOptions(sampleRate: 100, exclude: [])
+        opts.beforeSendCallBack = { batch in sink(batch) }
+        return CoralogixRum(options: opts, sdkFramework: .reactNative(version: "2.0.0"))
+    }
+
+    private func otelAttributes(of event: [String: Any]) throws -> [String: Any] {
+        let inst = try XCTUnwrap(event[Keys.instrumentationData.rawValue] as? [String: Any])
+        let otel = try XCTUnwrap(inst[Keys.otelSpan.rawValue] as? [String: Any])
+        return try XCTUnwrap(otel[Keys.attributes.rawValue] as? [String: Any])
+    }
+
+    private func textCxRum(of event: [String: Any]) throws -> [String: Any] {
+        let text = try XCTUnwrap(event[Keys.text.rawValue] as? [String: Any])
+        return try XCTUnwrap(text[Keys.cxRum.rawValue] as? [String: Any])
+    }
+
+    /// Applies `transform` to `event.text.cx_rum`, returning the edited event — the shape a
+    /// hybrid bridge produces after the JS edit, before calling back into `sendBeforeSendData`.
+    private func editingCxRum(_ event: [String: Any],
+                              _ transform: ([String: Any]) -> [String: Any]) throws -> [String: Any] {
+        var result = event
+        var text = try XCTUnwrap(event[Keys.text.rawValue] as? [String: Any])
+        let cxRum = try XCTUnwrap(text[Keys.cxRum.rawValue] as? [String: Any])
+        text[Keys.cxRum.rawValue] = transform(cxRum)
+        result[Keys.text.rawValue] = text
+        return result
+    }
+
+    // MARK: - Tests
+
+    /// Primary acceptance: an editable field (user_email) and labels edited on the hybrid
+    /// batch propagate into BOTH destinations of the uploaded payload.
+    func test_hybridPath_beforeSendEdit_rebuildsOtelSpanAttributes() throws {
+        var captured: [[String: Any]] = []
+        coralogixRum = makeHybridRum { captured = $0 }
+        let exporter = try XCTUnwrap(coralogixRum.coralogixExporter)
+        let uploader = CapturingUploader()
+        exporter.spanUploader = uploader
+
+        // 1) Encode + hand the batch to the hybrid callback.
+        _ = exporter.export(spans: [makeHybridSpan(eventType: .networkRequest)], explicitTimeout: nil)
+        XCTAssertEqual(captured.count, 1, "hybrid callback must receive the encoded network span")
+
+        // Falsifiability anchor: before the JS edit, otelSpan.attributes still carry the
+        // ORIGINAL email — no rebuild ran at encode time (hybrid uses beforeSendCallBack, not
+        // beforeSend). Without the fix, this same value would survive into the upload.
+        let preEdit = try otelAttributes(of: captured[0])
+        XCTAssertEqual(preEdit["cx_rum.session_context.user_email"] as? String, "test@example.com")
+
+        // 2) JS edits text.cx_rum, then the bridge calls back into sendBeforeSendData.
+        let edited = try editingCxRum(captured[0]) { cxRum in
+            var c = cxRum
+            var session = (c[Keys.sessionContext.rawValue] as? [String: Any]) ?? [:]
+            session[Keys.userEmail.rawValue] = "redacted@coralogix.com"
+            c[Keys.sessionContext.rawValue] = session
+            c[Keys.labels.rawValue] = ["tier": "edited"]
+            return c
+        }
+        exporter.sendBeforeSendData(data: [edited])
+
+        // 3) The uploaded payload reflects the edit in BOTH destinations.
+        let uploaded = try XCTUnwrap(uploader.uploaded?.first)
+
+        let cxRum = try textCxRum(of: uploaded)
+        let textEmail = (cxRum[Keys.sessionContext.rawValue] as? [String: Any])?[Keys.userEmail.rawValue] as? String
+        XCTAssertEqual(textEmail, "redacted@coralogix.com", "text.cx_rum must reflect the JS edit")
+
+        let attrs = try otelAttributes(of: uploaded)
+        XCTAssertEqual(attrs["cx_rum.session_context.user_email"] as? String, "redacted@coralogix.com",
+                       "otelSpan.attributes must be rebuilt from the edited cx_rum on the hybrid path")
+        XCTAssertEqual((attrs["cx_rum.labels"] as? [String: Any])?["tier"] as? String, "edited",
+                       "labels edit must propagate into otelSpan.attributes on the hybrid path")
+    }
+
+    /// The ticket scope is "events that carry instrumentation_data (network-request,
+    /// custom-span)" — custom-span must rebuild the same way as network-request.
+    func test_hybridPath_customSpan_rebuildsOtelSpanAttributes() throws {
+        var captured: [[String: Any]] = []
+        coralogixRum = makeHybridRum { captured = $0 }
+        let exporter = try XCTUnwrap(coralogixRum.coralogixExporter)
+        let uploader = CapturingUploader()
+        exporter.spanUploader = uploader
+
+        _ = exporter.export(spans: [makeHybridSpan(eventType: .customSpan)], explicitTimeout: nil)
+        XCTAssertEqual(captured.count, 1, "hybrid callback must receive the encoded custom span")
+
+        let edited = try editingCxRum(captured[0]) { cxRum in
+            var c = cxRum
+            var session = (c[Keys.sessionContext.rawValue] as? [String: Any]) ?? [:]
+            session[Keys.userEmail.rawValue] = "redacted@coralogix.com"
+            c[Keys.sessionContext.rawValue] = session
+            return c
+        }
+        exporter.sendBeforeSendData(data: [edited])
+
+        let attrs = try otelAttributes(of: try XCTUnwrap(uploader.uploaded?.first))
+        XCTAssertEqual(attrs["cx_rum.session_context.user_email"] as? String, "redacted@coralogix.com",
+                       "custom-span otelSpan.attributes must be rebuilt from the edited cx_rum")
+    }
+
+    /// Events without instrumentation_data (anything but network-request / custom-span) must
+    /// pass through sendBeforeSendData unchanged — no otelSpan section to rebuild, and the
+    /// edited text must be uploaded verbatim.
+    func test_hybridPath_eventWithoutInstrumentationData_passesThroughUnchanged() throws {
+        coralogixRum = makeHybridRum { _ in }
+        let exporter = try XCTUnwrap(coralogixRum.coralogixExporter)
+        let uploader = CapturingUploader()
+        exporter.spanUploader = uploader
+
+        let logEvent: [String: Any] = [
+            Keys.text.rawValue: [
+                Keys.cxRum.rawValue: [
+                    Keys.eventContext.rawValue: [Keys.type.rawValue: CoralogixEventType.log.rawValue],
+                    Keys.sessionContext.rawValue: [Keys.userEmail.rawValue: "redacted@coralogix.com"]
+                ]
+            ]
+        ]
+        exporter.sendBeforeSendData(data: [logEvent])
+
+        let uploaded = try XCTUnwrap(uploader.uploaded?.first)
+        XCTAssertNil(uploaded[Keys.instrumentationData.rawValue],
+                     "events without instrumentation_data must not gain an otelSpan section")
+        let cxRum = try textCxRum(of: uploaded)
+        let email = (cxRum[Keys.sessionContext.rawValue] as? [String: Any])?[Keys.userEmail.rawValue] as? String
+        XCTAssertEqual(email, "redacted@coralogix.com", "the edited text must be uploaded verbatim")
+    }
+}


### PR DESCRIPTION
## Summary

On the hybrid (React Native / Flutter) path, a `beforeSend` edit to an editable `cx_rum` field reached `text.cx_rum` but **not** `instrumentation_data.otelSpan.attributes`, so the tracing mirror stayed stale (e.g. a redacted `user_email` still leaked through tracing). This PR rebuilds the OTEL attributes from the edited `cx_rum` before upload, so both destinations of a span carry identical values.

## Problem

The CX-44686 rebuild of `otelSpan.attributes` from the post-`beforeSend` `cx_rum` runs only on the **native** single-event path (`CxSpan.getDictionary()`, gated on `beforeSend != nil`). The hybrid path uses the array `beforeSendCallBack`: spans are encoded **before** the JS edit, and `sendBeforeSendData → SpanUploader.upload` uploads the edited batch **verbatim** — so the rebuild never ran. Confirmed at runtime on 2.9.1 for network-request spans (`user_email` redacted in `text.cx_rum`, original in `otelSpan.attributes`).

## Fix

In `CoralogixExporter.sendBeforeSendData(data:)`, rebuild each event's `instrumentation_data.otelSpan.attributes` from the edited `text.cx_rum` via `OtelSpan`'s existing dict-based attribute builder — the same logic the native path uses. Events without `instrumentation_data` (anything but network-request / custom-span) pass through unchanged. Native single-event `beforeSend` behavior is untouched.

### Page preservation (from review)

A code-review pass flagged that the rebuild originally re-derived `page_url`/`page_fragments` from the **live** `viewManager` at callback time. A span belongs to the view active when it was created — the same snapshot `text.cx_rum.view_context` froze — and on a host using **native navigation** the view can advance during the bridge round-trip, which would drift `otelSpan.attributes` to a different page than the span's origin and disagree with `text.cx_rum`.

The rebuild now uses `OtelSpan.rebuiltAttributes(fromCxRumDict:preservingPageFrom:mobileSdkVersion:)`, which builds from the edited `cx_rum` but **carries the page fields over from the encode-time attributes** (and no longer reads the live `viewManager`). Two related review suggestions were considered and **not** applied, with reasons:
- Reading `page_url` from the dict's `view_context` is not behavior-preserving — `view_context` may hold the *previous* view (`getPrevDictionary()`), while `page_url` is the *current* view; the builder is shared with the native path.
- Further consolidation with `CxSpan.addInstrumentationData` was declined — the attribute build is already shared; the remaining lines differ only because the inputs differ (live `CxSpan` vs. serialized dict).

## Test plan

- New `HybridBeforeSendInstrumentationDataTests` (4 tests): network-request and custom-span edits propagate into **both** `text.cx_rum` and `otelSpan.attributes`; non-instrumented events pass through verbatim; and `page_url` is preserved from encode time even when the view advances before the callback. Includes a pre-edit falsifiability anchor (asserts the encoded attrs carry the original value, so the test fails without the fix).
- Full `CoralogixRumTests` target: **728 tests, 0 failures** on iPhone 17 Pro simulator.

## Pre-PR checklist

- ✅ Code review (`/pr-review`) — no blockers; review follow-up (page preservation) applied
- ✅ Ticket scope — matches CX-46400 acceptance criteria
- ✅ Test coverage — new behavior covered; full suite green
- ✅ Version sync — patch bump **2.9.1 → 2.9.2** across the 4 files
- ✅ CHANGELOG — `[2.9.2]` entry under Fixed
- ✅ README — checked; no new/changed public API, SPM install uses git tag (no pinned version)

🤖 Generated with [Claude Code](https://claude.com/claude-code)