### PR TITLE
ci(publish-pods): recover from GitHub commit API timeout on trunk push

### DIFF
--- a/.github/workflows/publish-pods.yml
+++ b/.github/workflows/publish-pods.yml
@@ -72,36 +72,38 @@ jobs:
             
             if [ $push_exit_code -eq 0 ]; then
               echo "✅ CoralogixInternal.podspec pushed!"
-              
-              # Wait for CoralogixInternal to become available
-              echo "⏳ Waiting for CoralogixInternal to be available in CocoaPods Specs..."
-              timeout=1800
-              elapsed=0
-              until pod trunk info CoralogixInternal | grep -q "${TAG_RAW}"; do
-                if [ "$elapsed" -ge "$timeout" ]; then
-                  echo "❌ Timeout: CoralogixInternal not available after $timeout seconds."
-                  exit 1
-                fi
-                echo "⏳ CoralogixInternal not yet available, waiting 30 seconds..."
-                sleep 30
-                elapsed=$((elapsed + 30))
-              done
-              echo "✅ CoralogixInternal is now available on trunk. Updating local CDN cache..."
-              pod repo update
-              echo "✅ Local CDN cache updated."
+            elif echo "$push_output" | grep -q "Unable to accept duplicate entry"; then
+              echo "⚠️ Duplicate entry detected for CoralogixInternal (already on Trunk)."
+            elif pod trunk info CoralogixInternal | grep -Eq "^[[:space:]]*-[[:space:]]*${TAG_RAW}([[:space:]]|\(|$)"; then
+              # A client-side failure (e.g. "Calling the GitHub commit API timed out")
+              # frequently still lands the spec server-side. Trust Trunk, not the exit code.
+              echo "✅ CoralogixInternal ${TAG_RAW} is on Trunk — push landed despite a client error."
             else
-              if echo "$push_output" | grep -q "Unable to accept duplicate entry"; then
-                echo "⚠️ Duplicate entry detected for CoralogixInternal, skipping to next phase..."
-              elif pod trunk info CoralogixInternal | grep -Eq "^[[:space:]]*-[[:space:]]*${TAG_RAW}([[:space:]]|\(|$)"; then
-                # A client-side failure (e.g. "Calling the GitHub commit API timed out")
-                # frequently still lands the spec server-side. Trust Trunk, not the exit code.
-                echo "✅ CoralogixInternal ${TAG_RAW} is on Trunk — push landed despite a client error."
-              else
-                echo "❌ Error pushing CoralogixInternal.podspec:"
-                echo "$push_output"
+              echo "❌ Error pushing CoralogixInternal.podspec:"
+              echo "$push_output"
+              exit 1
+            fi
+
+            # CoralogixInternal is on Trunk now — fresh push, duplicate, or a client
+            # error that still landed server-side. SessionReplay/Coralogix depend on it,
+            # so wait for it to become available and refresh the local CDN cache before
+            # proceeding, regardless of which branch above confirmed it. (The genuine
+            # error case already exited.)
+            echo "⏳ Waiting for CoralogixInternal to be available in CocoaPods Specs..."
+            timeout=1800
+            elapsed=0
+            until pod trunk info CoralogixInternal | grep -q "${TAG_RAW}"; do
+              if [ "$elapsed" -ge "$timeout" ]; then
+                echo "❌ Timeout: CoralogixInternal not available after $timeout seconds."
                 exit 1
               fi
-            fi
+              echo "⏳ CoralogixInternal not yet available, waiting 30 seconds..."
+              sleep 30
+              elapsed=$((elapsed + 30))
+            done
+            echo "✅ CoralogixInternal is now available on trunk. Updating local CDN cache..."
+            pod repo update
+            echo "✅ Local CDN cache updated."
           fi
 
       # Clear CocoaPods cache

--- a/.github/workflows/publish-pods.yml
+++ b/.github/workflows/publish-pods.yml
@@ -92,6 +92,10 @@ jobs:
             else
               if echo "$push_output" | grep -q "Unable to accept duplicate entry"; then
                 echo "⚠️ Duplicate entry detected for CoralogixInternal, skipping to next phase..."
+              elif pod trunk info CoralogixInternal | grep -Eq "^[[:space:]]*-[[:space:]]*${TAG_RAW}([[:space:]]|\(|$)"; then
+                # A client-side failure (e.g. "Calling the GitHub commit API timed out")
+                # frequently still lands the spec server-side. Trust Trunk, not the exit code.
+                echo "✅ CoralogixInternal ${TAG_RAW} is on Trunk — push landed despite a client error."
               else
                 echo "❌ Error pushing CoralogixInternal.podspec:"
                 echo "$push_output"
@@ -140,11 +144,19 @@ jobs:
                 break
               fi
 
-              # CocoaPods CDN/spec propagation can lag after pushing dependencies.
-              # Retry only on dependency-resolution errors.
-              if echo "$push_output" | grep -Eq "Unable to find a specification for|None of your spec sources contain|required by"; then
+              # A client-side failure (e.g. "Calling the GitHub commit API timed out")
+              # frequently still lands the spec server-side. Trust Trunk, not the exit code.
+              if pod trunk info SessionReplay | grep -Eq "^[[:space:]]*-[[:space:]]*${TAG_RAW}([[:space:]]|\(|$)"; then
+                echo "✅ SessionReplay ${TAG_RAW} is on Trunk — push landed despite a client error."
+                pushed=true
+                break
+              fi
+
+              # Retry on CDN/spec propagation lag AND transient Trunk/GitHub failures
+              # (the GitHub commit API times out intermittently mid-push).
+              if echo "$push_output" | grep -Eq "Unable to find a specification for|None of your spec sources contain|required by|GitHub commit API timed out|timed out|Timeout|50[234]|Net::|Connection reset|getaddrinfo"; then
                 if [ "$attempt" -lt "$max_attempts" ]; then
-                  echo "⏳ Dependency not resolvable yet (likely CDN propagation). Retrying in ${retry_sleep_seconds}s..."
+                  echo "⏳ Not resolvable yet (CDN propagation or transient Trunk/GitHub error). Retrying in ${retry_sleep_seconds}s..."
                   sleep "$retry_sleep_seconds"
                   attempt=$((attempt + 1))
                   continue
@@ -195,11 +207,19 @@ jobs:
                 break
               fi
 
-              # CocoaPods CDN/spec propagation can lag after pushing dependencies.
-              # Retry only on dependency-resolution errors.
-              if echo "$push_output" | grep -Eq "Unable to find a specification for|None of your spec sources contain|required by"; then
+              # A client-side failure (e.g. "Calling the GitHub commit API timed out")
+              # frequently still lands the spec server-side. Trust Trunk, not the exit code.
+              if pod trunk info Coralogix | grep -Eq "^[[:space:]]*-[[:space:]]*${TAG_RAW}([[:space:]]|\(|$)"; then
+                echo "✅ Coralogix ${TAG_RAW} is on Trunk — push landed despite a client error."
+                pushed=true
+                break
+              fi
+
+              # Retry on CDN/spec propagation lag AND transient Trunk/GitHub failures
+              # (the GitHub commit API times out intermittently mid-push).
+              if echo "$push_output" | grep -Eq "Unable to find a specification for|None of your spec sources contain|required by|GitHub commit API timed out|timed out|Timeout|50[234]|Net::|Connection reset|getaddrinfo"; then
                 if [ "$attempt" -lt "$max_attempts" ]; then
-                  echo "⏳ Dependency not resolvable yet (likely CDN propagation). Retrying in ${retry_sleep_seconds}s..."
+                  echo "⏳ Not resolvable yet (CDN propagation or transient Trunk/GitHub error). Retrying in ${retry_sleep_seconds}s..."
                   sleep "$retry_sleep_seconds"
                   attempt=$((attempt + 1))
                   continue

--- a/.github/workflows/publish-pods.yml
+++ b/.github/workflows/publish-pods.yml
@@ -61,7 +61,10 @@ jobs:
         run: |
           set -euo pipefail
           echo "Target version: ${TAG_RAW}"
-          if pod trunk info CoralogixInternal | grep -Eq "^[[:space:]]*-[[:space:]]*${TAG_RAW}([[:space:]]|\(|$)"; then
+          # Escape the tag for literal use in the version-match regexes below
+          # (a bare semver like 2.10.0 contains regex-special dots).
+          TAG_RE=$(printf '%s' "$TAG_RAW" | sed 's/[^[:alnum:]]/\\&/g')
+          if pod trunk info CoralogixInternal | grep -Eq "^[[:space:]]*-[[:space:]]*${TAG_RE}([[:space:]]|\(|$)"; then
             echo "ℹ️  CoralogixInternal ${TAG_RAW} already on Trunk. Skipping push."
           else
             echo "🚀 Pushing CoralogixInternal.podspec..."
@@ -74,7 +77,7 @@ jobs:
               echo "✅ CoralogixInternal.podspec pushed!"
             elif echo "$push_output" | grep -q "Unable to accept duplicate entry"; then
               echo "⚠️ Duplicate entry detected for CoralogixInternal (already on Trunk)."
-            elif pod trunk info CoralogixInternal | grep -Eq "^[[:space:]]*-[[:space:]]*${TAG_RAW}([[:space:]]|\(|$)"; then
+            elif pod trunk info CoralogixInternal | grep -Eq "^[[:space:]]*-[[:space:]]*${TAG_RE}([[:space:]]|\(|$)"; then
               # A client-side failure (e.g. "Calling the GitHub commit API timed out")
               # frequently still lands the spec server-side. Trust Trunk, not the exit code.
               echo "✅ CoralogixInternal ${TAG_RAW} is on Trunk — push landed despite a client error."
@@ -92,7 +95,7 @@ jobs:
             echo "⏳ Waiting for CoralogixInternal to be available in CocoaPods Specs..."
             timeout=1800
             elapsed=0
-            until pod trunk info CoralogixInternal | grep -q "${TAG_RAW}"; do
+            until pod trunk info CoralogixInternal | grep -Eq "^[[:space:]]*-[[:space:]]*${TAG_RE}([[:space:]]|\(|$)"; do
               if [ "$elapsed" -ge "$timeout" ]; then
                 echo "❌ Timeout: CoralogixInternal not available after $timeout seconds."
                 exit 1
@@ -118,7 +121,10 @@ jobs:
         run: |
           set -euo pipefail
           echo "Target version: ${TAG_RAW}"
-          if pod trunk info SessionReplay | grep -Eq "^[[:space:]]*-[[:space:]]*${TAG_RAW}([[:space:]]|\(|$)"; then
+          # Escape the tag for literal use in the version-match regexes below
+          # (a bare semver like 2.10.0 contains regex-special dots).
+          TAG_RE=$(printf '%s' "$TAG_RAW" | sed 's/[^[:alnum:]]/\\&/g')
+          if pod trunk info SessionReplay | grep -Eq "^[[:space:]]*-[[:space:]]*${TAG_RE}([[:space:]]|\(|$)"; then
             echo "ℹ️ SessionReplay ${TAG_RAW} already on Trunk. Skipping push."
           else
             echo "🚀 Pushing SessionReplay.podspec..."
@@ -148,7 +154,7 @@ jobs:
 
               # A client-side failure (e.g. "Calling the GitHub commit API timed out")
               # frequently still lands the spec server-side. Trust Trunk, not the exit code.
-              if pod trunk info SessionReplay | grep -Eq "^[[:space:]]*-[[:space:]]*${TAG_RAW}([[:space:]]|\(|$)"; then
+              if pod trunk info SessionReplay | grep -Eq "^[[:space:]]*-[[:space:]]*${TAG_RE}([[:space:]]|\(|$)"; then
                 echo "✅ SessionReplay ${TAG_RAW} is on Trunk — push landed despite a client error."
                 pushed=true
                 break
@@ -181,7 +187,10 @@ jobs:
         run: |
           set -euo pipefail
           echo "Target version: ${TAG_RAW}"
-          if pod trunk info Coralogix | grep -Eq "^[[:space:]]*-[[:space:]]*${TAG_RAW}([[:space:]]|\(|$)"; then
+          # Escape the tag for literal use in the version-match regexes below
+          # (a bare semver like 2.10.0 contains regex-special dots).
+          TAG_RE=$(printf '%s' "$TAG_RAW" | sed 's/[^[:alnum:]]/\\&/g')
+          if pod trunk info Coralogix | grep -Eq "^[[:space:]]*-[[:space:]]*${TAG_RE}([[:space:]]|\(|$)"; then
             echo "ℹ️ Coralogix ${TAG_RAW} already on Trunk. Skipping push."
           else
             echo "🚀 Pushing Coralogix.podspec..."
@@ -211,7 +220,7 @@ jobs:
 
               # A client-side failure (e.g. "Calling the GitHub commit API timed out")
               # frequently still lands the spec server-side. Trust Trunk, not the exit code.
-              if pod trunk info Coralogix | grep -Eq "^[[:space:]]*-[[:space:]]*${TAG_RAW}([[:space:]]|\(|$)"; then
+              if pod trunk info Coralogix | grep -Eq "^[[:space:]]*-[[:space:]]*${TAG_RE}([[:space:]]|\(|$)"; then
                 echo "✅ Coralogix ${TAG_RAW} is on Trunk — push landed despite a client error."
                 pushed=true
                 break


### PR DESCRIPTION
# User description
## Why

The CocoaPods publish workflow is **flaky on every release**. `pod trunk push` intermittently exits non-zero with:

```
[!] Calling the GitHub commit API timed out. Please check GitHub's status... and try again later.
```

…even though the spec **lands on Trunk server-side**. On the 2.9.2 release run, the lint build passed and `SessionReplay 2.9.2` actually published, but the timeout exit code was treated as a hard failure — which skipped the final `Coralogix` push and left the release half-published.

The retry loops only retried CDN/dependency-resolution errors (`Unable to find a specification for`, `None of your spec sources contain`, `required by`), so this transient GitHub-API timeout fell straight through to `exit 1`.

## What

For all three pods (`CoralogixInternal`, `SessionReplay`, `Coralogix`):

1. **After a non-zero push, re-check Trunk** for the target version and treat its presence as success — the timeout commonly lands the spec anyway, so trust Trunk over the client exit code.
2. **Retry on the timeout / transient errors too** — added `GitHub commit API timed out`, `timed out`, `Timeout`, `50[234]`, `Net::`, `Connection reset`, `getaddrinfo` to the retryable patterns (alongside the existing CDN-propagation ones).

This is **CI/release-infra only** — no SDK source, version, CHANGELOG, or README impact.

## Test

YAML validated. Logic mirrors the existing idempotency check already used at the top of each step (`pod trunk info <Pod> | grep -E ...${TAG_RAW}`). Real-world validation will be the next release run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Revise the publish-pods workflow to reverify each <code>pod trunk</code> push by checking <code>pod trunk info</code> with escaped <code>TAG_RAW</code> so the job trusts Trunk’s state instead of intermittent client failures. Add retries and CDN wait adjustments for CoralogixInternal, SessionReplay, and Coralogix pushes so transient GitHub-API timeouts no longer block the release flow.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/228?tool=ast&topic=Trunk+Re-checks>Trunk Re-checks</a>
        </td><td>Reverify each pushed pod by matching the escaped <code>TAG_RAW</code> against <code>pod trunk info</code>, trusting Trunk when duplicates or timeout errors still land the spec and waiting for the CDN cache to refresh before moving on.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/publish-pods.yml</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>ci(publish-pods): esca...</td><td>July 05, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/228?tool=ast&topic=Transient+Retries>Transient Retries</a>
        </td><td>Retry SessionReplay and Coralogix pushes for CDN propagation and transient GitHub/Trunk failures such as timeouts, HTTP 50x, and network resets so the CI loop keeps trying before declaring errors.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/publish-pods.yml</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>ci(publish-pods): esca...</td><td>July 05, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/coralogix/cx-ios-sdk/228?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>