### PR TITLE
feat: truncate native crash stack traces (middle-out + thread cap + byte guard)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ omitted; the focus here is user-facing behavior changes. Tickets are referenced 
 ## [2.11.0] - 2026-07-12
 
 ### Added
-- `maxStackTraceFramesPerThread` (default 20) and `maxThreads` (default 2) on `CoralogixExporterOptions` bound the size of a native crash report. Each thread's stack is truncated middle-out — the top frames and the bottom frames are kept — so deep and recursive crashes still show both the crash site and the entry point, and the number of reported threads is capped with the crashing thread always retained. Oversized reports are then trimmed deterministically, so a large crash is no longer at risk of being cut mid-payload and corrupted on ingestion.
+- `maxStackTraceFramesPerThread` (default 20) on `CoralogixExporterOptions` bounds the size of a native crash report. Each thread's stack is truncated middle-out — the top frames and the bottom frames are kept — so deep and recursive crashes still show both the crash site and the entry point. If a report is still too large, the SDK deterministically reduces the number of threads it includes (always keeping the thread that crashed) until it fits, so a large crash is no longer at risk of being cut mid-payload and corrupted on ingestion.
 
 ## [2.10.1] - 2026-07-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Release-mechanics commits (version bumps, podspec/script tweaks, README edits) a
 omitted; the focus here is user-facing behavior changes. Tickets are referenced as
 `CX-XXXXX` (Jira) or `ALPH-XXXX` (legacy). Pull request numbers are in parentheses.
 
+## [2.11.0] - 2026-07-12
+
+### Added
+- `maxStackTraceFramesPerThread` (default 20) and `maxThreads` (default 2) on `CoralogixExporterOptions` bound the size of a native crash report. Each thread's stack is truncated middle-out — the top frames and the bottom frames are kept — so deep and recursive crashes still show both the crash site and the entry point, and the number of reported threads is capped with the crashing thread always retained. Oversized reports are then trimmed deterministically, so a large crash is no longer at risk of being cut mid-payload and corrupted on ingestion.
+
 ## [2.10.1] - 2026-07-09
 
 ### Fixed

--- a/Coralogix.podspec
+++ b/Coralogix.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "Coralogix"
-  spec.version      = "2.10.1"
+  spec.version      = "2.11.0"
   spec.summary      = "Coralogix OpenTelemetry pod for iOS."
 
   spec.description  = <<-DESC
@@ -29,7 +29,7 @@ Pod::Spec.new do |spec|
 
   spec.static_framework = true
   spec.dependency 'PLCrashReporter', '~> 1.12'
-  spec.dependency 'CoralogixInternal', '2.10.1'
+  spec.dependency 'CoralogixInternal', '2.11.0'
 
   spec.test_spec 'Tests' do |test|
     test.source_files = 'Tests/CoralogixRumTests/**/*.swift'

--- a/Coralogix/Sources/Exporter/CoralogixExporter.swift
+++ b/Coralogix/Sources/Exporter/CoralogixExporter.swift
@@ -257,8 +257,23 @@ public class CoralogixExporter: SpanExporter {
                                   options: self.options) else {
             return nil  // Span will be filtered out by compactMap
         }
-        
-        return cxSpan.getDictionary()
+
+        guard let record = cxSpan.getDictionary() else { return nil }
+
+        // Enforce the crash-payload byte budget against the fully-assembled record (post-beforeSend),
+        // so the measurement reflects the exact JSON that goes on the wire — not a build-time estimate.
+        // No-op for non-crash records (they carry no crash `threads`).
+        // Read via getAttribute (which stringifies the stored Int) — matching how ErrorContext reads
+        // triggered_by_thread; getAttributes()/attributeStringValue would surface it as a raw Int and
+        // miss it, leaving crashedIndex nil and risking a drop of the real crashed thread.
+        let crashedIndex = (otelSpan.getAttribute(forKey: Keys.crashedThreadIndex.rawValue) as? String)
+            .flatMap { Int($0) }
+        return Helper.fitCrashRecordToByteBudget(
+            record: record,
+            crashedIndex: crashedIndex,
+            frameCap: self.options.maxStackTraceFramesPerThread,
+            byteBudget: CoralogixExporterOptions.crashLogRecordByteBudget
+        )
     }
     
     private func isMatchesRegexPattern(string: String, regexs: [String]) -> Bool {

--- a/Coralogix/Sources/Exporter/CoralogixExporter.swift
+++ b/Coralogix/Sources/Exporter/CoralogixExporter.swift
@@ -262,14 +262,17 @@ public class CoralogixExporter: SpanExporter {
 
         // Enforce the crash-payload byte budget against the fully-assembled record (post-beforeSend),
         // so the measurement reflects the exact JSON that goes on the wire — not a build-time estimate.
-        // No-op for non-crash records (they carry no crash `threads`).
-        // Read via getAttribute (which stringifies the stored Int) — matching how ErrorContext reads
-        // triggered_by_thread; getAttributes()/attributeStringValue would surface it as a raw Int and
-        // miss it, leaving crashedIndex nil and risking a drop of the real crashed thread.
+        // No-op for non-crash records (they carry no `threads` attribute).
+        //
+        // The threads and crashed-index come from the SDK's own span attributes, not the record:
+        // beforeSend can reorder/drop/reshape error_context.threads, which would desync the index or
+        // hide the array from the guard. Read via getAttribute (it stringifies the stored values) —
+        // getAttributes()/attributeStringValue would surface the Int as a raw Int and miss it.
         let crashedIndex = (otelSpan.getAttribute(forKey: Keys.crashedThreadIndex.rawValue) as? String)
             .flatMap { Int($0) }
         return Helper.fitCrashRecordToByteBudget(
             record: record,
+            threadsTransport: otelSpan.getAttribute(forKey: Keys.threads.rawValue) as? String,
             crashedIndex: crashedIndex,
             frameCap: self.options.maxStackTraceFramesPerThread,
             byteBudget: CoralogixExporterOptions.crashLogRecordByteBudget

--- a/Coralogix/Sources/Instrumentation/CrashInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/CrashInstrumentation.swift
@@ -80,15 +80,11 @@ extension CoralogixRum {
     }
     
     private func createStackTrace(report: PLCrashReport, span: any Span) {
-        var allThreads = [PLCrashReportThreadInfo]()
-        for case let thread as PLCrashReportThreadInfo in report.threads {
-            allThreads.append(thread)
-        }
+        let allThreads = report.threads.compactMap { $0 as? PLCrashReportThreadInfo }
 
-        var crashedIndex: Int?
-        for (index, thread) in allThreads.enumerated() where thread.crashed {
-            span.setAttribute(key: Keys.triggeredByThread.rawValue, value: thread.threadNumber)
-            crashedIndex = index
+        let crashedIndex = allThreads.firstIndex(where: { $0.crashed })
+        if let crashedIndex {
+            span.setAttribute(key: Keys.triggeredByThread.rawValue, value: allThreads[crashedIndex].threadNumber)
         }
         span.setAttribute(key: Keys.totalThreads.rawValue, value: allThreads.count)
 

--- a/Coralogix/Sources/Instrumentation/CrashInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/CrashInstrumentation.swift
@@ -103,7 +103,6 @@ extension CoralogixRum {
         let threadsJson = Helper.buildTruncatedThreads(
             allFrames: allFrames,
             crashedIndex: crashedIndex,
-            maxThreads: options?.maxThreads ?? CoralogixExporterOptions.defaultMaxThreads,
             frameCap: options?.maxStackTraceFramesPerThread ?? CoralogixExporterOptions.defaultMaxStackTraceFramesPerThread,
             byteBudget: CoralogixExporterOptions.crashThreadsByteBudget
         )

--- a/Coralogix/Sources/Instrumentation/CrashInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/CrashInstrumentation.swift
@@ -80,17 +80,34 @@ extension CoralogixRum {
     }
     
     private func createStackTrace(report: PLCrashReport, span: any Span) {
-        var threads = [String]()
+        var allThreads = [PLCrashReportThreadInfo]()
         for case let thread as PLCrashReportThreadInfo in report.threads {
-            if thread.crashed {
-                span.setAttribute(key: Keys.triggeredByThread.rawValue, value: thread.threadNumber)
-            }
-            
-            let crashedThreadFrames = crashedThread(report: report, thread: thread)
-            let data = self.parseFrameArray(crashedThreadFrameArray: crashedThreadFrames)
-            threads.append(Helper.convertArrayToJsonString(array: data))
+            allThreads.append(thread)
         }
-        span.setAttribute(key: Keys.threads.rawValue, value: Helper.convertArrayOfStringToJsonString(array: threads))
+
+        var crashedIndex: Int?
+        for (index, thread) in allThreads.enumerated() where thread.crashed {
+            span.setAttribute(key: Keys.triggeredByThread.rawValue, value: thread.threadNumber)
+            crashedIndex = index
+        }
+        span.setAttribute(key: Keys.totalThreads.rawValue, value: allThreads.count)
+
+        // Frames per thread, in report order — order is never changed, because the backend locates
+        // the crashed thread positionally via triggered_by_thread. Truncation only removes frames
+        // within each thread and, under the byte guard, drops tail threads past the crashed one.
+        let allFrames = allThreads.map {
+            self.parseFrameArray(crashedThreadFrameArray: self.crashedThread(report: report, thread: $0))
+        }
+
+        let options = self.options
+        let threadsJson = Helper.buildTruncatedThreads(
+            allFrames: allFrames,
+            crashedIndex: crashedIndex,
+            maxThreads: options?.maxThreads ?? CoralogixExporterOptions.defaultMaxThreads,
+            frameCap: options?.maxStackTraceFramesPerThread ?? CoralogixExporterOptions.defaultMaxStackTraceFramesPerThread,
+            byteBudget: CoralogixExporterOptions.crashThreadsByteBudget
+        )
+        span.setAttribute(key: Keys.threads.rawValue, value: threadsJson)
     }
     
     func parseFrameArray(crashedThreadFrameArray: [StackFrame]) -> [[String: Any]] {

--- a/Coralogix/Sources/Instrumentation/CrashInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/CrashInstrumentation.swift
@@ -84,25 +84,33 @@ extension CoralogixRum {
 
         let crashedIndex = allThreads.firstIndex(where: { $0.crashed })
         if let crashedIndex {
+            // triggered_by_thread carries the original crash report's thread *number* (unchanged).
             span.setAttribute(key: Keys.triggeredByThread.rawValue, value: allThreads[crashedIndex].threadNumber)
+            // The positional index is carried separately so the export-time byte guard can trim
+            // without dropping past the crashed thread, independent of the thread-number value.
+            span.setAttribute(key: Keys.crashedThreadIndex.rawValue, value: crashedIndex)
         }
+        // total_threads reports the true count — before the ceiling below — so a truncated report
+        // still reads "N of M threads".
         span.setAttribute(key: Keys.totalThreads.rawValue, value: allThreads.count)
 
-        // Frames per thread, in report order — order is never changed, because the backend locates
-        // the crashed thread positionally via triggered_by_thread. Truncation only removes frames
-        // within each thread and, under the byte guard, drops tail threads past the crashed one.
-        let allFrames = allThreads.map {
-            self.parseFrameArray(crashedThreadFrameArray: self.crashedThread(report: report, thread: $0))
-        }
+        // Cap how many threads we parse before doing any work, to bound worst-case parse/serialize
+        // cost on a process with an unusually large thread count. The crashed thread and every thread
+        // before it are always kept, so this can never drop past the crash site.
+        let requiredPrefix = crashedIndex.map { $0 + 1 } ?? 0
+        let keptThreadCount = min(allThreads.count,
+                                  max(CoralogixExporterOptions.crashThreadCountCeiling, requiredPrefix))
 
-        let options = self.options
-        let threadsJson = Helper.buildTruncatedThreads(
-            allFrames: allFrames,
-            crashedIndex: crashedIndex,
-            frameCap: options?.maxStackTraceFramesPerThread ?? CoralogixExporterOptions.defaultMaxStackTraceFramesPerThread,
-            byteBudget: CoralogixExporterOptions.crashThreadsByteBudget
-        )
-        span.setAttribute(key: Keys.threads.rawValue, value: threadsJson)
+        // Frames per thread, in report order (never reordered). Each thread is truncated middle-out to
+        // the per-thread frame cap; the byte guard that fits the whole payload runs later at export,
+        // against the fully-assembled record (see Helper.fitCrashRecordToByteBudget).
+        let frameCap = self.options?.maxStackTraceFramesPerThread
+            ?? CoralogixExporterOptions.defaultMaxStackTraceFramesPerThread
+        let threads = allThreads.prefix(keptThreadCount).map { thread -> String in
+            let frames = self.parseFrameArray(crashedThreadFrameArray: self.crashedThread(report: report, thread: thread))
+            return Helper.convertArrayToJsonString(array: Helper.truncateMiddleOut(frames, cap: frameCap))
+        }
+        span.setAttribute(key: Keys.threads.rawValue, value: Helper.convertArrayOfStringToJsonString(array: threads))
     }
     
     func parseFrameArray(crashedThreadFrameArray: [StackFrame]) -> [[String: Any]] {

--- a/Coralogix/Sources/Model/Contexts/ErrorContext.swift
+++ b/Coralogix/Sources/Model/Contexts/ErrorContext.swift
@@ -19,6 +19,7 @@ struct ErrorContext {
     let processName: String
     let applicationIdentifier: String
     var triggeredByThread: Int = 0
+    var totalThreads: Int = 0
     var threads: [[[String: Any]]]?
     var stackTrace: [[String: Any]]?
     let baseAddress: String
@@ -47,6 +48,9 @@ struct ErrorContext {
         self.applicationIdentifier = otel.getAttribute(forKey: Keys.applicationIdentifier.rawValue) as? String ?? ""
         if let triggeredByThread = otel.getAttribute(forKey: Keys.triggeredByThread.rawValue) as? String {
             self.triggeredByThread = Int(triggeredByThread) ?? -1
+        }
+        if let totalThreads = otel.getAttribute(forKey: Keys.totalThreads.rawValue) as? String {
+            self.totalThreads = Int(totalThreads) ?? 0
         }
     
         if let jsonString = otel.getAttribute(forKey: Keys.stackTrace.rawValue) as? String,
@@ -87,6 +91,7 @@ struct ErrorContext {
             errorContext[Keys.processName.rawValue] = self.processName
             errorContext[Keys.applicationIdentifier.rawValue] = self.applicationIdentifier
             errorContext[Keys.triggeredByThread.rawValue] = self.triggeredByThread
+            errorContext[Keys.totalThreads.rawValue] = self.totalThreads
             errorContext[Keys.baseAddress.rawValue] = self.baseAddress
             errorContext[Keys.arch.rawValue] = self.arch
             if let threads = self.threads {

--- a/Coralogix/Sources/Model/CoralogixExporterOptions.swift
+++ b/Coralogix/Sources/Model/CoralogixExporterOptions.swift
@@ -156,6 +156,25 @@ public struct CoralogixExporterOptions {
     /// ```
     public var tracesExporter: TracesExporterCallback?
 
+    /// Maximum stack-trace frames kept per thread on a native crash. Frames beyond this are
+    /// truncated middle-out (head + tail kept, middle dropped) so deep or recursive stacks
+    /// retain both the fault site and the entry point. Floored at 1.
+    public let maxStackTraceFramesPerThread: Int
+
+    /// Maximum number of threads kept on a native crash report. Clamped to `1...4`: a single
+    /// thread at the frame cap serializes to a few KB and the backend drops any log over ~10 KB,
+    /// so higher values only invite truncation. The crashed thread is always retained.
+    public let maxThreads: Int
+
+    public static let defaultMaxStackTraceFramesPerThread = 20
+    public static let defaultMaxThreads = 2
+    public static let maxThreadsRange = 1...4
+
+    /// Byte budget for the serialized `threads` attribute, sized so the whole crash event
+    /// (threads + the surrounding cx_rum envelope) clears the backend's ~10 KB hard limit with
+    /// headroom. Conservative; to be confirmed against a real customer crash log.
+    public static let crashThreadsByteBudget = 6_000
+
     public init(coralogixDomain: CoralogixDomain,
                 userContext: UserContext? = nil,
                 environment: String,
@@ -178,6 +197,8 @@ public struct CoralogixExporterOptions {
                 tracesExporter: TracesExporterCallback? = nil,
                 shouldSendText: ((UIView, String) -> Bool)? = nil,
                 resolveTargetName: ((UIView) -> String?)? = nil,
+                maxStackTraceFramesPerThread: Int = CoralogixExporterOptions.defaultMaxStackTraceFramesPerThread,
+                maxThreads: Int = CoralogixExporterOptions.defaultMaxThreads,
                 debug: Bool = false) {
         self.coralogixDomain = coralogixDomain
         self.userContext = userContext
@@ -202,6 +223,14 @@ public struct CoralogixExporterOptions {
         self.tracesExporter = tracesExporter
         self.shouldSendText = shouldSendText
         self.resolveTargetName = resolveTargetName
+        self.maxStackTraceFramesPerThread = max(1, maxStackTraceFramesPerThread)
+
+        let range = CoralogixExporterOptions.maxThreadsRange
+        let clampedMaxThreads = min(range.upperBound, max(range.lowerBound, maxThreads))
+        if clampedMaxThreads != maxThreads {
+            Log.w("maxThreads \(maxThreads) is out of range \(range.lowerBound)...\(range.upperBound); clamped to \(clampedMaxThreads)")
+        }
+        self.maxThreads = clampedMaxThreads
     }
     
     internal func shouldInitInstrumentation(instrumentation: InstrumentationType) -> Bool {

--- a/Coralogix/Sources/Model/CoralogixExporterOptions.swift
+++ b/Coralogix/Sources/Model/CoralogixExporterOptions.swift
@@ -170,10 +170,15 @@ public struct CoralogixExporterOptions {
     public static let defaultMaxThreads = 2
     public static let maxThreadsRange = 1...4
 
-    /// Byte budget for the serialized `threads` attribute, sized so the whole crash event
-    /// (threads + the surrounding cx_rum envelope) clears the backend's ~10 KB hard limit with
-    /// headroom. Conservative; to be confirmed against a real customer crash log.
-    public static let crashThreadsByteBudget = 6_000
+    /// Byte budget for the serialized `threads` attribute, measured at build time — before the
+    /// span is OTLP-encoded. It deliberately leaves room for the two things the wire payload adds
+    /// on top of this string: (1) the OTLP/JSON re-escaping of the attribute value (~1.25x), and
+    /// (2) the rest of the crash event — span envelope, cx_rum contexts, other attributes (~2.5–4 KB).
+    /// Sized so `~1.25 * budget + envelope` clears the backend's ~10 KB hard limit with headroom
+    /// (~1.25 * 4500 + ~3000 ≈ 8.6 KB). Under-budgeting is the safe direction: worst case the stack
+    /// is a little shorter, whereas over-budgeting risks a mid-payload cut. Conservative placeholder —
+    /// to be confirmed against a real customer crash log.
+    public static let crashThreadsByteBudget = 4_500
 
     public init(coralogixDomain: CoralogixDomain,
                 userContext: UserContext? = nil,

--- a/Coralogix/Sources/Model/CoralogixExporterOptions.swift
+++ b/Coralogix/Sources/Model/CoralogixExporterOptions.swift
@@ -161,14 +161,7 @@ public struct CoralogixExporterOptions {
     /// retain both the fault site and the entry point. Floored at 1.
     public let maxStackTraceFramesPerThread: Int
 
-    /// Maximum number of threads kept on a native crash report. Clamped to `1...4`: a single
-    /// thread at the frame cap serializes to a few KB and the backend drops any log over ~10 KB,
-    /// so higher values only invite truncation. The crashed thread is always retained.
-    public let maxThreads: Int
-
     public static let defaultMaxStackTraceFramesPerThread = 20
-    public static let defaultMaxThreads = 2
-    public static let maxThreadsRange = 1...4
 
     /// Byte budget for the serialized `threads` attribute, measured at build time — before the
     /// span is OTLP-encoded. It deliberately leaves room for the two things the wire payload adds
@@ -203,7 +196,6 @@ public struct CoralogixExporterOptions {
                 shouldSendText: ((UIView, String) -> Bool)? = nil,
                 resolveTargetName: ((UIView) -> String?)? = nil,
                 maxStackTraceFramesPerThread: Int = CoralogixExporterOptions.defaultMaxStackTraceFramesPerThread,
-                maxThreads: Int = CoralogixExporterOptions.defaultMaxThreads,
                 debug: Bool = false) {
         self.coralogixDomain = coralogixDomain
         self.userContext = userContext
@@ -229,13 +221,6 @@ public struct CoralogixExporterOptions {
         self.shouldSendText = shouldSendText
         self.resolveTargetName = resolveTargetName
         self.maxStackTraceFramesPerThread = max(1, maxStackTraceFramesPerThread)
-
-        let range = CoralogixExporterOptions.maxThreadsRange
-        let clampedMaxThreads = min(range.upperBound, max(range.lowerBound, maxThreads))
-        if clampedMaxThreads != maxThreads {
-            Log.w("maxThreads \(maxThreads) is out of range \(range.lowerBound)...\(range.upperBound); clamped to \(clampedMaxThreads)")
-        }
-        self.maxThreads = clampedMaxThreads
     }
     
     internal func shouldInitInstrumentation(instrumentation: InstrumentationType) -> Bool {

--- a/Coralogix/Sources/Model/CoralogixExporterOptions.swift
+++ b/Coralogix/Sources/Model/CoralogixExporterOptions.swift
@@ -163,15 +163,21 @@ public struct CoralogixExporterOptions {
 
     public static let defaultMaxStackTraceFramesPerThread = 20
 
-    /// Byte budget for the serialized `threads` attribute, measured at build time — before the
-    /// span is OTLP-encoded. It deliberately leaves room for the two things the wire payload adds
-    /// on top of this string: (1) the OTLP/JSON re-escaping of the attribute value (~1.25x), and
-    /// (2) the rest of the crash event — span envelope, cx_rum contexts, other attributes (~2.5–4 KB).
-    /// Sized so `~1.25 * budget + envelope` clears the backend's ~10 KB hard limit with headroom
-    /// (~1.25 * 4500 + ~3000 ≈ 8.6 KB). Under-budgeting is the safe direction: worst case the stack
-    /// is a little shorter, whereas over-budgeting risks a mid-payload cut. Conservative placeholder —
-    /// to be confirmed against a real customer crash log.
-    public static let crashThreadsByteBudget = 4_500
+    /// Byte budget for the *fully-assembled* crash log record, enforced at export time against the
+    /// exact JSON that goes on the wire (post-`beforeSend`, post-assembly). Because the guard now
+    /// measures the real record — envelope, cx_rum contexts, and the `threads` array together —
+    /// there is no estimate to under-count: whatever the user context, view name, or labels add is
+    /// already included. Kept under the backend's ~10 KB hard limit with headroom for the batch
+    /// wrapper. Under-budgeting is the safe direction (a slightly shorter stack) versus a mid-payload
+    /// cut. Conservative placeholder — to be confirmed against a real customer crash log.
+    public static let crashLogRecordByteBudget = 9_000
+
+    /// Upper bound on how many threads a native crash report is parsed into, applied before the byte
+    /// guard runs. The export-time byte guard already bounds how many threads reach the wire, so this
+    /// only caps worst-case parse/serialize work when a process crashes with an unusually large thread
+    /// count (e.g. GCD thread explosion). The crashed thread and every thread before it are always
+    /// retained, so the ceiling can never drop past the crash site.
+    public static let crashThreadCountCeiling = 50
 
     public init(coralogixDomain: CoralogixDomain,
                 userContext: UserContext? = nil,

--- a/Coralogix/Sources/Utils/Helper.swift
+++ b/Coralogix/Sources/Utils/Helper.swift
@@ -161,23 +161,34 @@ class Helper {
     /// alone and *estimating* the rest of the payload, it measures the actual record that goes on the
     /// wire (post-assembly, post-`beforeSend`) and derives the space left for `threads` from that
     /// measurement — so whatever the user context, view name, or labels add is already accounted for.
-    /// The trimming itself is `buildTruncatedThreads`, unchanged; it just receives a record-derived
-    /// budget instead of a fixed constant.
+    /// The trimming itself is `buildTruncatedThreads`, unchanged; it just receives a record-derived budget.
     ///
-    /// `crashedIndex` is the crashed thread's position within the record's `threads` array (carried
-    /// from crash-parse time via `Keys.crashedThreadIndex`); the guard never drops past it. Returns
-    /// the record untouched when it already fits, carries no crash `threads`, or can't be measured —
-    /// best effort, never crashing the host app.
+    /// `threadsTransport` is the SDK's own `threads` attribute (from `Keys.threads`, in report order)
+    /// and is the source of truth for the array — NOT the record's `error_context.threads`, which
+    /// `beforeSend` can reorder, drop, or reshape (either would desync `crashedIndex` or hide the array
+    /// from the guard). Crash threads are SDK-owned diagnostic data, so the guard rebases the record on
+    /// them and `beforeSend` edits to the array don't survive. `crashedIndex` is the crashed thread's
+    /// position in that array (from `Keys.crashedThreadIndex`); the guard never drops past it. Returns
+    /// the record untouched when it carries no crash threads or already fits, and logs when even the
+    /// minimal form can't fit (the envelope alone exceeds the budget) — best effort, never crashing.
     internal static func fitCrashRecordToByteBudget(record: [String: Any],
+                                                    threadsTransport: String?,
                                                     crashedIndex: Int?,
                                                     frameCap: Int,
                                                     byteBudget: Int) -> [String: Any] {
-        // Cheap crash-detection first (dict lookups only) so non-crash spans — the overwhelming
-        // majority — return before paying for any JSON serialization.
-        guard let threads = crashThreads(in: record), !threads.isEmpty else { return record }
-        guard let recordBytes = jsonByteCount(record), recordBytes > byteBudget else { return record }
-        guard let envelopeBytes = jsonByteCount(replacingCrashThreads(in: record, with: [])) else {
-            return record
+        // Only native crashes carry the threads transport attribute; non-crash spans return here for
+        // free (a nil check, no record traversal or serialization).
+        guard let threadsTransport else { return record }
+        let threads = decodeThreadsTransport(threadsTransport)
+        guard !threads.isEmpty else { return record }
+
+        // Rebase the record on the SDK's own threads so measurement, trimming, and crashedIndex stay
+        // consistent no matter what beforeSend did to error_context.threads. A no-op (returns the input)
+        // when beforeSend removed the crash context entirely — there's nothing to write into.
+        let base = replacingCrashThreads(in: record, with: threads)
+        guard let recordBytes = jsonByteCount(base), recordBytes > byteBudget else { return base }
+        guard let envelopeBytes = jsonByteCount(replacingCrashThreads(in: base, with: [])) else {
+            return base
         }
 
         // `buildTruncatedThreads` fits the escaped transport form (array-of-strings) to its budget,
@@ -186,13 +197,20 @@ class Helper {
         // The bounded loop re-measures the real record and tightens the budget on the off chance the
         // two encodings diverge enough to matter.
         var budget = max(0, byteBudget - envelopeBytes)
-        var result = record
+        var result = base
         for _ in 0..<5 {
             let trimmedJson = buildTruncatedThreads(allFrames: threads, crashedIndex: crashedIndex,
                                                     frameCap: frameCap, byteBudget: budget)
-            result = replacingCrashThreads(in: record, with: decodeThreadsTransport(trimmedJson))
-            guard let bytes = jsonByteCount(result), bytes > byteBudget, budget > 0 else { return result }
+            result = replacingCrashThreads(in: base, with: decodeThreadsTransport(trimmedJson))
+            let bytes = jsonByteCount(result) ?? Int.max
+            if bytes <= byteBudget || budget == 0 { break }
             budget = Int(Double(budget) * 0.85)
+        }
+        if let bytes = jsonByteCount(result), bytes > byteBudget {
+            // A fat envelope (large session context / labels / user context) can leave no room even
+            // after threads shrink to the minimum. We don't drop customer-owned envelope fields —
+            // surface it so it's diagnosable rather than silently over budget.
+            Log.w("[Crash] log record is \(bytes)B after trimming, over the \(byteBudget)B budget — the envelope alone may exceed it")
         }
         return result
     }
@@ -203,15 +221,6 @@ class Helper {
     private static func decodeThreadsTransport(_ json: String) -> [[[String: Any]]] {
         guard let threadStrings = convertJsonStringToArrayOfStrings(jsonString: json) else { return [] }
         return threadStrings.map { convertJsonStringToArray(jsonString: $0) ?? [] }
-    }
-
-    private static func crashThreads(in record: [String: Any]) -> [[[String: Any]]]? {
-        guard let text = record[Keys.text.rawValue] as? [String: Any],
-              let cxRum = text[Keys.cxRum.rawValue] as? [String: Any],
-              let errorContext = cxRum[Keys.errorContext.rawValue] as? [String: Any] else {
-            return nil
-        }
-        return errorContext[Keys.threads.rawValue] as? [[[String: Any]]]
     }
 
     private static func replacingCrashThreads(in record: [String: Any],

--- a/Coralogix/Sources/Utils/Helper.swift
+++ b/Coralogix/Sources/Utils/Helper.swift
@@ -87,13 +87,18 @@ class Helper {
     }
 
     /// Builds the serialized `threads` attribute for a native crash. It keeps every thread in
-    /// report order and applies:
-    ///   1. middle-out frame truncation per thread;
-    ///   2. a deterministic byte guard that shrinks — first dropping tail threads (never past the
-    ///      crashed thread), then trimming frames harder — until the serialized string fits `byteBudget`.
-    /// The number of threads reported is bounded solely by the byte guard (there is no separate
-    /// thread-count knob): threads are never reordered, and the crashed thread plus everything
-    /// before it are always retained, so positions stay stable and `triggered_by_thread` cannot desync.
+    /// report order and applies a deterministic byte guard that shrinks until the serialized string
+    /// fits `byteBudget`:
+    ///   1. drop tail threads (never past the crashed thread);
+    ///   2. trim every kept thread's frames middle-out down to a floor;
+    ///   3. last resort — when positional alignment forces keeping more threads than fit even at the
+    ///      floor, empty the context (before-crashed) threads' frame arrays and, if still needed,
+    ///      trim the crashed thread below the floor toward a single frame.
+    /// Threads are never reordered and the crashed thread plus its positional slot are always
+    /// retained, so `triggered_by_thread` cannot desync. The number of threads reported is bounded
+    /// solely by this guard (there is no separate thread-count knob). The result always fits
+    /// `byteBudget` unless even the minimal positional-safe form (one frame + empty context slots)
+    /// exceeds it, in which case that minimal form is returned as a best effort.
     /// `allFrames` holds every thread's full frame array in report order; `crashedIndex` is the
     /// position of the crashed thread in that array, or nil if unknown.
     internal static func buildTruncatedThreads(allFrames: [[[String: Any]]],
@@ -104,17 +109,26 @@ class Helper {
 
         let frameFloor = 4
         let frameTrimStep = 4
-        let minKept = min(allFrames.count, crashedIndex.map { $0 + 1 } ?? 1)
+        let crashed = crashedIndex.map { min(max(0, $0), allFrames.count - 1) }
+        let keepIndex = crashed ?? 0                          // thread whose frames we protect longest
+        let minKept = (crashed.map { $0 + 1 }) ?? 1
         var keptCount = allFrames.count
         var cap = max(1, frameCap)
 
-        func serialize() -> String {
-            let kept = allFrames.prefix(keptCount).map {
-                convertArrayToJsonString(array: truncateMiddleOut($0, cap: cap))
+        // When `emptyContext` is set, every kept thread except `keepIndex` is serialized as an empty
+        // frame array. This shrinks the payload while preserving array positions, so the crashed
+        // thread stays at its index and `triggered_by_thread` cannot desync.
+        func serialize(emptyContext: Bool = false) -> String {
+            let kept = allFrames.prefix(keptCount).enumerated().map { index, frames -> String in
+                if emptyContext && index != keepIndex {
+                    return convertArrayToJsonString(array: [])
+                }
+                return convertArrayToJsonString(array: truncateMiddleOut(frames, cap: cap))
             }
             return convertArrayOfStringToJsonString(array: Array(kept))
         }
 
+        // Stages 1–2: drop tail threads, then trim frames to the floor.
         var json = serialize()
         while json.utf8.count > byteBudget {
             if keptCount > minKept {
@@ -122,9 +136,19 @@ class Helper {
             } else if cap > frameFloor {
                 cap = max(frameFloor, cap - frameTrimStep)
             } else {
-                break // floor reached — cannot shrink further without dropping the crashed thread
+                break
             }
             json = serialize()
+        }
+        if json.utf8.count <= byteBudget { return json }
+
+        // Stage 3 (last resort): positional alignment forces keeping `minKept` threads that still
+        // exceed the budget at the floor. Empty the context threads (positions preserved) and, if
+        // needed, trim the crashed thread below the floor toward a single frame.
+        json = serialize(emptyContext: true)
+        while json.utf8.count > byteBudget && cap > 1 {
+            cap -= 1
+            json = serialize(emptyContext: true)
         }
         return json
     }

--- a/Coralogix/Sources/Utils/Helper.swift
+++ b/Coralogix/Sources/Utils/Helper.swift
@@ -86,17 +86,18 @@ class Helper {
         return result
     }
 
-    /// Builds the serialized `threads` attribute for a native crash, applying in order:
-    ///   1. a contiguous-prefix thread cap that always retains the crashed thread and never
-    ///      reorders threads — positions stay stable so `triggered_by_thread` cannot desync;
-    ///   2. middle-out frame truncation per kept thread;
-    ///   3. a deterministic byte guard that shrinks — first dropping tail threads (never past the
+    /// Builds the serialized `threads` attribute for a native crash. It keeps every thread in
+    /// report order and applies:
+    ///   1. middle-out frame truncation per thread;
+    ///   2. a deterministic byte guard that shrinks — first dropping tail threads (never past the
     ///      crashed thread), then trimming frames harder — until the serialized string fits `byteBudget`.
+    /// The number of threads reported is bounded solely by the byte guard (there is no separate
+    /// thread-count knob): threads are never reordered, and the crashed thread plus everything
+    /// before it are always retained, so positions stay stable and `triggered_by_thread` cannot desync.
     /// `allFrames` holds every thread's full frame array in report order; `crashedIndex` is the
     /// position of the crashed thread in that array, or nil if unknown.
     internal static func buildTruncatedThreads(allFrames: [[[String: Any]]],
                                                crashedIndex: Int?,
-                                               maxThreads: Int,
                                                frameCap: Int,
                                                byteBudget: Int) -> String {
         guard !allFrames.isEmpty else { return convertArrayOfStringToJsonString(array: []) }
@@ -104,7 +105,7 @@ class Helper {
         let frameFloor = 4
         let frameTrimStep = 4
         let minKept = min(allFrames.count, crashedIndex.map { $0 + 1 } ?? 1)
-        var keptCount = min(allFrames.count, max(maxThreads, minKept))
+        var keptCount = allFrames.count
         var cap = max(1, frameCap)
 
         func serialize() -> String {

--- a/Coralogix/Sources/Utils/Helper.swift
+++ b/Coralogix/Sources/Utils/Helper.swift
@@ -71,6 +71,63 @@ class Helper {
         return ""
     }
     
+    /// Truncates a frame list middle-out: keeps the head (75%) and tail (25%), drops the middle.
+    /// The head is weighted heavier because the fault site and its immediate callers matter most;
+    /// a short tail anchors the entry point and reveals recursion boundaries. No marker is inserted —
+    /// the array keeps its existing element shape, and a gap in the frames' own `frame_number` values
+    /// is the self-describing signal that frames were dropped. Returns the input unchanged when
+    /// `frames.count <= cap`.
+    internal static func truncateMiddleOut<T>(_ frames: [T], cap: Int) -> [T] {
+        guard cap > 0, frames.count > cap else { return frames }
+        let head = Int((Double(cap) * 0.75).rounded())
+        let tail = cap - head
+        var result = Array(frames.prefix(head))
+        if tail > 0 { result.append(contentsOf: frames.suffix(tail)) }
+        return result
+    }
+
+    /// Builds the serialized `threads` attribute for a native crash, applying in order:
+    ///   1. a contiguous-prefix thread cap that always retains the crashed thread and never
+    ///      reorders threads — positions stay stable so `triggered_by_thread` cannot desync;
+    ///   2. middle-out frame truncation per kept thread;
+    ///   3. a deterministic byte guard that shrinks — first dropping tail threads (never past the
+    ///      crashed thread), then trimming frames harder — until the serialized string fits `byteBudget`.
+    /// `allFrames` holds every thread's full frame array in report order; `crashedIndex` is the
+    /// position of the crashed thread in that array, or nil if unknown.
+    internal static func buildTruncatedThreads(allFrames: [[[String: Any]]],
+                                               crashedIndex: Int?,
+                                               maxThreads: Int,
+                                               frameCap: Int,
+                                               byteBudget: Int) -> String {
+        guard !allFrames.isEmpty else { return convertArrayOfStringToJsonString(array: []) }
+
+        let frameFloor = 4
+        let frameTrimStep = 4
+        let minKept = min(allFrames.count, crashedIndex.map { $0 + 1 } ?? 1)
+        var keptCount = min(allFrames.count, max(maxThreads, minKept))
+        var cap = max(1, frameCap)
+
+        func serialize() -> String {
+            let kept = allFrames.prefix(keptCount).map {
+                convertArrayToJsonString(array: truncateMiddleOut($0, cap: cap))
+            }
+            return convertArrayOfStringToJsonString(array: Array(kept))
+        }
+
+        var json = serialize()
+        while json.utf8.count > byteBudget {
+            if keptCount > minKept {
+                keptCount -= 1
+            } else if cap > frameFloor {
+                cap = max(frameFloor, cap - frameTrimStep)
+            } else {
+                break // floor reached — cannot shrink further without dropping the crashed thread
+            }
+            json = serialize()
+        }
+        return json
+    }
+
     internal static func convertDictionaryToJsonString(dict: [String: Any]) -> String {
         func encode(_ d: [String: Any]) -> String? {
             // `isValidJSONObject` rejects `Date` and other non-JSON types without raising an Obj‑C

--- a/Coralogix/Sources/Utils/Helper.swift
+++ b/Coralogix/Sources/Utils/Helper.swift
@@ -79,7 +79,10 @@ class Helper {
     /// `frames.count <= cap`.
     internal static func truncateMiddleOut<T>(_ frames: [T], cap: Int) -> [T] {
         guard cap > 0, frames.count > cap else { return frames }
-        let head = Int((Double(cap) * 0.75).rounded())
+        // Clamp head to cap - 1 whenever cap >= 2 so at least one tail frame (the entry point) is
+        // always kept — rounding could otherwise take the whole budget as head (e.g. cap == 2 →
+        // head 2, tail 0, dropping the entry frame).
+        let head = cap == 1 ? 1 : min(Int((Double(cap) * 0.75).rounded()), cap - 1)
         let tail = cap - head
         var result = Array(frames.prefix(head))
         if tail > 0 { result.append(contentsOf: frames.suffix(tail)) }
@@ -151,6 +154,84 @@ class Helper {
             json = serialize(emptyContext: true)
         }
         return json
+    }
+
+    /// Trims a fully-assembled native-crash log record so its serialized JSON fits `byteBudget`.
+    /// Export-time counterpart to `buildTruncatedThreads`: rather than budgeting the `threads` string
+    /// alone and *estimating* the rest of the payload, it measures the actual record that goes on the
+    /// wire (post-assembly, post-`beforeSend`) and derives the space left for `threads` from that
+    /// measurement — so whatever the user context, view name, or labels add is already accounted for.
+    /// The trimming itself is `buildTruncatedThreads`, unchanged; it just receives a record-derived
+    /// budget instead of a fixed constant.
+    ///
+    /// `crashedIndex` is the crashed thread's position within the record's `threads` array (carried
+    /// from crash-parse time via `Keys.crashedThreadIndex`); the guard never drops past it. Returns
+    /// the record untouched when it already fits, carries no crash `threads`, or can't be measured —
+    /// best effort, never crashing the host app.
+    internal static func fitCrashRecordToByteBudget(record: [String: Any],
+                                                    crashedIndex: Int?,
+                                                    frameCap: Int,
+                                                    byteBudget: Int) -> [String: Any] {
+        // Cheap crash-detection first (dict lookups only) so non-crash spans — the overwhelming
+        // majority — return before paying for any JSON serialization.
+        guard let threads = crashThreads(in: record), !threads.isEmpty else { return record }
+        guard let recordBytes = jsonByteCount(record), recordBytes > byteBudget else { return record }
+        guard let envelopeBytes = jsonByteCount(replacingCrashThreads(in: record, with: [])) else {
+            return record
+        }
+
+        // `buildTruncatedThreads` fits the escaped transport form (array-of-strings) to its budget,
+        // while the record embeds `threads` as a plain nested array (smaller) — so fitting the
+        // transport form to `byteBudget - envelope` lands the reassembled record at or under budget.
+        // The bounded loop re-measures the real record and tightens the budget on the off chance the
+        // two encodings diverge enough to matter.
+        var budget = max(0, byteBudget - envelopeBytes)
+        var result = record
+        for _ in 0..<5 {
+            let trimmedJson = buildTruncatedThreads(allFrames: threads, crashedIndex: crashedIndex,
+                                                    frameCap: frameCap, byteBudget: budget)
+            result = replacingCrashThreads(in: record, with: decodeThreadsTransport(trimmedJson))
+            guard let bytes = jsonByteCount(result), bytes > byteBudget, budget > 0 else { return result }
+            budget = Int(Double(budget) * 0.85)
+        }
+        return result
+    }
+
+    /// Decodes the `threads` transport form produced by `buildTruncatedThreads` (a JSON array of
+    /// per-thread JSON strings) back into the nested frame arrays the record embeds. An empty
+    /// per-thread string decodes to an empty frame array, preserving the thread's position.
+    private static func decodeThreadsTransport(_ json: String) -> [[[String: Any]]] {
+        guard let threadStrings = convertJsonStringToArrayOfStrings(jsonString: json) else { return [] }
+        return threadStrings.map { convertJsonStringToArray(jsonString: $0) ?? [] }
+    }
+
+    private static func crashThreads(in record: [String: Any]) -> [[[String: Any]]]? {
+        guard let text = record[Keys.text.rawValue] as? [String: Any],
+              let cxRum = text[Keys.cxRum.rawValue] as? [String: Any],
+              let errorContext = cxRum[Keys.errorContext.rawValue] as? [String: Any] else {
+            return nil
+        }
+        return errorContext[Keys.threads.rawValue] as? [[[String: Any]]]
+    }
+
+    private static func replacingCrashThreads(in record: [String: Any],
+                                              with threads: [[[String: Any]]]) -> [String: Any] {
+        guard var text = record[Keys.text.rawValue] as? [String: Any],
+              var cxRum = text[Keys.cxRum.rawValue] as? [String: Any],
+              var errorContext = cxRum[Keys.errorContext.rawValue] as? [String: Any] else {
+            return record
+        }
+        errorContext[Keys.threads.rawValue] = threads
+        cxRum[Keys.errorContext.rawValue] = errorContext
+        text[Keys.cxRum.rawValue] = cxRum
+        var result = record
+        result[Keys.text.rawValue] = text
+        return result
+    }
+
+    private static func jsonByteCount(_ object: [String: Any]) -> Int? {
+        guard JSONSerialization.isValidJSONObject(object) else { return nil }
+        return (try? JSONSerialization.data(withJSONObject: object, options: []))?.count
     }
 
     internal static func convertDictionaryToJsonString(dict: [String: Any]) -> String {

--- a/CoralogixInternal.podspec
+++ b/CoralogixInternal.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "CoralogixInternal"
-  spec.version      = "2.10.1"
+  spec.version      = "2.11.0"
   spec.summary      = "Coralogix Internal Package. This module is not for public use."
 
   spec.description  = <<-DESC

--- a/CoralogixInternal/Sources/Keys.swift
+++ b/CoralogixInternal/Sources/Keys.swift
@@ -144,6 +144,7 @@ public enum Keys: String {
     // store the counter under the wrong slot and break the restore path.
     case storedViewNumber = "viewNumber"
     case threads
+    case totalThreads = "total_threads"
     case httpResponseBodySize = "http_response_body_size"
     case stackTrace
     case instrumentationData = "instrumentation_data"

--- a/CoralogixInternal/Sources/Keys.swift
+++ b/CoralogixInternal/Sources/Keys.swift
@@ -145,6 +145,11 @@ public enum Keys: String {
     case storedViewNumber = "viewNumber"
     case threads
     case totalThreads = "total_threads"
+    // Array index of the crashed thread within `threads`, carried from crash-parse time to
+    // export time so the byte guard can trim without dropping past the crashed thread. Internal
+    // only — never emitted on the wire (crash records carry `triggered_by_thread`, the original
+    // crash thread *number*, not this positional index).
+    case crashedThreadIndex = "crashed_thread_index"
     case httpResponseBodySize = "http_response_body_size"
     case stackTrace
     case instrumentationData = "instrumentation_data"

--- a/CoralogixInternal/Sources/Utils.swift
+++ b/CoralogixInternal/Sources/Utils.swift
@@ -16,7 +16,7 @@ public enum ImageFormat {
 }
 
 public enum Global: String {
-    case sdk = "2.10.1"
+    case sdk = "2.11.0"
     case swiftVersion = "5.9"
     case coralogixPath = "/browser/v1beta/logs"
     case sessionReplayPath = "/browser/alpha/sessionrecording"

--- a/Example/DemoAppSwift/MainViewController.swift
+++ b/Example/DemoAppSwift/MainViewController.swift
@@ -179,9 +179,16 @@ final class MainViewController: UITableViewController {
             copyButton.trailingAnchor.constraint(equalTo: card.trailingAnchor, constant: -12)
         ])
 
-        // Size header explicitly
+        // Size the header to fit its Auto Layout content so the session ID isn't clipped.
         let headerWidth = view.bounds.width
-        container.frame = CGRect(x: 0, y: 0, width: headerWidth, height: 80)
+        container.frame = CGRect(x: 0, y: 0, width: headerWidth, height: 0)
+        container.layoutIfNeeded()
+        let fittingHeight = container.systemLayoutSizeFitting(
+            CGSize(width: headerWidth, height: UIView.layoutFittingCompressedSize.height),
+            withHorizontalFittingPriority: .required,
+            verticalFittingPriority: .fittingSizeLevel
+        ).height
+        container.frame = CGRect(x: 0, y: 0, width: headerWidth, height: fittingHeight)
         tableView.tableHeaderView = container
     }
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,23 @@ let options = CoralogixExporterOptions(coralogixDomain: CORALOGIX-DOMAIN,
                                         sessionSampleRate: 100)
 ```
 
+### Crash Stack Trace Limits
+Bound the size of a native crash report so it stays within the backend's ingestion limit (crash logs above the limit are truncated by the pipeline and can be corrupted).
+
+- `maxStackTraceFramesPerThread` (default `20`) — maximum frames kept per thread. When a thread has more, its stack is truncated **middle-out**: the top frames (the crash site and its immediate callers) and the bottom frames (the entry point) are kept, and the middle is dropped. This keeps deep and recursive stacks useful instead of showing one repeated frame.
+- `maxThreads` (default `2`, clamped to `1...4`) — maximum number of threads reported. The thread that crashed is always kept.
+
+The reported thread order is unchanged; only the volume of frames and threads is reduced. Hybrid (Flutter / React Native) crash paths are unaffected — those SDKs apply their own limits.
+```swift
+let options = CoralogixExporterOptions(coralogixDomain: CORALOGIX-DOMAIN,
+                                        environment: "ENVIRONMENT",
+                                        application: "APP-NAME",
+                                        version: "APP-VERSION",
+                                        publicKey: "API-KEY",
+                                        maxStackTraceFramesPerThread: 20,
+                                        maxThreads: 2)
+```
+
 ### Excluding Instrumentations from Session Sampling
 Opt specific event categories out of the `sessionSampleRate` gate so they always export, even from sessions that are otherwise sampled out. Useful when you want a low session sample rate for general telemetry but still need every log and error captured.
 

--- a/README.md
+++ b/README.md
@@ -160,17 +160,15 @@ let options = CoralogixExporterOptions(coralogixDomain: CORALOGIX-DOMAIN,
 Bound the size of a native crash report so it stays within the backend's ingestion limit (crash logs above the limit are truncated by the pipeline and can be corrupted).
 
 - `maxStackTraceFramesPerThread` (default `20`) — maximum frames kept per thread. When a thread has more, its stack is truncated **middle-out**: the top frames (the crash site and its immediate callers) and the bottom frames (the entry point) are kept, and the middle is dropped. This keeps deep and recursive stacks useful instead of showing one repeated frame.
-- `maxThreads` (default `2`, clamped to `1...4`) — maximum number of threads reported. The thread that crashed is always kept.
 
-The reported thread order is unchanged; only the volume of frames and threads is reduced. Hybrid (Flutter / React Native) crash paths are unaffected — those SDKs apply their own limits.
+If a report is still too large, the SDK automatically reduces the number of threads it includes — always keeping the thread that crashed — until it fits under the ingestion limit. Thread order is never changed; only the volume of frames and threads is reduced. Hybrid (Flutter / React Native) crash paths are unaffected — those SDKs apply their own limits.
 ```swift
 let options = CoralogixExporterOptions(coralogixDomain: CORALOGIX-DOMAIN,
                                         environment: "ENVIRONMENT",
                                         application: "APP-NAME",
                                         version: "APP-VERSION",
                                         publicKey: "API-KEY",
-                                        maxStackTraceFramesPerThread: 20,
-                                        maxThreads: 2)
+                                        maxStackTraceFramesPerThread: 20)
 ```
 
 ### Excluding Instrumentations from Session Sampling

--- a/SessionReplay.podspec
+++ b/SessionReplay.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "SessionReplay"
-  spec.version      = "2.10.1"
+  spec.version      = "2.11.0"
   spec.summary      = "Coralogix Session-Replay pod for iOS."
 
   spec.description  = <<-DESC
@@ -23,7 +23,7 @@ Pod::Spec.new do |spec|
   spec.static_framework = true
 
   spec.source_files  = 'SessionReplay/Sources/**/*.swift'
-  spec.dependency 'CoralogixInternal', '2.10.1'
+  spec.dependency 'CoralogixInternal', '2.11.0'
   
     spec.test_spec 'Tests' do |test|
         test.source_files = 'Tests/SessionReplayTests/**/*.swift'

--- a/Tests/CoralogixRumTests/ErrorContextTests.swift
+++ b/Tests/CoralogixRumTests/ErrorContextTests.swift
@@ -112,6 +112,7 @@ final class ErrorContextTests: XCTestCase {
             Keys.processName.rawValue: AttributeValue("ExampleApp"),
             Keys.applicationIdentifier.rawValue: AttributeValue("com.myapp"),
             Keys.triggeredByThread.rawValue: AttributeValue("1"),
+            Keys.totalThreads.rawValue: AttributeValue("40"),
             Keys.baseAddress.rawValue: AttributeValue("0x1000000"),
             Keys.arch.rawValue: AttributeValue("x86_64")
         ])
@@ -137,6 +138,8 @@ final class ErrorContextTests: XCTestCase {
         XCTAssertEqual(dictionary[Keys.exceptionType.rawValue] as? String, "Fatal")
         XCTAssertEqual(dictionary[Keys.arch.rawValue] as? String, "x86_64")
         XCTAssertEqual(dictionary[Keys.baseAddress.rawValue] as? String, "0x1000000")
+        XCTAssertEqual(errorStruct.totalThreads, 40)
+        XCTAssertEqual(dictionary[Keys.totalThreads.rawValue] as? Int, 40)
         XCTAssertEqual(dictionary[Keys.triggeredByThread.rawValue] as? Int, 1)
         XCTAssertEqual(dictionary[Keys.applicationIdentifier.rawValue] as? String, "com.myapp")
         XCTAssertEqual(dictionary[Keys.processName.rawValue] as? String, "ExampleApp")

--- a/Tests/CoralogixRumTests/StackTraceTruncationTests.swift
+++ b/Tests/CoralogixRumTests/StackTraceTruncationTests.swift
@@ -167,6 +167,21 @@ final class StackTraceTruncationTests: XCTestCase {
         }
     }
 
+    func test_byteGuard_emptiesContextThreadsWhenCrashedIsHighIndex() {
+        // Crash on a high-index thread among many: positional alignment forces keeping 26 threads,
+        // which can't fit even at the frame floor. The guard must empty the context threads (keeping
+        // their positions) so the payload still fits, while the crashed thread retains its frames.
+        let all = (0..<30).map { makeThread(id: $0, frames: 10) }
+        let budget = 3_000
+        let json = Helper.buildTruncatedThreads(allFrames: all, crashedIndex: 25,
+                                                frameCap: 20, byteBudget: budget)
+        XCTAssertLessThanOrEqual(json.utf8.count, budget)   // guarantee holds even in this case
+        let decoded = decodeThreads(json)
+        XCTAssertEqual(decoded.count, 26)                   // positions preserved through the crashed thread
+        XCTAssertEqual(binaryTag(decoded[25]), "T25")       // crashed thread retained with its frames
+        XCTAssertTrue(decoded[0].isEmpty)                   // a context thread emptied to fit
+    }
+
     func test_emptyThreadsProducesEmptyArray() {
         let json = Helper.buildTruncatedThreads(allFrames: [], crashedIndex: nil,
                                                 frameCap: 20, byteBudget: 9_000)

--- a/Tests/CoralogixRumTests/StackTraceTruncationTests.swift
+++ b/Tests/CoralogixRumTests/StackTraceTruncationTests.swift
@@ -1,0 +1,194 @@
+//
+//  StackTraceTruncationTests.swift
+//
+//  Covers CX-48437 — native-crash stack-trace truncation: middle-out frame truncation,
+//  maxThreads clamping, and the contiguous-prefix thread cap + deterministic byte guard.
+//
+
+import XCTest
+import CoralogixInternal
+@testable import Coralogix
+
+final class StackTraceTruncationTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    /// A synthetic thread of `count` frames; `binary` is tagged "T<id>" so the thread is
+    /// identifiable after serialization, and `frame_number` runs 0..<count.
+    private func makeThread(id: Int, frames count: Int) -> [[String: Any]] {
+        (0..<count).map { i in
+            [
+                Keys.frameNumber.rawValue: "\(i)",
+                Keys.binary.rawValue: "T\(id)",
+                Keys.functionAddressCalled.rawValue: "0x000000010000\(String(format: "%04x", i))",
+                Keys.base.rawValue: "symbol_\(i)",
+                Keys.offset.rawValue: "\(i * 7)"
+            ]
+        }
+    }
+
+    /// Decodes the `threads` attribute (JSON array of per-thread JSON strings) back into frames.
+    private func decodeThreads(_ json: String) -> [[[String: Any]]] {
+        guard let data = json.data(using: .utf8),
+              let threadStrings = try? JSONSerialization.jsonObject(with: data) as? [String] else {
+            return []
+        }
+        return threadStrings.compactMap { threadString in
+            guard let d = threadString.data(using: .utf8),
+                  let frames = try? JSONSerialization.jsonObject(with: d) as? [[String: Any]] else { return nil }
+            return frames
+        }
+    }
+
+    private func binaryTag(_ frames: [[String: Any]]) -> String? {
+        frames.first?[Keys.binary.rawValue] as? String
+    }
+
+    // MARK: - truncateMiddleOut
+
+    func test_truncateMiddleOut_keepsAllWhenUnderCap() {
+        let frames = Array(0..<10)
+        XCTAssertEqual(Helper.truncateMiddleOut(frames, cap: 20), frames)
+    }
+
+    func test_truncateMiddleOut_keepsAllWhenExactlyCap() {
+        let frames = Array(0..<20)
+        XCTAssertEqual(Helper.truncateMiddleOut(frames, cap: 20), frames)
+    }
+
+    func test_truncateMiddleOut_keepsHead75TailForCap20() {
+        let frames = Array(0..<2000)
+        let out = Helper.truncateMiddleOut(frames, cap: 20)
+        XCTAssertEqual(out.count, 20)
+        // head = round(0.75 * 20) = 15 → 0...14, tail = 5 → 1995...1999
+        XCTAssertEqual(Array(out.prefix(15)), Array(0...14))
+        XCTAssertEqual(Array(out.suffix(5)), Array(1995...1999))
+        // the jump from 14 -> 1995 (a gap in frame numbers) is the self-describing "dropped" signal
+        XCTAssertEqual(out[14], 14)
+        XCTAssertEqual(out[15], 1995)
+    }
+
+    func test_truncateMiddleOut_nonZeroFloorSplit() {
+        // cap 4: head = round(3.0) = 3, tail = 1
+        let out = Helper.truncateMiddleOut(Array(0..<100), cap: 4)
+        XCTAssertEqual(out, [0, 1, 2, 99])
+    }
+
+    func test_truncateMiddleOut_capZeroOrNegativeReturnsInput() {
+        let frames = Array(0..<10)
+        XCTAssertEqual(Helper.truncateMiddleOut(frames, cap: 0), frames)
+        XCTAssertEqual(Helper.truncateMiddleOut(frames, cap: -3), frames)
+    }
+
+    // MARK: - Options clamping
+
+    private func options(maxThreads: Int? = nil, framesPerThread: Int? = nil) -> CoralogixExporterOptions {
+        CoralogixExporterOptions(
+            coralogixDomain: .US2,
+            environment: "PROD",
+            application: "TestApp-iOS",
+            version: "1.0",
+            publicKey: "token",
+            maxStackTraceFramesPerThread: framesPerThread ?? CoralogixExporterOptions.defaultMaxStackTraceFramesPerThread,
+            maxThreads: maxThreads ?? CoralogixExporterOptions.defaultMaxThreads
+        )
+    }
+
+    func test_options_defaults() {
+        let opts = options()
+        XCTAssertEqual(opts.maxThreads, 2)
+        XCTAssertEqual(opts.maxStackTraceFramesPerThread, 20)
+    }
+
+    func test_options_maxThreads_clampedToCeiling() {
+        XCTAssertEqual(options(maxThreads: 10).maxThreads, 4)
+    }
+
+    func test_options_maxThreads_clampedToFloor() {
+        XCTAssertEqual(options(maxThreads: 0).maxThreads, 1)
+        XCTAssertEqual(options(maxThreads: -5).maxThreads, 1)
+    }
+
+    func test_options_framesPerThread_flooredAtOne() {
+        XCTAssertEqual(options(framesPerThread: 0).maxStackTraceFramesPerThread, 1)
+        XCTAssertEqual(options(framesPerThread: -9).maxStackTraceFramesPerThread, 1)
+    }
+
+    // MARK: - buildTruncatedThreads: thread cap
+
+    func test_threadCap_keepsMaxThreadsWhenCrashedIsFirst() {
+        let all = (0..<5).map { makeThread(id: $0, frames: 10) }
+        let json = Helper.buildTruncatedThreads(allFrames: all, crashedIndex: 0,
+                                                maxThreads: 2, frameCap: 20, byteBudget: 1_000_000)
+        let decoded = decodeThreads(json)
+        XCTAssertEqual(decoded.count, 2)
+        XCTAssertEqual(binaryTag(decoded[0]), "T0")
+        XCTAssertEqual(binaryTag(decoded[1]), "T1")
+        XCTAssertEqual(decoded[0].count, 10) // under frame cap → untouched
+    }
+
+    func test_threadCap_extendsPrefixToIncludeCrashedThread() {
+        // crashed thread at index 3, maxThreads 2 → contiguous prefix must reach index 3.
+        let all = (0..<6).map { makeThread(id: $0, frames: 8) }
+        let json = Helper.buildTruncatedThreads(allFrames: all, crashedIndex: 3,
+                                                maxThreads: 2, frameCap: 20, byteBudget: 1_000_000)
+        let decoded = decodeThreads(json)
+        XCTAssertEqual(decoded.count, 4)
+        XCTAssertEqual(binaryTag(decoded[3]), "T3") // crashed thread present at its original position
+    }
+
+    func test_threadOrder_isNeverChanged() {
+        let all = (0..<3).map { makeThread(id: $0, frames: 5) }
+        let json = Helper.buildTruncatedThreads(allFrames: all, crashedIndex: 0,
+                                                maxThreads: 4, frameCap: 20, byteBudget: 1_000_000)
+        let decoded = decodeThreads(json)
+        XCTAssertEqual(decoded.map { binaryTag($0) }, ["T0", "T1", "T2"])
+    }
+
+    // MARK: - buildTruncatedThreads: frame truncation
+
+    func test_frameTruncation_appliedPerThread() {
+        let all = [makeThread(id: 0, frames: 100)]
+        let json = Helper.buildTruncatedThreads(allFrames: all, crashedIndex: 0,
+                                                maxThreads: 1, frameCap: 20, byteBudget: 1_000_000)
+        let decoded = decodeThreads(json)
+        XCTAssertEqual(decoded.count, 1)
+        XCTAssertEqual(decoded[0].count, 20)
+        XCTAssertEqual(decoded[0].first?[Keys.frameNumber.rawValue] as? String, "0")
+        // head 15 (0...14) + tail 5 (95...99): the frame after the head is #95
+        XCTAssertEqual(decoded[0][15][Keys.frameNumber.rawValue] as? String, "95")
+        XCTAssertEqual(decoded[0].last?[Keys.frameNumber.rawValue] as? String, "99")
+    }
+
+    // MARK: - buildTruncatedThreads: byte guard
+
+    func test_byteGuard_dropsTailThreadsUntilUnderBudget() {
+        let all = (0..<5).map { makeThread(id: $0, frames: 30) }
+        let budget = 2_500
+        let json = Helper.buildTruncatedThreads(allFrames: all, crashedIndex: 0,
+                                                maxThreads: 4, frameCap: 20, byteBudget: budget)
+        XCTAssertLessThanOrEqual(json.utf8.count, budget)
+        let decoded = decodeThreads(json)
+        XCTAssertGreaterThanOrEqual(decoded.count, 1)
+        XCTAssertEqual(binaryTag(decoded[0]), "T0") // crashed thread never dropped
+    }
+
+    func test_byteGuard_trimsFramesWhenCrashedThreadIsLast() {
+        // crashed thread is last → no tail threads may be dropped; guard must trim frames instead.
+        let all = (0..<5).map { makeThread(id: $0, frames: 40) }
+        let json = Helper.buildTruncatedThreads(allFrames: all, crashedIndex: 4,
+                                                maxThreads: 2, frameCap: 20, byteBudget: 2_000)
+        let decoded = decodeThreads(json)
+        XCTAssertEqual(decoded.count, 5)                  // all threads retained (crashed is last)
+        XCTAssertEqual(binaryTag(decoded[4]), "T4")       // crashed thread present
+        for frames in decoded {
+            XCTAssertLessThanOrEqual(frames.count, 4)     // trimmed to the frame floor
+        }
+    }
+
+    func test_emptyThreadsProducesEmptyArray() {
+        let json = Helper.buildTruncatedThreads(allFrames: [], crashedIndex: nil,
+                                                maxThreads: 2, frameCap: 20, byteBudget: 9_000)
+        XCTAssertTrue(decodeThreads(json).isEmpty)
+    }
+}

--- a/Tests/CoralogixRumTests/StackTraceTruncationTests.swift
+++ b/Tests/CoralogixRumTests/StackTraceTruncationTests.swift
@@ -2,7 +2,7 @@
 //  StackTraceTruncationTests.swift
 //
 //  Covers CX-48437 — native-crash stack-trace truncation: middle-out frame truncation,
-//  maxThreads clamping, and the contiguous-prefix thread cap + deterministic byte guard.
+//  frame-cap flooring, and the contiguous-prefix thread retention + deterministic byte guard.
 //
 
 import XCTest
@@ -82,31 +82,19 @@ final class StackTraceTruncationTests: XCTestCase {
 
     // MARK: - Options clamping
 
-    private func options(maxThreads: Int? = nil, framesPerThread: Int? = nil) -> CoralogixExporterOptions {
+    private func options(framesPerThread: Int? = nil) -> CoralogixExporterOptions {
         CoralogixExporterOptions(
             coralogixDomain: .US2,
             environment: "PROD",
             application: "TestApp-iOS",
             version: "1.0",
             publicKey: "token",
-            maxStackTraceFramesPerThread: framesPerThread ?? CoralogixExporterOptions.defaultMaxStackTraceFramesPerThread,
-            maxThreads: maxThreads ?? CoralogixExporterOptions.defaultMaxThreads
+            maxStackTraceFramesPerThread: framesPerThread ?? CoralogixExporterOptions.defaultMaxStackTraceFramesPerThread
         )
     }
 
     func test_options_defaults() {
-        let opts = options()
-        XCTAssertEqual(opts.maxThreads, 2)
-        XCTAssertEqual(opts.maxStackTraceFramesPerThread, 20)
-    }
-
-    func test_options_maxThreads_clampedToCeiling() {
-        XCTAssertEqual(options(maxThreads: 10).maxThreads, 4)
-    }
-
-    func test_options_maxThreads_clampedToFloor() {
-        XCTAssertEqual(options(maxThreads: 0).maxThreads, 1)
-        XCTAssertEqual(options(maxThreads: -5).maxThreads, 1)
+        XCTAssertEqual(options().maxStackTraceFramesPerThread, 20)
     }
 
     func test_options_framesPerThread_flooredAtOne() {
@@ -114,35 +102,28 @@ final class StackTraceTruncationTests: XCTestCase {
         XCTAssertEqual(options(framesPerThread: -9).maxStackTraceFramesPerThread, 1)
     }
 
-    // MARK: - buildTruncatedThreads: thread cap
+    // MARK: - buildTruncatedThreads: threads
 
-    func test_threadCap_keepsMaxThreadsWhenCrashedIsFirst() {
+    func test_underBudget_keepsAllThreadsInOrder() {
+        // Ample budget → the byte guard drops nothing: every thread is kept, in report order.
         let all = (0..<5).map { makeThread(id: $0, frames: 10) }
         let json = Helper.buildTruncatedThreads(allFrames: all, crashedIndex: 0,
-                                                maxThreads: 2, frameCap: 20, byteBudget: 1_000_000)
+                                                frameCap: 20, byteBudget: 1_000_000)
         let decoded = decodeThreads(json)
-        XCTAssertEqual(decoded.count, 2)
-        XCTAssertEqual(binaryTag(decoded[0]), "T0")
-        XCTAssertEqual(binaryTag(decoded[1]), "T1")
+        XCTAssertEqual(decoded.map { binaryTag($0) }, ["T0", "T1", "T2", "T3", "T4"])
         XCTAssertEqual(decoded[0].count, 10) // under frame cap → untouched
     }
 
-    func test_threadCap_extendsPrefixToIncludeCrashedThread() {
-        // crashed thread at index 3, maxThreads 2 → contiguous prefix must reach index 3.
-        let all = (0..<6).map { makeThread(id: $0, frames: 8) }
+    func test_byteGuard_neverDropsBelowCrashedThreadPrefix() {
+        // crashed thread at index 3; under byte pressure the guard drops only tail threads and
+        // never reorders, so the contiguous prefix through the crashed thread (T0…T3) is retained.
+        let all = (0..<8).map { makeThread(id: $0, frames: 5) }
         let json = Helper.buildTruncatedThreads(allFrames: all, crashedIndex: 3,
-                                                maxThreads: 2, frameCap: 20, byteBudget: 1_000_000)
+                                                frameCap: 20, byteBudget: 3_000)
         let decoded = decodeThreads(json)
-        XCTAssertEqual(decoded.count, 4)
-        XCTAssertEqual(binaryTag(decoded[3]), "T3") // crashed thread present at its original position
-    }
-
-    func test_threadOrder_isNeverChanged() {
-        let all = (0..<3).map { makeThread(id: $0, frames: 5) }
-        let json = Helper.buildTruncatedThreads(allFrames: all, crashedIndex: 0,
-                                                maxThreads: 4, frameCap: 20, byteBudget: 1_000_000)
-        let decoded = decodeThreads(json)
-        XCTAssertEqual(decoded.map { binaryTag($0) }, ["T0", "T1", "T2"])
+        XCTAssertLessThan(decoded.count, 8)          // guard engaged: some tail threads dropped
+        XCTAssertGreaterThanOrEqual(decoded.count, 4) // never below the crashed-thread prefix
+        XCTAssertEqual(Array(decoded.prefix(4)).map { binaryTag($0) }, ["T0", "T1", "T2", "T3"])
     }
 
     // MARK: - buildTruncatedThreads: frame truncation
@@ -150,7 +131,7 @@ final class StackTraceTruncationTests: XCTestCase {
     func test_frameTruncation_appliedPerThread() {
         let all = [makeThread(id: 0, frames: 100)]
         let json = Helper.buildTruncatedThreads(allFrames: all, crashedIndex: 0,
-                                                maxThreads: 1, frameCap: 20, byteBudget: 1_000_000)
+                                                frameCap: 20, byteBudget: 1_000_000)
         let decoded = decodeThreads(json)
         XCTAssertEqual(decoded.count, 1)
         XCTAssertEqual(decoded[0].count, 20)
@@ -166,7 +147,7 @@ final class StackTraceTruncationTests: XCTestCase {
         let all = (0..<5).map { makeThread(id: $0, frames: 30) }
         let budget = 2_500
         let json = Helper.buildTruncatedThreads(allFrames: all, crashedIndex: 0,
-                                                maxThreads: 4, frameCap: 20, byteBudget: budget)
+                                                frameCap: 20, byteBudget: budget)
         XCTAssertLessThanOrEqual(json.utf8.count, budget)
         let decoded = decodeThreads(json)
         XCTAssertGreaterThanOrEqual(decoded.count, 1)
@@ -177,7 +158,7 @@ final class StackTraceTruncationTests: XCTestCase {
         // crashed thread is last → no tail threads may be dropped; guard must trim frames instead.
         let all = (0..<5).map { makeThread(id: $0, frames: 40) }
         let json = Helper.buildTruncatedThreads(allFrames: all, crashedIndex: 4,
-                                                maxThreads: 2, frameCap: 20, byteBudget: 2_000)
+                                                frameCap: 20, byteBudget: 2_000)
         let decoded = decodeThreads(json)
         XCTAssertEqual(decoded.count, 5)                  // all threads retained (crashed is last)
         XCTAssertEqual(binaryTag(decoded[4]), "T4")       // crashed thread present
@@ -188,7 +169,7 @@ final class StackTraceTruncationTests: XCTestCase {
 
     func test_emptyThreadsProducesEmptyArray() {
         let json = Helper.buildTruncatedThreads(allFrames: [], crashedIndex: nil,
-                                                maxThreads: 2, frameCap: 20, byteBudget: 9_000)
+                                                frameCap: 20, byteBudget: 9_000)
         XCTAssertTrue(decodeThreads(json).isEmpty)
     }
 }

--- a/Tests/CoralogixRumTests/StackTraceTruncationTests.swift
+++ b/Tests/CoralogixRumTests/StackTraceTruncationTests.swift
@@ -222,11 +222,17 @@ final class StackTraceTruncationTests: XCTestCase {
         (try? JSONSerialization.data(withJSONObject: record)).map { $0.count } ?? -1
     }
 
+    /// The SDK's `threads` span-attribute transport form (array of per-thread JSON strings) — the
+    /// trusted source the export guard reads, matching what CrashInstrumentation emits.
+    private func threadsTransport(_ threads: [[[String: Any]]]) -> String {
+        Helper.convertArrayOfStringToJsonString(array: threads.map { Helper.convertArrayToJsonString(array: $0) })
+    }
+
     func test_fitRecord_underBudget_returnedUnchanged() {
         let threads = (0..<3).map { makeThread(id: $0, frames: 5) }
         let record = crashRecord(threads: threads, crashedThreadIndex: 0)
-        let out = Helper.fitCrashRecordToByteBudget(record: record, crashedIndex: 0,
-                                                    frameCap: 20, byteBudget: 100_000)
+        let out = Helper.fitCrashRecordToByteBudget(record: record, threadsTransport: threadsTransport(threads),
+                                                    crashedIndex: 0, frameCap: 20, byteBudget: 100_000)
         XCTAssertEqual(extractThreads(out).count, 3)
         XCTAssertEqual(extractThreads(out)[0].count, 5) // nothing trimmed
     }
@@ -235,9 +241,9 @@ final class StackTraceTruncationTests: XCTestCase {
         let record: [String: Any] = [
             Keys.text.rawValue: [Keys.cxRum.rawValue: [Keys.logContext.rawValue: ["message": "hello"]]]
         ]
-        // Tiny budget, but no crash `threads` to trim → the record is left alone rather than mangled.
-        let out = Helper.fitCrashRecordToByteBudget(record: record, crashedIndex: nil,
-                                                    frameCap: 20, byteBudget: 5)
+        // Tiny budget, but no threads attribute → not a native crash → left alone rather than mangled.
+        let out = Helper.fitCrashRecordToByteBudget(record: record, threadsTransport: nil,
+                                                    crashedIndex: nil, frameCap: 20, byteBudget: 5)
         let cxRum = (out[Keys.text.rawValue] as? [String: Any])?[Keys.cxRum.rawValue] as? [String: Any]
         XCTAssertNotNil(cxRum?[Keys.logContext.rawValue])
         XCTAssertTrue(extractThreads(out).isEmpty)
@@ -248,8 +254,8 @@ final class StackTraceTruncationTests: XCTestCase {
         let record = crashRecord(threads: threads, crashedThreadIndex: 0)
         let budget = 4_000
         XCTAssertGreaterThan(recordBytes(record), budget) // precondition: starts oversized
-        let out = Helper.fitCrashRecordToByteBudget(record: record, crashedIndex: 0,
-                                                    frameCap: 20, byteBudget: budget)
+        let out = Helper.fitCrashRecordToByteBudget(record: record, threadsTransport: threadsTransport(threads),
+                                                    crashedIndex: 0, frameCap: 20, byteBudget: budget)
         XCTAssertLessThanOrEqual(recordBytes(out), budget) // the entire assembled record now fits
         XCTAssertGreaterThanOrEqual(extractThreads(out).count, 1)
         XCTAssertEqual(binaryTag(extractThreads(out)[0]), "T0") // crashed thread never dropped
@@ -260,14 +266,14 @@ final class StackTraceTruncationTests: XCTestCase {
         let budget = 6_000
         let lean = Helper.fitCrashRecordToByteBudget(
             record: crashRecord(threads: threads, crashedThreadIndex: 0),
-            crashedIndex: 0, frameCap: 20, byteBudget: budget)
+            threadsTransport: threadsTransport(threads), crashedIndex: 0, frameCap: 20, byteBudget: budget)
         let fat = Helper.fitCrashRecordToByteBudget(
             record: crashRecord(threads: threads, crashedThreadIndex: 0, envelopePadding: 3_000),
-            crashedIndex: 0, frameCap: 20, byteBudget: budget)
+            threadsTransport: threadsTransport(threads), crashedIndex: 0, frameCap: 20, byteBudget: budget)
         XCTAssertLessThanOrEqual(recordBytes(lean), budget)
         XCTAssertLessThanOrEqual(recordBytes(fat), budget)
         // The only difference is envelope size. Fewer threads survive the fat envelope — proof the
-        // guard responds to the real payload, not a fixed threads-only budget (Daniel's point).
+        // guard responds to the real assembled payload, not a fixed threads-only budget.
         XCTAssertLessThan(extractThreads(fat).count, extractThreads(lean).count)
     }
 
@@ -275,10 +281,57 @@ final class StackTraceTruncationTests: XCTestCase {
         let threads = (0..<8).map { makeThread(id: $0, frames: 10) }
         let record = crashRecord(threads: threads, crashedThreadIndex: 3)
         let budget = 6_000
-        let out = Helper.fitCrashRecordToByteBudget(record: record, crashedIndex: 3,
-                                                    frameCap: 20, byteBudget: budget)
+        let out = Helper.fitCrashRecordToByteBudget(record: record, threadsTransport: threadsTransport(threads),
+                                                    crashedIndex: 3, frameCap: 20, byteBudget: budget)
         XCTAssertLessThanOrEqual(recordBytes(out), budget)
         XCTAssertGreaterThanOrEqual(extractThreads(out).count, 4) // prefix through the crashed thread
         XCTAssertEqual(binaryTag(extractThreads(out)[3]), "T3")   // crashed thread retained with frames
+    }
+
+    func test_fitRecord_sourcesThreadsFromAttributeNotRecord() {
+        // Simulate beforeSend having reordered the record's threads: the record carries the array
+        // REVERSED, so the build-time crashedIndex would point at the wrong thread. The guard must
+        // trim the SDK's own attribute (correct order), keeping the real crashed thread T3.
+        let trusted = (0..<8).map { makeThread(id: $0, frames: 10) }
+        let record = crashRecord(threads: Array(trusted.reversed()), crashedThreadIndex: 3)
+        let budget = 6_000
+        let out = Helper.fitCrashRecordToByteBudget(record: record, threadsTransport: threadsTransport(trusted),
+                                                    crashedIndex: 3, frameCap: 20, byteBudget: budget)
+        XCTAssertLessThanOrEqual(recordBytes(out), budget)
+        XCTAssertEqual(binaryTag(extractThreads(out)[0]), "T0") // trusted order, not the reversed record
+        XCTAssertGreaterThanOrEqual(extractThreads(out).count, 4)
+        XCTAssertEqual(binaryTag(extractThreads(out)[3]), "T3") // the real crashed thread survives
+    }
+
+    func test_fitRecord_trimsEvenWhenRecordThreadsAreWrongShape() {
+        // Simulate beforeSend having left error_context.threads as a string. A cast off the record
+        // would fail and skip the guard; sourcing from the transport attribute still trims to fit.
+        let trusted = (0..<10).map { makeThread(id: $0, frames: 30) }
+        var record = crashRecord(threads: trusted, crashedThreadIndex: 0)
+        if var text = record[Keys.text.rawValue] as? [String: Any],
+           var cxRum = text[Keys.cxRum.rawValue] as? [String: Any],
+           var ec = cxRum[Keys.errorContext.rawValue] as? [String: Any] {
+            ec[Keys.threads.rawValue] = "corrupted-string"
+            cxRum[Keys.errorContext.rawValue] = ec
+            text[Keys.cxRum.rawValue] = cxRum
+            record[Keys.text.rawValue] = text
+        }
+        let budget = 4_000
+        let out = Helper.fitCrashRecordToByteBudget(record: record, threadsTransport: threadsTransport(trusted),
+                                                    crashedIndex: 0, frameCap: 20, byteBudget: budget)
+        XCTAssertLessThanOrEqual(recordBytes(out), budget) // trimmed, not skipped
+        XCTAssertGreaterThanOrEqual(extractThreads(out).count, 1)
+        XCTAssertEqual(binaryTag(extractThreads(out)[0]), "T0")
+    }
+
+    func test_fitRecord_envelopeExceedsBudget_bestEffort() {
+        // Envelope alone blows the budget → threads shrink to the minimum but can't save it. Best
+        // effort: return with the crashed thread intact rather than crashing or looping forever.
+        let trusted = (0..<5).map { makeThread(id: $0, frames: 20) }
+        let record = crashRecord(threads: trusted, crashedThreadIndex: 0, envelopePadding: 5_000)
+        let out = Helper.fitCrashRecordToByteBudget(record: record, threadsTransport: threadsTransport(trusted),
+                                                    crashedIndex: 0, frameCap: 20, byteBudget: 3_000)
+        XCTAssertLessThanOrEqual(extractThreads(out).count, trusted.count) // threads trimmed hard
+        XCTAssertEqual(binaryTag(extractThreads(out)[0]), "T0")            // crashed thread still present
     }
 }

--- a/Tests/CoralogixRumTests/StackTraceTruncationTests.swift
+++ b/Tests/CoralogixRumTests/StackTraceTruncationTests.swift
@@ -187,4 +187,98 @@ final class StackTraceTruncationTests: XCTestCase {
                                                 frameCap: 20, byteBudget: 9_000)
         XCTAssertTrue(decodeThreads(json).isEmpty)
     }
+
+    // MARK: - fitCrashRecordToByteBudget (export-time, measures the assembled record)
+
+    /// Builds a crash log record shaped like the real one: text → cx_rum → error_context → threads.
+    /// `envelopePadding` simulates a large user context / labels blob inflating everything *around*
+    /// the threads, which is exactly what a fixed threads-only budget could not see.
+    private func crashRecord(threads: [[[String: Any]]],
+                             crashedThreadIndex: Int,
+                             envelopePadding: Int = 0) -> [String: Any] {
+        var errorContext: [String: Any] = [
+            Keys.exceptionType.rawValue: "SIGSEGV",
+            Keys.triggeredByThread.rawValue: crashedThreadIndex,
+            Keys.totalThreads.rawValue: threads.count,
+            Keys.isCrash.rawValue: true,
+            Keys.threads.rawValue: threads
+        ]
+        var cxRum: [String: Any] = [Keys.errorContext.rawValue: errorContext]
+        if envelopePadding > 0 {
+            cxRum[Keys.userContext.rawValue] = String(repeating: "x", count: envelopePadding)
+        }
+        return [Keys.text.rawValue: [Keys.cxRum.rawValue: cxRum]]
+    }
+
+    private func extractThreads(_ record: [String: Any]) -> [[[String: Any]]] {
+        guard let text = record[Keys.text.rawValue] as? [String: Any],
+              let cxRum = text[Keys.cxRum.rawValue] as? [String: Any],
+              let ec = cxRum[Keys.errorContext.rawValue] as? [String: Any],
+              let threads = ec[Keys.threads.rawValue] as? [[[String: Any]]] else { return [] }
+        return threads
+    }
+
+    private func recordBytes(_ record: [String: Any]) -> Int {
+        (try? JSONSerialization.data(withJSONObject: record)).map { $0.count } ?? -1
+    }
+
+    func test_fitRecord_underBudget_returnedUnchanged() {
+        let threads = (0..<3).map { makeThread(id: $0, frames: 5) }
+        let record = crashRecord(threads: threads, crashedThreadIndex: 0)
+        let out = Helper.fitCrashRecordToByteBudget(record: record, crashedIndex: 0,
+                                                    frameCap: 20, byteBudget: 100_000)
+        XCTAssertEqual(extractThreads(out).count, 3)
+        XCTAssertEqual(extractThreads(out)[0].count, 5) // nothing trimmed
+    }
+
+    func test_fitRecord_nonCrashRecord_returnedUntouched() {
+        let record: [String: Any] = [
+            Keys.text.rawValue: [Keys.cxRum.rawValue: [Keys.logContext.rawValue: ["message": "hello"]]]
+        ]
+        // Tiny budget, but no crash `threads` to trim → the record is left alone rather than mangled.
+        let out = Helper.fitCrashRecordToByteBudget(record: record, crashedIndex: nil,
+                                                    frameCap: 20, byteBudget: 5)
+        let cxRum = (out[Keys.text.rawValue] as? [String: Any])?[Keys.cxRum.rawValue] as? [String: Any]
+        XCTAssertNotNil(cxRum?[Keys.logContext.rawValue])
+        XCTAssertTrue(extractThreads(out).isEmpty)
+    }
+
+    func test_fitRecord_overBudget_trimsUntilWholeRecordFits() {
+        let threads = (0..<10).map { makeThread(id: $0, frames: 30) }
+        let record = crashRecord(threads: threads, crashedThreadIndex: 0)
+        let budget = 4_000
+        XCTAssertGreaterThan(recordBytes(record), budget) // precondition: starts oversized
+        let out = Helper.fitCrashRecordToByteBudget(record: record, crashedIndex: 0,
+                                                    frameCap: 20, byteBudget: budget)
+        XCTAssertLessThanOrEqual(recordBytes(out), budget) // the entire assembled record now fits
+        XCTAssertGreaterThanOrEqual(extractThreads(out).count, 1)
+        XCTAssertEqual(binaryTag(extractThreads(out)[0]), "T0") // crashed thread never dropped
+    }
+
+    func test_fitRecord_largerEnvelopeForcesMoreTrimming() {
+        let threads = (0..<10).map { makeThread(id: $0, frames: 20) }
+        let budget = 6_000
+        let lean = Helper.fitCrashRecordToByteBudget(
+            record: crashRecord(threads: threads, crashedThreadIndex: 0),
+            crashedIndex: 0, frameCap: 20, byteBudget: budget)
+        let fat = Helper.fitCrashRecordToByteBudget(
+            record: crashRecord(threads: threads, crashedThreadIndex: 0, envelopePadding: 3_000),
+            crashedIndex: 0, frameCap: 20, byteBudget: budget)
+        XCTAssertLessThanOrEqual(recordBytes(lean), budget)
+        XCTAssertLessThanOrEqual(recordBytes(fat), budget)
+        // The only difference is envelope size. Fewer threads survive the fat envelope — proof the
+        // guard responds to the real payload, not a fixed threads-only budget (Daniel's point).
+        XCTAssertLessThan(extractThreads(fat).count, extractThreads(lean).count)
+    }
+
+    func test_fitRecord_retainsCrashedThreadWhenCrashedIsHighIndex() {
+        let threads = (0..<8).map { makeThread(id: $0, frames: 10) }
+        let record = crashRecord(threads: threads, crashedThreadIndex: 3)
+        let budget = 6_000
+        let out = Helper.fitCrashRecordToByteBudget(record: record, crashedIndex: 3,
+                                                    frameCap: 20, byteBudget: budget)
+        XCTAssertLessThanOrEqual(recordBytes(out), budget)
+        XCTAssertGreaterThanOrEqual(extractThreads(out).count, 4) // prefix through the crashed thread
+        XCTAssertEqual(binaryTag(extractThreads(out)[3]), "T3")   // crashed thread retained with frames
+    }
 }


### PR DESCRIPTION
# User description
## What & why

Native crash reports could exceed the backend's ~10 KB hard limit, which truncates oversized logs with unpredictable logic — it can cut mid-JSON and corrupt the stack. This bounds a crash event's size **deterministically** so it always fits, by measuring the **actual assembled payload the SDK sends** and trimming until it fits.

Part of epic CX-48436 — *Truncate stacktraces/threads in mobile*.

## What changed (native crash path only)

1. **`maxStackTraceFramesPerThread`** (default 20) — each thread's frames are truncated **middle-out**, 75/25 head/tail, so deep and recursive stacks keep both the fault site and the entry point. Applied at crash-parse time. No marker is inserted; a gap in `frame_number` is the self-describing drop signal.

2. **Export-time byte guard — measures the real record.** After the crash event is fully assembled (post-`beforeSend`, the exact JSON `SpanUploader` posts), `Helper.fitCrashRecordToByteBudget` measures the whole log record; if it exceeds the budget it deterministically drops tail threads (**never** past the crashed thread) and trims frames until the serialized record fits. Because it measures the assembled record — envelope, `cx_rum` contexts, and the `threads` array **together** — there is no estimate to under-count: a large user context, long view name, or custom labels are already in the measurement. `buildTruncatedThreads` is unchanged; it just receives a record-derived budget (`crashLogRecordByteBudget − envelope`) instead of a fixed constant.

3. **`total_threads`** — one additive top-level attribute so a truncated report reads "N of M threads" (M is the true count, before any capping).

4. **`crashed_thread_index`** — an **internal-only** span attribute carrying the crashed thread's array position from crash-parse time to export, so the byte guard can trim without dropping past the crashed thread. Never emitted on the wire; `triggered_by_thread` remains the original crash report's thread *number*, so the no-desync guarantee no longer rests on `threadNumber == arrayIndex` holding by luck.

5. **Thread-count ceiling** — `crashThreadCountCeiling` (50) caps how many threads are parsed before any work, bounding worst-case cost on a process with an unusually large thread count. The crashed thread and everything before it are always kept, so it can never drop past the crash site.

## Public API

A **single** new option: **`maxStackTraceFramesPerThread`**. (The byte budget and thread ceiling are internal tuning constants.)

An earlier draft also added `maxThreads`, but it was dropped: only iOS (PLCrashReporter) captures *multiple threads* per crash — Android, Flutter, and RN all capture a single stack — so `maxThreads` is an iOS-only concept that would break API parity across the mobile SDKs. It was also redundant with the byte guard, which already bounds thread count.

## Where the guard runs (and why export-time)

The byte guard runs in `CoralogixExporter`, not `CrashInstrumentation`, because the `cx_rum` record doesn't exist at crash-parse time — it's assembled later, at export. Measuring there means the guard sees the exact payload that goes on the wire (no OTLP re-encode for the CX log pipeline; `threads` embeds as a nested array, so there's no escaping fudge factor). It runs once per crash at the next launch, so re-serializing a shrinking payload a few times is free.

## Not changed

- **Hybrid (Flutter / React Native) paths are untouched** — `ErrorInstrumentation.swift` is not in this diff. Those SDKs own their own limit, and the export-time guard is a no-op for them (a cheap dict-lookup crash check bails out before any serialization).
- The `threads` wire shape (array-of-arrays, report order) is identical to today — threads are never reordered, so `triggered_by_thread` can't desync.

## Why middle-out (head + tail)

Keeping frames from *both* ends preserves the fault site (top) and the entry point (bottom). Tail-only truncation degenerates on stack overflow — it would show N identical recursive frames — which is why the stack is trimmed from the middle.

## Testing

`CoralogixRumTests`: **755 tests, 0 failures** (iPhone 17 Pro sim). `StackTraceTruncationTests` covers middle-out split, frame-cap floor, contiguous-prefix thread retention, order preservation, the thread byte guard (`buildTruncatedThreads`), and the new export-time `fitCrashRecordToByteBudget` — fitting the whole assembled record, a fatter envelope forcing more trimming, and the crashed thread always being retained.

## Release

- Version **2.10.1 → 2.11.0** (minor — new public API) across the 3 podspecs + `Global.sdk`.
- CHANGELOG `[2.11.0]` entry.
- README "Crash Stack Trace Limits" section with usage.

## Open

- **Actual backend limit (review #1):** the exact limit — and what it applies to (the `text` field? the whole log record? the whole HTTP request?) — is still to be confirmed against a real customer crash log; the record-level `9000` budget is conservative pending that. Measuring the whole record is a safe superset of any narrower field.
- **`frame_number` gap contract (review #3a):** dropping the omitted-frames marker makes a gap in `frame_number` the drop signal. This needs a confirmation from the backend/UI side that they treat `frame_number` as an opaque label, not a dense `0..N` index — otherwise a truncated thread renders wrong instead of being cleanly reduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Enforce deterministic crash payload sizing by streaming CrashInstrumentation metadata through to CoralogixExporter and Helper so every native crash record is truncated middle-out per thread and clipped to <code>crashLogRecordByteBudget</code> without dropping the crashed thread. Document the new <code>maxStackTraceFramesPerThread</code> option, bump podspec/SDK versions, and adjust the demo header layout so release materials reflect the iOS SDK’s crash limits.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/232?tool=ast&topic=Release+docs%2FUI>Release docs/UI</a>
        </td><td>Align release artifacts by documenting the crash stack limits, bumping every relevant podspec/<code>Global.sdk</code> version, and sizing the demo session header dynamically so the published SDK, changelog, README, and sample app all match the new behavior.<details><summary>Modified files (7)</summary><ul><li>CHANGELOG.md</li>
<li>Coralogix.podspec</li>
<li>CoralogixInternal.podspec</li>
<li>CoralogixInternal/Sources/Utils.swift</li>
<li>Example/DemoAppSwift/MainViewController.swift</li>
<li>README.md</li>
<li>SessionReplay.podspec</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>refactor: drop public ...</td><td>July 12, 2026</td></tr>
<tr><td>dan.gavrielov@coralogi...</td><td>fix(session-replay): m...</td><td>June 15, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/232?tool=ast&topic=Crash+truncation>Crash truncation</a>
        </td><td>Enforce the native crash flow by populating <code>total_threads</code> and <code>crashed_thread_index</code> in <code>CrashInstrumentation</code>, honoring <code>maxStackTraceFramesPerThread</code> in <code>CoralogixExporterOptions</code>, and running <code>Helper.fitCrashRecordToByteBudget</code> so every assembled record (post-<code>beforeSend</code>) is byte-budgeted while tests prove middle-out truncation, byte guard behavior, and preserved metadata.<details><summary>Modified files (8)</summary><ul><li>Coralogix/Sources/Exporter/CoralogixExporter.swift</li>
<li>Coralogix/Sources/Instrumentation/CrashInstrumentation.swift</li>
<li>Coralogix/Sources/Model/Contexts/ErrorContext.swift</li>
<li>Coralogix/Sources/Model/CoralogixExporterOptions.swift</li>
<li>Coralogix/Sources/Utils/Helper.swift</li>
<li>CoralogixInternal/Sources/Keys.swift</li>
<li>Tests/CoralogixRumTests/ErrorContextTests.swift</li>
<li>Tests/CoralogixRumTests/StackTraceTruncationTests.swift</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>fix: source crash thre...</td><td>July 13, 2026</td></tr>
<tr><td>aking618</td><td>Allow clearing user co...</td><td>February 19, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/coralogix/cx-ios-sdk/232?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>