### PR TITLE
fix(CX-48780): reuse task span on resume so wire traceparent matches exported span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Release-mechanics commits (version bumps, podspec/script tweaks, README edits) a
 omitted; the focus here is user-facing behavior changes. Tickets are referenced as
 `CX-XXXXX` (Jira) or `ALPH-XXXX` (legacy). Pull request numbers are in parentheses.
 
+## [2.10.1] - 2026-07-09
+
+### Fixed
+- The `traceparent` header sent on an outgoing request and the network span exported for that request could land on different traces, so RUM spans could never be stitched to their backend traces (`traceParentInHeader` was effectively broken for correlation). A task created through a URLSession factory method (`dataTask(with:)`, `dataTask(with:completionHandler:)`, upload/download variants) was instrumented twice: the factory swizzle started the span whose `traceparent` went on the wire, then the resume swizzle started a second span that overwrote the first in the running-spans map and became the one exported — while the first span leaked, never ended. The resume path now reuses the task's existing span instead of starting a second one, so the wire `traceparent` and the exported network span always share the same trace id and span id, across every task-creation path (including bare-URL tasks that inject their header at resume).
+
 ## [2.10.0] - 2026-07-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ omitted; the focus here is user-facing behavior changes. Tickets are referenced 
 ## [2.10.1] - 2026-07-09
 
 ### Fixed
-- The `traceparent` header sent on an outgoing request and the network span exported for that request could land on different traces, so RUM spans could never be stitched to their backend traces (`traceParentInHeader` was effectively broken for correlation). A task created through a URLSession factory method (`dataTask(with:)`, `dataTask(with:completionHandler:)`, upload/download variants) was instrumented twice: the factory swizzle started the span whose `traceparent` went on the wire, then the resume swizzle started a second span that overwrote the first in the running-spans map and became the one exported — while the first span leaked, never ended. The resume path now reuses the task's existing span instead of starting a second one, so the wire `traceparent` and the exported network span always share the same trace id and span id, across every task-creation path (including bare-URL tasks that inject their header at resume).
+- The `traceparent` sent on an outgoing request now always shares the same trace as the network span the SDK reports for it, so RUM spans correlate with their backend traces instead of landing on a separate, unstitchable trace.
 
 ## [2.10.0] - 2026-07-05
 

--- a/Coralogix.podspec
+++ b/Coralogix.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "Coralogix"
-  spec.version      = "2.10.0"
+  spec.version      = "2.10.1"
   spec.summary      = "Coralogix OpenTelemetry pod for iOS."
 
   spec.description  = <<-DESC
@@ -29,7 +29,7 @@ Pod::Spec.new do |spec|
 
   spec.static_framework = true
   spec.dependency 'PLCrashReporter', '~> 1.12'
-  spec.dependency 'CoralogixInternal', '2.10.0'
+  spec.dependency 'CoralogixInternal', '2.10.1'
 
   spec.test_spec 'Tests' do |test|
     test.source_files = 'Tests/CoralogixRumTests/**/*.swift'

--- a/Coralogix/Sources/Otel/URLSession/URLSessionLogger.swift
+++ b/Coralogix/Sources/Otel/URLSession/URLSessionLogger.swift
@@ -52,6 +52,22 @@ class URLSessionLogger {
             return nil
         }
 
+        // A single task reaches this method twice: the task-factory swizzle starts the span and puts its
+        // traceparent on the wire, then the resume swizzle calls again for the same task id. Starting a
+        // second span here would overwrite the first in `runningSpans`, so the span that gets exported
+        // would carry a different trace id than the traceparent already sent on the wire — and the first
+        // span would leak, never ended. Reuse the existing span: only (re)inject headers with its context
+        // and return, without starting a new one. Tasks created from a bare URL have a factory span but no
+        // header on the wire yet (there was no request to inject into then); reusing the span here injects
+        // that same span's traceparent, so the wire and the exported span stay on one trace.
+        let existingSpan: (any Span)? = runningSpansQueue.sync { runningSpans[sessionTaskId] }
+        if let existingSpan {
+            guard shouldInjectHeaders, effectiveConfig.shouldInjectTracingHeaders?(request) ?? true else {
+                return nil
+            }
+            return instrumentedRequest(for: request, span: existingSpan, effectiveConfig: effectiveConfig)
+        }
+
         var attributes = [String: AttributeValue]()
 
         attributes[SemanticAttributes.httpMethod.rawValue] = AttributeValue.string(request.httpMethod ?? "unknown_method")

--- a/CoralogixInternal.podspec
+++ b/CoralogixInternal.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "CoralogixInternal"
-  spec.version      = "2.10.0"
+  spec.version      = "2.10.1"
   spec.summary      = "Coralogix Internal Package. This module is not for public use."
 
   spec.description  = <<-DESC

--- a/CoralogixInternal/Sources/Utils.swift
+++ b/CoralogixInternal/Sources/Utils.swift
@@ -16,7 +16,7 @@ public enum ImageFormat {
 }
 
 public enum Global: String {
-    case sdk = "2.10.0"
+    case sdk = "2.10.1"
     case swiftVersion = "5.9"
     case coralogixPath = "/browser/v1beta/logs"
     case sessionReplayPath = "/browser/alpha/sessionrecording"

--- a/SessionReplay.podspec
+++ b/SessionReplay.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "SessionReplay"
-  spec.version      = "2.10.0"
+  spec.version      = "2.10.1"
   spec.summary      = "Coralogix Session-Replay pod for iOS."
 
   spec.description  = <<-DESC
@@ -23,7 +23,7 @@ Pod::Spec.new do |spec|
   spec.static_framework = true
 
   spec.source_files  = 'SessionReplay/Sources/**/*.swift'
-  spec.dependency 'CoralogixInternal', '2.10.0'
+  spec.dependency 'CoralogixInternal', '2.10.1'
   
     spec.test_spec 'Tests' do |test|
         test.source_files = 'Tests/SessionReplayTests/**/*.swift'

--- a/Tests/CoralogixRumTests/TraceparentExportedSpanCorrelationTests.swift
+++ b/Tests/CoralogixRumTests/TraceparentExportedSpanCorrelationTests.swift
@@ -13,9 +13,10 @@
 //  A leaked, never ended). `TraceparentHeaderInjectionTests` only validate the header is W3C-shaped;
 //  they never compare it to the exported span — which is why that regression went unnoticed.
 //
-//  Coverage below spans the request-factory task paths that reach the resume swizzle. The completion-
-//  handler and no-completion request paths go red on the unfixed code (wire=A, exported=B); the
-//  bare-URL path is a regression guard for the same invariant (there the fix also stops span A leaking).
+//  Coverage below spans the task-creation paths that reach the resume swizzle. The completion-handler
+//  and no-completion request paths go red on the unfixed code (wire=A, exported=B); the bare-URL path
+//  is a regression guard for the same invariant (there the fix also stops span A leaking); the
+//  async/await `data(for:)` path confirms the invariant holds for Swift concurrency too.
 //
 
 import XCTest
@@ -237,6 +238,34 @@ final class TraceparentExportedSpanCorrelationTests: XCTestCase {
 
         let url = try XCTUnwrap(URL(string: "\(Self.baseURL)/bare-url"))
         URLSession.shared.dataTask(with: url).resume()
+
+        let spans = waitForNetworkSpans(url: url)
+        try assertExportedSpanMatchesWire(url: url, exportedSpans: spans)
+    }
+
+    // MARK: - async/await task
+
+    /// `data(for:)` — the async/await path. Routed through a dedicated session with the stub pinned in
+    /// `configuration.protocolClasses`; the globally registered stub is removed first so the async path
+    /// resolves solely via the session's protocol list (registering the same class both globally and on
+    /// the session does not route reliably for async `data(for:)`). Confirms the wire `traceparent` and
+    /// the exported span stay correlated on the async path too.
+    @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
+    func test_asyncAwaitTask_exportedSpanMatchesWire() async throws {
+        URLProtocol.unregisterClass(CorrelationTestURLProtocol.self)
+        CorrelationTestURLProtocol.stub = (200, ["Content-Type": "application/json"], Data("{}".utf8))
+        startRUM()
+
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [CorrelationTestURLProtocol.self]
+        let session = URLSession(configuration: config)
+        defer { session.finishTasksAndInvalidate() }
+
+        let url = try XCTUnwrap(URL(string: "\(Self.baseURL)/async-await"))
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+
+        _ = try await session.data(for: request)
 
         let spans = waitForNetworkSpans(url: url)
         try assertExportedSpanMatchesWire(url: url, exportedSpans: spans)

--- a/Tests/CoralogixRumTests/TraceparentExportedSpanCorrelationTests.swift
+++ b/Tests/CoralogixRumTests/TraceparentExportedSpanCorrelationTests.swift
@@ -1,0 +1,244 @@
+//
+//  TraceparentExportedSpanCorrelationTests.swift
+//  CoralogixRumTests
+//
+//  Regression tests: the `traceparent` header injected into an outgoing request MUST carry the
+//  same trace id AND span id as the network span the SDK exports for that request. If they differ,
+//  backend spans (children of the wire traceparent) and the RUM span land on two different traces
+//  and can never be stitched — defeating the purpose of `traceParentInHeader`.
+//
+//  The defect this guards against: a task created via a URLSession factory method was instrumented
+//  twice — the factory swizzle made span A and put A's traceparent on the wire; the resume swizzle
+//  then made span B that overwrote A in `runningSpans`, so B was exported while the wire kept A (and
+//  A leaked, never ended). `TraceparentHeaderInjectionTests` only validate the header is W3C-shaped;
+//  they never compare it to the exported span — which is why that regression went unnoticed.
+//
+//  Coverage below spans the request-factory task paths that reach the resume swizzle. The completion-
+//  handler and no-completion request paths go red on the unfixed code (wire=A, exported=B); the
+//  bare-URL path is a regression guard for the same invariant (there the fix also stops span A leaking).
+//
+
+import XCTest
+import CoralogixInternal
+@testable import Coralogix
+
+// MARK: - URLProtocol stub for capturing the wire traceparent
+
+private final class CorrelationTestURLProtocol: URLProtocol {
+    static var stub: (status: Int, headers: [String: String], body: Data)?
+    static var lastTraceparentHeader: String?
+    static let scheme = "traceparentcorrelationtest"
+
+    private static func header(from request: URLRequest, named headerName: String) -> String? {
+        guard let fields = request.allHTTPHeaderFields else { return nil }
+        for (key, value) in fields where key.lowercased() == headerName.lowercased() {
+            return value
+        }
+        return nil
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        request.url?.scheme == scheme
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        Self.lastTraceparentHeader = Self.header(from: request, named: "traceparent")
+
+        guard let stub = Self.stub else {
+            client?.urlProtocol(self, didFailWithError: NSError(domain: "CorrelationTest", code: -1, userInfo: nil))
+            return
+        }
+        let url = request.url ?? URL(string: "\(Self.scheme)://localhost/")!
+        let response = HTTPURLResponse(url: url, statusCode: stub.status, httpVersion: nil, headerFields: stub.headers)!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: stub.body)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+
+    static func reset() {
+        stub = nil
+        lastTraceparentHeader = nil
+    }
+}
+
+// MARK: - Tests
+
+final class TraceparentExportedSpanCorrelationTests: XCTestCase {
+
+    static let baseURL = "traceparentcorrelationtest://correlation"
+    var rum: CoralogixRum?
+    var capturedSpans: [SpanData] = []
+    let captureLock = NSLock()
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        capturedSpans = []
+        CorrelationTestURLProtocol.reset()
+        URLProtocol.registerClass(CorrelationTestURLProtocol.self)
+        CoralogixExporter.testExportCallback = { [weak self] spans in
+            self?.captureLock.lock()
+            self?.capturedSpans.append(contentsOf: spans)
+            self?.captureLock.unlock()
+        }
+    }
+
+    override func tearDownWithError() throws {
+        rum = nil
+        CoralogixRum.isInitialized = false
+        CoralogixRum.resetCustomTracerIssuanceForTesting()
+        CoralogixExporter.testExportCallback = nil
+        captureLock.lock()
+        capturedSpans.removeAll(keepingCapacity: false)
+        captureLock.unlock()
+        CorrelationTestURLProtocol.reset()
+        URLProtocol.unregisterClass(CorrelationTestURLProtocol.self)
+        try super.tearDownWithError()
+    }
+
+    // MARK: - Helpers
+
+    func startRUM() {
+        let options = CoralogixExporterOptions(
+            coralogixDomain: .EU2,
+            userContext: nil,
+            environment: "test",
+            application: "TraceparentCorrelationTests",
+            version: "1.0",
+            publicKey: "test-key",
+            ignoreUrls: [],
+            ignoreErrors: [],
+            labels: [:],
+            sessionSampleRate: 100,
+            instrumentations: [.network: true],
+            traceParentInHeader: [Keys.enable.rawValue: true],
+            debug: true
+        )
+        rum = CoralogixRum(options: options)
+        XCTAssertTrue(CoralogixRum.isInitialized)
+    }
+
+    func forceFlush() {
+        (OpenTelemetry.instance.tracerProvider as? TracerProviderSdk)?.forceFlush(timeout: 3)
+        Thread.sleep(forTimeInterval: 0.5)
+    }
+
+    private func attributeString(_ value: AttributeValue?) -> String? {
+        if case let .string(s)? = value { return s }
+        return nil
+    }
+
+    /// Splits a W3C `traceparent` (version-traceid-spanid-flags) into its fields.
+    private func parseTraceparent(_ header: String) throws -> (traceId: String, spanId: String, flags: String) {
+        let parts = header.split(separator: "-", omittingEmptySubsequences: false).map(String.init)
+        guard parts.count == 4 else {
+            throw XCTSkip("traceparent is not W3C-shaped: \(header)")
+        }
+        return (parts[1], parts[2], parts[3])
+    }
+
+    /// Force-flushes and polls the captured spans until a network span for `url` appears (or timeout),
+    /// then returns every exported network span for that URL. Polling makes the delegate/async paths
+    /// robust against export timing without relying on a specific completion callback ordering.
+    private func waitForNetworkSpans(url: URL, timeout: TimeInterval = 8) -> [SpanData] {
+        let deadline = Date().addingTimeInterval(timeout)
+        repeat {
+            forceFlush()
+            captureLock.lock()
+            let spans = capturedSpans.filter {
+                attributeString($0.attributes[SemanticAttributes.httpUrl.rawValue]) == url.absoluteString
+            }
+            captureLock.unlock()
+            if !spans.isEmpty { return spans }
+            Thread.sleep(forTimeInterval: 0.1)
+        } while Date() < deadline
+        return []
+    }
+
+    /// THE invariant: exactly one network span is exported for the request, and its trace id AND span id
+    /// equal the trace id / parent-span id on the wire `traceparent`. Span-id equality (not just trace id)
+    /// is what pins the exported span to the exact span whose context went on the wire.
+    private func assertExportedSpanMatchesWire(url: URL,
+                                               exportedSpans: [SpanData],
+                                               file: StaticString = #filePath,
+                                               line: UInt = #line) throws {
+        let header = try XCTUnwrap(CorrelationTestURLProtocol.lastTraceparentHeader,
+                                   "traceparent must be injected on the wire when enabled",
+                                   file: file, line: line)
+        let wire = try parseTraceparent(header)
+        XCTAssertEqual(wire.traceId.count, 32, "wire trace id must be 32 hex chars, got: \(wire.traceId)", file: file, line: line)
+        XCTAssertEqual(wire.spanId.count, 16, "wire span id must be 16 hex chars, got: \(wire.spanId)", file: file, line: line)
+
+        XCTAssertEqual(exportedSpans.count, 1,
+                       "exactly one network span must be exported per request — more than one (or the wrong one) means the task was instrumented twice",
+                       file: file, line: line)
+
+        for span in exportedSpans {
+            XCTAssertEqual(span.traceId.hexString, wire.traceId,
+                           "exported network span is on a different trace than the wire traceparent (wire=\(wire.traceId) exported=\(span.traceId.hexString)) — backend spans parent to the wire trace, so the RUM span can never be stitched to them",
+                           file: file, line: line)
+            XCTAssertEqual(span.spanId.hexString, wire.spanId,
+                           "exported network span id differs from the wire traceparent parent-span id (wire=\(wire.spanId) exported=\(span.spanId.hexString)) — the exported span is not the one whose context was put on the wire",
+                           file: file, line: line)
+        }
+    }
+
+    // MARK: - Completion-handler request task (red→green)
+
+    /// `dataTask(with: request, completionHandler:)` — the path in the original bug report.
+    func test_completionHandlerRequestTask_exportedSpanMatchesWire() throws {
+        CorrelationTestURLProtocol.stub = (200, ["Content-Type": "application/json"], Data("{}".utf8))
+        startRUM()
+
+        let url = try XCTUnwrap(URL(string: "\(Self.baseURL)/completion-handler"))
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+
+        let exp = expectation(description: "request completes")
+        URLSession.shared.dataTask(with: request) { _, _, _ in exp.fulfill() }.resume()
+        wait(for: [exp], timeout: 5)
+
+        let spans = waitForNetworkSpans(url: url)
+        try assertExportedSpanMatchesWire(url: url, exportedSpans: spans)
+    }
+
+    // MARK: - Request task without completion handler (red→green)
+
+    /// `dataTask(with: request)` + `resume()` with no completion handler — the delegate/streaming
+    /// pattern (e.g. long-poll clients). The factory injects span A on the wire; the resume swizzle
+    /// used to export span B on a different trace. No completion handler here, so the SDK's own
+    /// FakeDelegate drives completion; the span is observed by polling the export callback.
+    func test_noCompletionHandlerRequestTask_exportedSpanMatchesWire() throws {
+        CorrelationTestURLProtocol.stub = (200, ["Content-Type": "application/json"], Data("{}".utf8))
+        startRUM()
+
+        let url = try XCTUnwrap(URL(string: "\(Self.baseURL)/no-completion"))
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+
+        URLSession.shared.dataTask(with: request).resume()
+
+        let spans = waitForNetworkSpans(url: url)
+        try assertExportedSpanMatchesWire(url: url, exportedSpans: spans)
+    }
+
+    // MARK: - Bare-URL task (regression guard)
+
+    /// `dataTask(with: url)` + `resume()`. The factory creates span A but injects nothing on the wire
+    /// (there is no request to inject into then); injection is completed at resume with the EXISTING
+    /// span's context. This guards that the fix keeps injecting for bare-URL tasks and that the wire
+    /// header matches the single exported span (previously span A leaked here, unended).
+    func test_bareURLTask_exportedSpanMatchesWire() throws {
+        CorrelationTestURLProtocol.stub = (200, ["Content-Type": "application/json"], Data("{}".utf8))
+        startRUM()
+
+        let url = try XCTUnwrap(URL(string: "\(Self.baseURL)/bare-url"))
+        URLSession.shared.dataTask(with: url).resume()
+
+        let spans = waitForNetworkSpans(url: url)
+        try assertExportedSpanMatchesWire(url: url, exportedSpans: spans)
+    }
+}

--- a/Tests/CoralogixRumTests/TraceparentExportedSpanCorrelationTests.swift
+++ b/Tests/CoralogixRumTests/TraceparentExportedSpanCorrelationTests.swift
@@ -132,18 +132,36 @@ final class TraceparentExportedSpanCorrelationTests: XCTestCase {
         return nil
     }
 
-    /// Splits a W3C `traceparent` (version-traceid-spanid-flags) into its fields.
-    /// A malformed header is a real failure (not a skip): if the SDK ever injects a non-W3C
-    /// `traceparent`, this test should go red rather than quietly pass.
+    /// Splits a W3C `traceparent` (version-traceid-spanid-flags) into its fields, validating full W3C
+    /// compliance first (each field lowercase hex of the spec length: version 2, traceid 32, spanid 16,
+    /// flags 2). A malformed header — wrong field count, non-hex, wrong length, or uppercase — is a real
+    /// failure (not a skip), so the regression test can't silently pass if the SDK ever injects a
+    /// non-W3C `traceparent`.
     private func parseTraceparent(_ header: String,
                                   file: StaticString = #filePath,
                                   line: UInt = #line) throws -> (traceId: String, spanId: String, flags: String) {
         let parts = header.split(separator: "-", omittingEmptySubsequences: false).map(String.init)
         let fields: (traceId: String, spanId: String, flags: String)? =
-            parts.count == 4 ? (parts[1], parts[2], parts[3]) : nil
+            Self.isW3CTraceparent(header) ? (parts[1], parts[2], parts[3]) : nil
         return try XCTUnwrap(fields,
-                             "traceparent is not W3C-shaped (expected 4 '-'-separated fields): \(header)",
+                             "traceparent is not W3C-compliant (version-traceid-spanid-flags, lowercase hex, lengths 2/32/16/2): \(header)",
                              file: file, line: line)
+    }
+
+    /// True when `header` is a fully W3C-compliant `traceparent`: exactly four `-`-separated fields
+    /// (version, trace id, span id, flags), each lowercase hex of length 2 / 32 / 16 / 2.
+    private static func isW3CTraceparent(_ header: String) -> Bool {
+        let parts = header.split(separator: "-", omittingEmptySubsequences: false).map(String.init)
+        return parts.count == 4
+            && isLowercaseHex(parts[0], length: 2)    // version
+            && isLowercaseHex(parts[1], length: 32)   // trace id
+            && isLowercaseHex(parts[2], length: 16)   // span id (parent id)
+            && isLowercaseHex(parts[3], length: 2)    // trace flags
+    }
+
+    /// True when `s` is exactly `length` lowercase-hex characters (`[0-9a-f]`).
+    private static func isLowercaseHex(_ s: String, length: Int) -> Bool {
+        s.count == length && s.allSatisfy { $0.isASCII && $0.isHexDigit && !$0.isUppercase }
     }
 
     /// Force-flushes and polls the captured spans until a network span for `url` appears (or timeout),
@@ -174,9 +192,8 @@ final class TraceparentExportedSpanCorrelationTests: XCTestCase {
         let header = try XCTUnwrap(CorrelationTestURLProtocol.lastTraceparentHeader,
                                    "traceparent must be injected on the wire when enabled",
                                    file: file, line: line)
+        // parseTraceparent already validates W3C shape/lengths (version 2, traceid 32, spanid 16, flags 2).
         let wire = try parseTraceparent(header, file: file, line: line)
-        XCTAssertEqual(wire.traceId.count, 32, "wire trace id must be 32 hex chars, got: \(wire.traceId)", file: file, line: line)
-        XCTAssertEqual(wire.spanId.count, 16, "wire span id must be 16 hex chars, got: \(wire.spanId)", file: file, line: line)
 
         XCTAssertEqual(exportedSpans.count, 1,
                        "exactly one network span must be exported per request — more than one (or the wrong one) means the task was instrumented twice",
@@ -274,5 +291,30 @@ final class TraceparentExportedSpanCorrelationTests: XCTestCase {
 
         let spans = waitForNetworkSpans(url: url)
         try assertExportedSpanMatchesWire(url: url, exportedSpans: spans)
+    }
+
+    // MARK: - traceparent validation (unit)
+
+    /// The correlation assertions lean on `parseTraceparent` rejecting anything that isn't a W3C
+    /// `traceparent`; if it accepted malformed headers, a broken injection could slip through green.
+    /// Pins the validator: a valid header parses into its fields, and non-hex / uppercase / wrong-length
+    /// / short headers are rejected.
+    func test_parseTraceparent_acceptsW3C_rejectsMalformed() throws {
+        let valid = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+        let fields = try parseTraceparent(valid)
+        XCTAssertEqual(fields.traceId, "0af7651916cd43dd8448eb211c80319c")
+        XCTAssertEqual(fields.spanId, "b7ad6b7169203331")
+        XCTAssertEqual(fields.flags, "01")
+
+        XCTAssertFalse(Self.isW3CTraceparent("zz-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"),
+                       "non-hex version (zz) must be rejected")
+        XCTAssertFalse(Self.isW3CTraceparent("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-gg"),
+                       "non-hex flags (gg) must be rejected")
+        XCTAssertFalse(Self.isW3CTraceparent("00-0AF7651916CD43DD8448EB211C80319C-b7ad6b7169203331-01"),
+                       "uppercase trace id must be rejected")
+        XCTAssertFalse(Self.isW3CTraceparent("00-0af7651916cd43dd8448eb211c80319c-b7ad6b71692033-01"),
+                       "wrong-length span id must be rejected")
+        XCTAssertFalse(Self.isW3CTraceparent("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331"),
+                       "missing flags field must be rejected")
     }
 }

--- a/Tests/CoralogixRumTests/TraceparentExportedSpanCorrelationTests.swift
+++ b/Tests/CoralogixRumTests/TraceparentExportedSpanCorrelationTests.swift
@@ -133,12 +133,17 @@ final class TraceparentExportedSpanCorrelationTests: XCTestCase {
     }
 
     /// Splits a W3C `traceparent` (version-traceid-spanid-flags) into its fields.
-    private func parseTraceparent(_ header: String) throws -> (traceId: String, spanId: String, flags: String) {
+    /// A malformed header is a real failure (not a skip): if the SDK ever injects a non-W3C
+    /// `traceparent`, this test should go red rather than quietly pass.
+    private func parseTraceparent(_ header: String,
+                                  file: StaticString = #filePath,
+                                  line: UInt = #line) throws -> (traceId: String, spanId: String, flags: String) {
         let parts = header.split(separator: "-", omittingEmptySubsequences: false).map(String.init)
-        guard parts.count == 4 else {
-            throw XCTSkip("traceparent is not W3C-shaped: \(header)")
-        }
-        return (parts[1], parts[2], parts[3])
+        let fields: (traceId: String, spanId: String, flags: String)? =
+            parts.count == 4 ? (parts[1], parts[2], parts[3]) : nil
+        return try XCTUnwrap(fields,
+                             "traceparent is not W3C-shaped (expected 4 '-'-separated fields): \(header)",
+                             file: file, line: line)
     }
 
     /// Force-flushes and polls the captured spans until a network span for `url` appears (or timeout),
@@ -169,7 +174,7 @@ final class TraceparentExportedSpanCorrelationTests: XCTestCase {
         let header = try XCTUnwrap(CorrelationTestURLProtocol.lastTraceparentHeader,
                                    "traceparent must be injected on the wire when enabled",
                                    file: file, line: line)
-        let wire = try parseTraceparent(header)
+        let wire = try parseTraceparent(header, file: file, line: line)
         XCTAssertEqual(wire.traceId.count, 32, "wire trace id must be 32 hex chars, got: \(wire.traceId)", file: file, line: line)
         XCTAssertEqual(wire.spanId.count, 16, "wire span id must be 16 hex chars, got: \(wire.spanId)", file: file, line: line)
 


### PR DESCRIPTION
# User description
## What & why

Escalated from Interface ([CX-48780](https://coralogix.atlassian.net/browse/CX-48780)): the `traceparent` sent on an outgoing request and the network span the SDK exported for that request landed on **different traces**, so RUM spans could never be stitched to their backend traces — `traceParentInHeader` was effectively broken for correlation.

**Root cause:** a URLSession task is instrumented twice. The factory swizzle starts span **A** (whose `traceparent` goes on the wire); then the resume swizzle calls `processAndLogRequest` again for the **same task id** and starts span **B**, which overwrites A in `runningSpans[taskId]`. The header merge keeps A on the wire, but completion exports B → wire = A, exported = B. Span A is also never ended (it leaks).

## The fix

One change, at the chokepoint both the factory swizzles and the resume hook call — `URLSessionLogger.processAndLogRequest`: **if a span already exists for this task id, reuse it** (only re-inject headers from its context) instead of starting a second one. `urlSessionTaskWillResume` is left untouched, so the async/await completion wiring is preserved. No new helpers, no header string literals.

## How it covers each task-creation path

| Path | Before | After |
|---|---|---|
| `dataTask(with: request, completionHandler:)` + resume (the report) | wire A, exported B, A leaks | reuse A → wire A = exported A ✅ |
| `dataTask(with: request)` + resume (no completion — delegate/streaming) | wire A, exported B, A leaks | reuse A → wire A = exported A ✅ |
| `dataTask(with: url)` + resume (bare URL; injects at resume) | wire B, exported B (coincidentally consistent) but A leaks | reuse A → wire A = exported A, no leak ✅ |
| `data(for:)` async/await | single span (no factory span to overwrite); the fix's reuse branch is inert | wire = exported, verified by test — injection works correctly on this path ✅ |

## Testing

- New `TraceparentExportedSpanCorrelationTests` (4 tests) asserts the exported span's trace id **and** span id equal the wire `traceparent`, plus exactly one span per request. The completion-handler and no-completion paths go **red→green** (verified by stashing the fix); the bare-URL path is a leak/regression guard; the async/await `data(for:)` path confirms correlation holds under Swift concurrency.
- No regressions: **129 tests** across the network + traceparent suites pass; existing `TraceparentHeaderInjectionTests` still green.

## Version

Patch bump **2.10.0 → 2.10.1** (all four version files) + CHANGELOG entry. No public API change → no README update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[CX-48780]: https://coralogix.atlassian.net/browse/CX-48780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Ensure URLSession instrumentation reuses the span already stored for a task so the injected <code>traceparent</code> matches the exported network span and no leaked spans persist. Document the regression coverage and ship version 2.10.1 metadata so downstream consumers see the fix that keeps trace/span correlation intact across URLSession flows.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/231?tool=ast&topic=Release+%26+correlation+tests>Release &amp; correlation tests</a>
        </td><td>Document the regression fix, bump <code>Coralogix</code>, <code>SessionReplay</code>, and <code>CoralogixInternal</code> pods to 2.10.1 (also updating <code>Global.sdk</code>) plus the changelog entry, aligning release metadata with the new <code>TraceparentExportedSpanCorrelationTests</code> that exercise completion-handler, delegate, bare-URL, and async flows to guarantee wire/header-to-exported-span correlation.<details><summary>Modified files (6)</summary><ul><li>CHANGELOG.md</li>
<li>Coralogix.podspec</li>
<li>CoralogixInternal.podspec</li>
<li>CoralogixInternal/Sources/Utils.swift</li>
<li>SessionReplay.podspec</li>
<li>Tests/CoralogixRumTests/TraceparentExportedSpanCorrelationTests.swift</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>docs(): make the 2.10....</td><td>July 09, 2026</td></tr>
<tr><td>dan.gavrielov@coralogi...</td><td>fix(session-replay): m...</td><td>June 15, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/231?tool=ast&topic=Task+span+reuse>Task span reuse</a>
        </td><td>Reuse the span stored in <code>runningSpans</code> when <code>URLSessionLogger.processAndLogRequest</code> runs again for the same task id, so resume hooks simply re-inject headers and return the original span instead of overwriting it (avoiding trace mismatch leaks).<details><summary>Modified files (1)</summary><ul><li>Coralogix/Sources/Otel/URLSession/URLSessionLogger.swift</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>fix(): reuse task span...</td><td>July 09, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/coralogix/cx-ios-sdk/231?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>