### PR TITLE
feat(CX-48135): add createNewSession() public API to rotate session on demand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Release-mechanics commits (version bumps, podspec/script tweaks, README edits) a
 omitted; the focus here is user-facing behavior changes. Tickets are referenced as
 `CX-XXXXX` (Jira) or `ALPH-XXXX` (legacy). Pull request numbers are in parentheses.
 
+## [2.10.0] - 2026-07-05
+
+### Added
+- `createNewSession()` on `CoralogixRum` — force-starts a fresh RUM session on demand (e.g. on user logout) without a full `shutdown()` + `init()`. Issues a new session ID and resets the per-session state (views, error/click counters, snapshot throttle, Session Replay) — the same reset the automatic idle / max-age rotation performs.
+
 ## [2.9.2] - 2026-06-24
 
 ### Fixed

--- a/Coralogix.podspec
+++ b/Coralogix.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "Coralogix"
-  spec.version      = "2.9.2"
+  spec.version      = "2.10.0"
   spec.summary      = "Coralogix OpenTelemetry pod for iOS."
 
   spec.description  = <<-DESC
@@ -29,7 +29,7 @@ Pod::Spec.new do |spec|
 
   spec.static_framework = true
   spec.dependency 'PLCrashReporter', '~> 1.12'
-  spec.dependency 'CoralogixInternal', '2.9.2'
+  spec.dependency 'CoralogixInternal', '2.10.0'
 
   spec.test_spec 'Tests' do |test|
     test.source_files = 'Tests/CoralogixRumTests/**/*.swift'

--- a/Coralogix/Sources/CoralogixRum.swift
+++ b/Coralogix/Sources/CoralogixRum.swift
@@ -376,6 +376,18 @@ public class CoralogixRum {
     public var isInitialized: Bool { return CoralogixRum.isInitialized }
     
     public var getSessionId: String? { return self.sessionManager?.getSessionMetadata()?.sessionId }
+
+    /// Ends the current RUM session and immediately starts a fresh one —
+    /// e.g. on user logout — without a full `shutdown()` + `init()`. Behaves
+    /// like the automatic idle / max-age rotation: a new session ID is issued
+    /// and the per-session state (views, error/click counters, snapshot
+    /// throttle, Session Replay) resets for the new session. The new ID rides
+    /// the next emitted span, so call `setView(name:)` afterwards for that span
+    /// to also carry a view number.
+    public func createNewSession() {
+        guard CoralogixRum.isInitialized else { return }
+        self.sessionManager?.setupSessionMetadata()
+    }
     
     public func setApplicationContext(application: String, version: String) {
         guard CoralogixRum.isInitialized else { return }

--- a/Coralogix/Sources/CoralogixRum.swift
+++ b/Coralogix/Sources/CoralogixRum.swift
@@ -379,11 +379,11 @@ public class CoralogixRum {
 
     /// Ends the current RUM session and immediately starts a fresh one —
     /// e.g. on user logout — without a full `shutdown()` + `init()`. Behaves
-    /// like the automatic idle / max-age rotation: a new session ID is issued
-    /// and the per-session state (views, error/click counters, snapshot
-    /// throttle, Session Replay) resets for the new session. The new ID rides
-    /// the next emitted span, so call `setView(name:)` afterwards for that span
-    /// to also carry a view number.
+    /// exactly like the automatic idle / max-age rotation: a new session ID is
+    /// issued and the per-session state (error/click counters, snapshot
+    /// throttle, Session Replay, view counter) resets. The current view is
+    /// carried into the new session as view #0, so its events keep their view
+    /// context automatically — no follow-up call needed.
     public func createNewSession() {
         guard CoralogixRum.isInitialized else { return }
         self.sessionManager?.setupSessionMetadata()

--- a/CoralogixInternal.podspec
+++ b/CoralogixInternal.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "CoralogixInternal"
-  spec.version      = "2.9.2"
+  spec.version      = "2.10.0"
   spec.summary      = "Coralogix Internal Package. This module is not for public use."
 
   spec.description  = <<-DESC

--- a/CoralogixInternal/Sources/Utils.swift
+++ b/CoralogixInternal/Sources/Utils.swift
@@ -16,7 +16,7 @@ public enum ImageFormat {
 }
 
 public enum Global: String {
-    case sdk = "2.9.2"
+    case sdk = "2.10.0"
     case swiftVersion = "5.9"
     case coralogixPath = "/browser/v1beta/logs"
     case sessionReplayPath = "/browser/alpha/sessionrecording"

--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ Force-start a fresh RUM session on demand — typically on user logout — witho
 // e.g. when the user logs out
 coralogixRum.createNewSession()
 ```
-On a logout → login flow, pair it with `setUserContext` for the new user, and call `setView(name:)` after the first screen appears so that session's first span carries a view number.
+On a logout → login flow, pair it with `setUserContext` for the new user. The current view carries into the new session automatically (as view #0), so events keep their view context without any extra call.
 
 ### Custom Logs
 Send a structured log at a chosen severity, with optional structured `data` and `labels`.

--- a/README.md
+++ b/README.md
@@ -374,6 +374,14 @@ coralogixRum.setUserContext(
 )
 ```
 
+### New Session on Logout
+Force-start a fresh RUM session on demand — typically on user logout — without a full `shutdown()` + `init()`. A new session ID is issued and the per-session state (views, error/click counters, snapshot throttle, Session Replay) resets, exactly like the automatic idle / max-age rotation.
+```swift
+// e.g. when the user logs out
+coralogixRum.createNewSession()
+```
+On a logout → login flow, pair it with `setUserContext` for the new user, and call `setView(name:)` after the first screen appears so that session's first span carries a view number.
+
 ### Custom Logs
 Send a structured log at a chosen severity, with optional structured `data` and `labels`.
 ```swift

--- a/SessionReplay.podspec
+++ b/SessionReplay.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "SessionReplay"
-  spec.version      = "2.9.2"
+  spec.version      = "2.10.0"
   spec.summary      = "Coralogix Session-Replay pod for iOS."
 
   spec.description  = <<-DESC
@@ -23,7 +23,7 @@ Pod::Spec.new do |spec|
   spec.static_framework = true
 
   spec.source_files  = 'SessionReplay/Sources/**/*.swift'
-  spec.dependency 'CoralogixInternal', '2.9.2'
+  spec.dependency 'CoralogixInternal', '2.10.0'
   
     spec.test_spec 'Tests' do |test|
         test.source_files = 'Tests/SessionReplayTests/**/*.swift'

--- a/Tests/CoralogixRumTests/CoralogixRumCreateNewSessionTests.swift
+++ b/Tests/CoralogixRumTests/CoralogixRumCreateNewSessionTests.swift
@@ -1,0 +1,93 @@
+//
+//  CoralogixRumCreateNewSessionTests.swift
+//
+//  Verifies the public `createNewSession()` API: on demand it rotates the
+//  session (fresh session ID), drives the rotation callbacks, and is a safe
+//  no-op when the SDK is not initialized.
+//
+
+import XCTest
+import CoralogixInternal
+@testable import Coralogix
+
+final class CoralogixRumCreateNewSessionTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        // Static SDK state can leak between tests if a prior init was not torn down.
+        CoralogixRum.isInitialized = false
+    }
+
+    func testCreateNewSession_rotatesSessionId() {
+        let rum = CoralogixRum(options: makeOptions())
+        defer { rum.shutdown() }
+
+        let oldSessionId = rum.getSessionId
+        XCTAssertNotNil(oldSessionId, "A session must exist after a successful init.")
+
+        rum.createNewSession()
+
+        let newSessionId = rum.getSessionId
+        XCTAssertNotNil(newSessionId)
+        XCTAssertNotEqual(oldSessionId, newSessionId,
+                          "createNewSession() must issue a fresh session ID.")
+    }
+
+    func testCreateNewSession_firesSessionRotationCallbacks() {
+        let rum = CoralogixRum(options: makeOptions())
+        defer { rum.shutdown() }
+
+        guard let sessionManager = rum.sessionManager else {
+            return XCTFail("SessionManager must exist after a successful init.")
+        }
+
+        // Callbacks fire synchronously inside setupSessionMetadata, so plain
+        // Bool flags are enough — no async wait needed.
+        var sessionEndedFired = false
+        var sessionChangedFired = false
+        sessionManager.sessionEndedCallback = { sessionEndedFired = true }
+        sessionManager.sessionChangedCallback = { _ in sessionChangedFired = true }
+
+        rum.createNewSession()
+
+        XCTAssertTrue(sessionEndedFired,
+                      "Rotating an existing session must fire sessionEndedCallback.")
+        XCTAssertTrue(sessionChangedFired,
+                      "createNewSession() must fire sessionChangedCallback with the new session ID.")
+    }
+
+    func testCreateNewSession_whenNotInitialized_isNoOp() {
+        let rum = CoralogixRum(options: makeOptions())
+        defer { rum.shutdown() }
+
+        let sessionIdBefore = rum.getSessionId
+        XCTAssertNotNil(sessionIdBefore)
+
+        // Simulate an uninitialized SDK (e.g. after shutdown or a sampled-out init).
+        CoralogixRum.isInitialized = false
+        rum.createNewSession()
+
+        XCTAssertEqual(rum.getSessionId, sessionIdBefore,
+                       "createNewSession() must be a no-op when the SDK is not initialized.")
+    }
+
+    // MARK: - Helpers
+
+    private func makeOptions() -> CoralogixExporterOptions {
+        return CoralogixExporterOptions(
+            coralogixDomain: .US2,
+            userContext: nil,
+            environment: "test",
+            application: "TestApp",
+            version: "1.0.0",
+            publicKey: "test-key",
+            ignoreUrls: [],
+            ignoreErrors: [],
+            labels: nil,
+            sessionSampleRate: 100,
+            excludeFromSampling: [],
+            instrumentations: nil,
+            debug: false
+        )
+    }
+}


### PR DESCRIPTION
# User description
## What

Adds a public `createNewSession()` to the iOS SDK — force-starts a fresh RUM session on demand (e.g. on user logout) **without** a full `shutdown()` + `init()` cycle.

Part of Epic **CX-48134** (from **PIPEV2-3243**) · ticket **CX-48135**.

## Why

A customer migrating RUM from Datadog needs to split the session on user logout without re-initializing the SDK. The SDK already rotates sessions internally on idle (15 min) / max-age (1 hr); this exposes that same, well-tested rotation as a public API.

## Changes

- **`CoralogixRum.createNewSession()`** — `guard isInitialized` → delegates to the existing `SessionManager.setupSessionMetadata()`, which issues a new session ID and cascades every per-session reset (views, error/click counters, snapshot throttle, Session Replay). No new state, no new locking, no visibility changes to internals.
- **Tests** (`CoralogixRumCreateNewSessionTests`): session ID rotates; `sessionEnded`/`sessionChanged` callbacks fire; no-op when uninitialized.
- **Version 2.9.2 → 2.10.0** (minor = new public API) across `Global.sdk` + the three podspecs.
- **CHANGELOG** 2.10.0 entry; **README** "New Session on Logout" section with usage.

## Behavior notes

- Pure delegation → identical result to an automatic idle / max-age rotation.
- The idle timer is intentionally **not** reset; the new session ID rides the next emitted span, so callers should `setView(name:)` after login for that span to carry a view number.
- No explicit "session start" event is emitted (consistent with automatic rotation).

## Testing

- `CoralogixRumCreateNewSessionTests` passes on the iPhone 17 simulator; full `CoralogixRumTests` suite green.

## Not in this PR

- CocoaPods publish (3 specs, in order) + git tag — release steps, performed after merge.
- Flutter / React Native bridges (CX-48137 / CX-48138) are separate tasks, blocked-by this + the Android task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Expose <code>createNewSession()</code> on <code>CoralogixRum</code> to invoke <code>SessionManager.setupSessionMetadata()</code>, letting callers trigger the same session reset flow used for idle/max-age rotations so logout flows can start a fresh RUM session without reinitializing the SDK. Document and package this new API by bumping the SDK/podspec versions, adding a changelog entry, and describing the logout usage pattern in the README.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/230?tool=ast&topic=Release+updates>Release updates</a>
        </td><td>Document and release the 2.10.0 SDK by adding the new changelog entry, README section, and bumping the <code>Global.sdk</code> constant plus all podspec versions/dependencies so the new public API ships with the updated metadata.<details><summary>Modified files (6)</summary><ul><li>CHANGELOG.md</li>
<li>Coralogix.podspec</li>
<li>CoralogixInternal.podspec</li>
<li>CoralogixInternal/Sources/Utils.swift</li>
<li>README.md</li>
<li>SessionReplay.podspec</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>feat(): add createNewS...</td><td>July 05, 2026</td></tr>
<tr><td>dan.gavrielov@coralogi...</td><td>fix(session-replay): m...</td><td>June 15, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/230?tool=ast&topic=Session+rotation+API>Session rotation API</a>
        </td><td>Enable <code>createNewSession()</code> to call <code>SessionManager.setupSessionMetadata()</code>, which rotates the session ID, fires the <code>sessionEnded</code>/<code>sessionChanged</code> callbacks, and leaves the per-session counters in their reset state without touching other initialization logic; cover the behavior with <code>CoralogixRumCreateNewSessionTests</code> to assert rotation and no-op semantics when the SDK is uninitialized.<details><summary>Modified files (2)</summary><ul><li>Coralogix/Sources/CoralogixRum.swift</li>
<li>Tests/CoralogixRumTests/CoralogixRumCreateNewSessionTests.swift</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>docs(): drop misleadin...</td><td>July 05, 2026</td></tr>
<tr><td>aking618</td><td>Allow clearing user co...</td><td>February 19, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/coralogix/cx-ios-sdk/230?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>