### PR TITLE
docs(CX-46746): align README with SDK public features

### DIFF
--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -11,6 +11,7 @@ You are an expert software engineer performing a code review on a feature branch
 2. Review readability, maintainability, and clarity of the new code.
 3. Flag security, performance, or concurrency concerns introduced by the changes.
 4. Suggest improvements only where the new code itself can be improved.
+5. **README coverage.** If the branch adds or changes a user-facing SDK feature or public API — a new `public` symbol, a new `CoralogixExporterOptions` parameter or `InstrumentationType` / mobile-vital case, or a new method on `CoralogixRum` — verify `README.md` documents it **with usage instructions**. Flag any new public feature that isn't in the README as a gap. The README must stay aligned with the SDK's public feature set; drifting out of sync is a recurring problem (a dedicated ticket, CX-46746, existed just to re-align it). Quick check: grep the diff for added `public func` / `public var` / new option parameters, then confirm each has a matching README section. Hybrid-bridge / internal APIs (React Native / Flutter plumbing) are exempt.
 
 **Guidelines:**
 - Be precise and reference specific lines or diff sections when possible.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The SDK provides mobile Telemetry instrumentation that captures:
 
 1. HTTP requests, using URLSession instrumentation
 2. Unhandled exceptions (NSException, NSError, Error)
-3. Custom Logs ()
+3. Custom Logs
 4. Crashes - using PLCrashReporter
 5. Page navigation (Swift use swizzling / SwiftUI use modifier)
 6. User Actions (Clicks - UI elements)
@@ -344,6 +344,91 @@ let options = CoralogixExporterOptions(coralogixDomain: CORALOGIX-DOMAIN,
 
 ### Session Recording
 See the [Session Recording Guide](SessionReplay/Sources/Docs/README.md) for installation steps and examples.
+
+### Error Reporting
+Report handled errors, caught exceptions, or custom error messages manually — this is separate from the automatic crash / unhandled-exception capture. Each call produces an error event in RUM.
+```swift
+// An NSException you caught
+coralogixRum.reportError(exception: someNSException)
+
+// A Swift Error / NSError
+do {
+    try riskyOperation()
+} catch {
+    coralogixRum.reportError(error: error)
+}
+
+// A custom message with optional structured data
+coralogixRum.reportError(message: "Checkout failed",
+                         data: ["cart_size": 3, "reason": "timeout"])
+```
+
+### User Context
+Attach the current user's identity to every subsequent event. Call it after sign-in; pass a new `UserContext` to replace it (e.g. on account switch), and an empty context to clear it on sign-out.
+```swift
+coralogixRum.setUserContext(
+    userContext: UserContext(userId: "user-123",
+                             userName: "Jane Doe",
+                             userEmail: "jane.doe@example.com",
+                             userMetadata: ["plan": "premium", "role": "admin"])
+)
+```
+
+### Custom Logs
+Send a structured log at a chosen severity, with optional structured `data` and `labels`.
+```swift
+coralogixRum.log(severity: .info,
+                 message: "User completed onboarding",
+                 data: ["step_count": 4],
+                 labels: ["flow": "onboarding"])
+```
+Severity levels: `.debug`, `.verbose`, `.info`, `.warn`, `.error`, `.critical`.
+
+### Custom Spans
+Create your own OpenTelemetry spans to trace app-specific work (e.g. a checkout flow) with full control over attributes, events, and status. The custom tracer requires `traceParentInHeader` to be enabled in the options.
+```swift
+// 1. Enable the custom tracer in your options
+let options = CoralogixExporterOptions(coralogixDomain: CORALOGIX-DOMAIN,
+                                        environment: "ENVIRONMENT",
+                                        application: "APP-NAME",
+                                        version: "APP-VERSION",
+                                        publicKey: "API-KEY",
+                                        traceParentInHeader: ["enable": true])
+
+// 2. Open a global span, then child spans under it
+guard let tracer = coralogixRum.getCustomTracer() else { return }
+guard let global = tracer.startGlobalSpan(name: "checkout.flow",
+                                          labels: ["screen": "cart"]) else { return }
+
+let child = global.startCustomSpan(name: "checkout.authorize")
+child.setAttribute(key: "step", value: "authorize")
+child.addEvent(name: "authorized")
+child.setStatus(.ok)
+child.endSpan()
+
+global.endSpan()
+```
+**Notes:**
+- `getCustomTracer()` returns `nil` unless `traceParentInHeader: ["enable": true]` is set.
+- While a global span is open it becomes OpenTelemetry's active context, so auto-instrumentation (e.g. `URLSession`) shares the same `traceId` until you call `endSpan()`.
+- Only one global span may be open at a time — a second `startGlobalSpan` returns `nil` until the first one ends.
+- Use `getCustomTracer(ignoredInstruments: [.networkRequests, .errors])` to exclude specific auto-instruments from the span's trace.
+
+### Custom Measurement
+Report a one-off numeric measurement (e.g. a computed score or payload size) as a `custom-measurement` event. To time a span of work instead, use [Custom Time Measurement](#custom-time-measurement).
+```swift
+coralogixRum.sendCustomMeasurement(name: "image_load_score", value: 43.0)
+```
+
+### Manual View & Application Context
+Override the automatically-tracked screen name, or update the reported application name / version at runtime.
+```swift
+// Set the current screen/view name manually (useful for custom navigation)
+coralogixRum.setView(name: "CheckoutScreen")
+
+// Update the application name / version reported on subsequent events
+coralogixRum.setApplicationContext(application: "MyApp", version: "2.5.0")
+```
 
 ### Custom Time Measurement
 Time arbitrary spans of work in your app code with `startTimeMeasure(name:labels:)` and `endTimeMeasure(name:)`. Use this when you need to measure something the SDK can't auto-instrument — checkout flows, custom render passes, asset loading, etc. The duration is reported as a `custom-measurement` span (milliseconds).


### PR DESCRIPTION
# User description
## What

Aligns the iOS SDK README with the SDK's public feature set — every public, user-facing feature is now documented **with usage instructions** (CX-46746). Also adds a README-coverage step to the `/pr-review` skill so this drift can't recur.

## Why

Several public APIs had no README coverage — most notably **custom spans** (the gap called out in the ticket), plus error reporting, user context, custom logs, custom measurement, and the manual view/application-context setters.

## Changes

- **`README.md`** — six new sections, each with an example verified against the real signatures and the demo apps:
  - Error Reporting (`reportError(exception:/error:/message:data:)`)
  - User Context (`setUserContext` + `UserContext`)
  - Custom Logs (`log(severity:message:data:labels:)` + severity levels)
  - Custom Spans (`getCustomTracer` → `startGlobalSpan`/`startCustomSpan`, incl. the `traceParentInHeader` precondition and active-context / single-global notes)
  - Custom Measurement (`sendCustomMeasurement`)
  - Manual View & Application Context (`setView`, `setApplicationContext`)
  - fixed the stray empty parens on the intro "Custom Logs" line
- **`.claude/commands/pr-review.md`** — new "README coverage" review task: flags any new public feature/option that isn't documented (hybrid-bridge / internal APIs exempt).

## Not changed (deliberately)

- No Swift source touched → **no version bump and no CHANGELOG entry** (docs-only; the compiled SDK is unchanged, so bumping would force a needless release).
- Already-documented features (instrumentations, ignore rules, before-send, mobile vitals, session recording, custom time measurement, etc.) left as-is.

## Testing

Docs-only — verified every example against the actual API and existing demo-app usage; markdown code fences balanced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Document the iOS SDK's public user-facing APIs in the README by providing usage examples for error reporting, user context, custom logs, custom spans, custom measurements, and manual view/application context setters. Add a README coverage check to the <code>/pr-review</code> skill so future public API additions stay documented.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/229?tool=ast&topic=Review+Task>Review Task</a>
        </td><td>Add a README coverage step to the review command list so reviewers flag any new public feature that lacks documentation in the README.<details><summary>Modified files (1)</summary><ul><li>.claude/commands/pr-review.md</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>docs(): align README w...</td><td>July 01, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/229?tool=ast&topic=README+Coverage>README Coverage</a>
        </td><td>Document every user-facing SDK feature in the README with usage instructions, covering error reporting, user context, custom logs, custom spans, custom measurements, and the manual view/application context setters so the public feature set remains aligned.<details><summary>Modified files (1)</summary><ul><li>README.md</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>docs(): align README w...</td><td>July 01, 2026</td></tr>
<tr><td>naftaly@users.noreply....</td><td>Fix typos and enhance ...</td><td>October 26, 2025</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/coralogix/cx-ios-sdk/229?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>