### PR TITLE
fix(CX-48731): make crash-event delivery survive process death

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ Release-mechanics commits (version bumps, podspec/script tweaks, README edits) a
 omitted; the focus here is user-facing behavior changes. Tickets are referenced as
 `CX-XXXXX` (Jira) or `ALPH-XXXX` (legacy). Pull request numbers are in parentheses.
 
+## [2.11.0] - 2026-07-20
+
+### Added
+- `CoralogixRum.flush(completion:)` — forces an immediate export of queued telemetry and calls the completion once the upload attempt finishes, so a crash can be delivered before the process terminates.
+
+### Fixed
+- Crash events reported through the hybrid (React Native / Flutter) bridge are now written to disk before upload and re-sent on the next launch when delivery was not confirmed, so a crash is no longer lost if the process dies before its network upload completes.
+- Crash events upload directly instead of taking the hybrid `beforeSend` round trip to JS and back, so a dying process is not racing the extra native→JS→native hop.
+- The pending crash report is purged (and re-sent stored events removed) only after their upload is confirmed, so an unconfirmed crash from an earlier launch is no longer dropped when a later crash succeeds.
+
 ## [2.10.3] - 2026-07-14
 
 ### Fixed

--- a/Coralogix.podspec
+++ b/Coralogix.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "Coralogix"
-  spec.version      = "2.10.3"
+  spec.version      = "2.11.0"
   spec.summary      = "Coralogix OpenTelemetry pod for iOS."
 
   spec.description  = <<-DESC
@@ -29,7 +29,7 @@ Pod::Spec.new do |spec|
 
   spec.static_framework = true
   spec.dependency 'PLCrashReporter', '~> 1.12'
-  spec.dependency 'CoralogixInternal', '2.10.3'
+  spec.dependency 'CoralogixInternal', '2.11.0'
 
   spec.test_spec 'Tests' do |test|
     test.source_files = 'Tests/CoralogixRumTests/**/*.swift'

--- a/Coralogix/Sources/CoralogixRum.swift
+++ b/Coralogix/Sources/CoralogixRum.swift
@@ -16,6 +16,16 @@ public class CoralogixRum {
     /// reaching through the global `OpenTelemetry.instance` (which another OTel
     /// consumer in the host app may have re-registered).
     internal var tracerProviderSdk: TracerProviderSdk?
+    /// Disk store for hybrid crash events (see `CrashEventStore`).
+    internal lazy var crashEventStore = CrashEventStore()
+    /// Deferred purge of the pending PLCrashReporter report. Set by
+    /// `initializeCrashInstrumentation`, executed by `completeCrashRecovery()`
+    /// after init finishes — the uploader rejects requests while
+    /// `isInitialized` is false, so upload confirmation is only possible then.
+    internal var pendingCrashPurge: (() -> Void)?
+    /// Whether stored crash events from a previous process were re-emitted
+    /// during this init and await upload confirmation before being cleared.
+    internal var didEmitStoredCrashEvents = false
     internal var networkManager = NetworkManager()
     internal var viewManager = ViewManager(keyChain: KeychainManager())
     internal var sessionManager: SessionManager?
@@ -126,6 +136,10 @@ public class CoralogixRum {
         self.createInitSpan()
 
         CoralogixRum.isInitialized = true
+
+        // Must run after isInitialized flips: SpanUploader rejects uploads and
+        // flush() no-ops before that, so crash recovery could never be confirmed.
+        self.completeCrashRecovery()
     }
     
     private func initializeEnabledInstrumentations(using options: CoralogixExporterOptions) {

--- a/Coralogix/Sources/CoralogixRum.swift
+++ b/Coralogix/Sources/CoralogixRum.swift
@@ -26,6 +26,9 @@ public class CoralogixRum {
     /// Whether stored crash events from a previous process were re-emitted
     /// during this init and await upload confirmation before being cleared.
     internal var didEmitStoredCrashEvents = false
+    /// Guards `pendingCrashPurge` and `didEmitStoredCrashEvents`: they are written
+    /// during init and read-and-cleared on `flush`'s background completion.
+    internal let crashRecoveryLock = NSLock()
     internal var networkManager = NetworkManager()
     internal var viewManager = ViewManager(keyChain: KeychainManager())
     internal var sessionManager: SessionManager?

--- a/Coralogix/Sources/CoralogixRum.swift
+++ b/Coralogix/Sources/CoralogixRum.swift
@@ -23,12 +23,16 @@ public class CoralogixRum {
     /// after init finishes — the uploader rejects requests while
     /// `isInitialized` is false, so upload confirmation is only possible then.
     internal var pendingCrashPurge: (() -> Void)?
+    /// Correlation id of the pending PLCrashReporter report's span, so its purge
+    /// is gated on that report's own upload rather than any crash upload.
+    internal var pendingCrashReportId: String?
     /// Store identities of the crash events re-emitted during this init, awaiting
     /// upload confirmation. Only these are removed on confirm — an event persisted
     /// after the resend (e.g. a fresh runtime crash) keeps its own lifecycle.
     internal var pendingRecoveryCrashEventIds: Set<String> = []
-    /// Guards `pendingCrashPurge` and `pendingRecoveryCrashEventIds`: they are
-    /// written during init and read-and-cleared on `flush`'s background completion.
+    /// Guards `pendingCrashPurge`, `pendingCrashReportId`, and
+    /// `pendingRecoveryCrashEventIds`: written during init and read-and-cleared on
+    /// `flush`'s background completion.
     internal let crashRecoveryLock = NSLock()
     internal var networkManager = NetworkManager()
     internal var viewManager = ViewManager(keyChain: KeychainManager())

--- a/Coralogix/Sources/CoralogixRum.swift
+++ b/Coralogix/Sources/CoralogixRum.swift
@@ -23,11 +23,12 @@ public class CoralogixRum {
     /// after init finishes — the uploader rejects requests while
     /// `isInitialized` is false, so upload confirmation is only possible then.
     internal var pendingCrashPurge: (() -> Void)?
-    /// Whether stored crash events from a previous process were re-emitted
-    /// during this init and await upload confirmation before being cleared.
-    internal var didEmitStoredCrashEvents = false
-    /// Guards `pendingCrashPurge` and `didEmitStoredCrashEvents`: they are written
-    /// during init and read-and-cleared on `flush`'s background completion.
+    /// Store identities of the crash events re-emitted during this init, awaiting
+    /// upload confirmation. Only these are removed on confirm — an event persisted
+    /// after the resend (e.g. a fresh runtime crash) keeps its own lifecycle.
+    internal var pendingRecoveryCrashEventIds: Set<String> = []
+    /// Guards `pendingCrashPurge` and `pendingRecoveryCrashEventIds`: they are
+    /// written during init and read-and-cleared on `flush`'s background completion.
     internal let crashRecoveryLock = NSLock()
     internal var networkManager = NetworkManager()
     internal var viewManager = ViewManager(keyChain: KeychainManager())

--- a/Coralogix/Sources/CoralogixRum.swift
+++ b/Coralogix/Sources/CoralogixRum.swift
@@ -12,6 +12,10 @@ extension Notification.Name {
 
 public class CoralogixRum {
     internal var coralogixExporter: CoralogixExporter?
+    /// The SDK's own tracer provider, kept so `flush()` can force-export without
+    /// reaching through the global `OpenTelemetry.instance` (which another OTel
+    /// consumer in the host app may have re-registered).
+    internal var tracerProviderSdk: TracerProviderSdk?
     internal var networkManager = NetworkManager()
     internal var viewManager = ViewManager(keyChain: KeychainManager())
     internal var sessionManager: SessionManager?
@@ -171,7 +175,8 @@ public class CoralogixRum {
             .with(resource: resource)
             .add(spanProcessor: spanProcessor)
             .build()
-        
+
+        self.tracerProviderSdk = tracerProvider
         OpenTelemetry.registerTracerProvider(tracerProvider: tracerProvider)
     }
     
@@ -360,6 +365,22 @@ public class CoralogixRum {
         self.logWith(severity: severity, message: message, data: data, labels: labels)
     }
     
+    /// Forces immediate export of every span still queued in the batch processor,
+    /// which otherwise holds spans for up to `Global.BatchSpan.scheduleDelay` seconds.
+    /// Uploads happen synchronously on a background queue; `completion` fires once the
+    /// flush attempt (successful or not) finishes. Called automatically when a crash
+    /// is reported; hybrid bridges call it before a fatal error terminates the process.
+    public func flush(completion: (() -> Void)? = nil) {
+        guard CoralogixRum.isInitialized, let tracerProviderSdk = self.tracerProviderSdk else {
+            completion?()
+            return
+        }
+        DispatchQueue.global(qos: .userInitiated).async {
+            tracerProviderSdk.forceFlush(timeout: TimeInterval(Global.BatchSpan.forceFlushTimeout.rawValue))
+            completion?()
+        }
+    }
+
     public func shutdown() {
         CoralogixCustomGlobalSpanRegistry.shared.teardownIfNeeded()
         Self.customTracerIssuanceLock.lock()

--- a/Coralogix/Sources/Exporter/CoralogixExporter.swift
+++ b/Coralogix/Sources/Exporter/CoralogixExporter.swift
@@ -24,24 +24,39 @@ public class CoralogixExporter: SpanExporter {
     private var currentSessionSampledIn: Bool = true
     private let samplingStateLock = NSLock()
 
-    /// `true` once a batch containing at least one crash event (`error_context.is_crash`)
-    /// uploaded successfully in this process. CrashInstrumentation consults this to decide
-    /// whether the pending PLCrashReporter report may be purged — kept pessimistic on
-    /// failure so the report survives on disk and is retried on the next launch.
-    private var crashUploadConfirmed = false
+    /// Correlation ids (`crash_event_id`) of crash events whose upload was confirmed
+    /// in this process. Confirmation is per-event, not a process-wide flag: a crash
+    /// is only removed from disk / its PLCrashReporter report purged once THAT crash's
+    /// own upload succeeded, so a later failed crash can't be dropped just because an
+    /// earlier one delivered.
+    private var confirmedCrashEventIds: Set<String> = []
     private let crashUploadLock = NSLock()
 
-    var didUploadCrashEvents: Bool {
+    func didConfirmCrashUpload(id: String) -> Bool {
         crashUploadLock.lock()
         defer { crashUploadLock.unlock() }
-        return crashUploadConfirmed
+        return confirmedCrashEventIds.contains(id)
     }
 
-    private func recordCrashUpload(succeeded: Bool) {
-        guard succeeded else { return }
+    private func recordCrashUpload(ids: Set<String>, succeeded: Bool) {
+        guard succeeded, !ids.isEmpty else { return }
         crashUploadLock.lock()
-        crashUploadConfirmed = true
+        confirmedCrashEventIds.formUnion(ids)
         crashUploadLock.unlock()
+    }
+
+    /// Correlation ids of the crash events in this batch, read from the raw span
+    /// attribute. The attribute is not mapped into cx_rum, so it stays off the wire.
+    private func crashEventIds(in spans: [SpanData]) -> Set<String> {
+        var ids: Set<String> = []
+        for span in spans {
+            guard (span.getAttribute(forKey: Keys.isCrash.rawValue) as? String) == "true",
+                  let id = span.getAttribute(forKey: Keys.crashEventId.rawValue) as? String else {
+                continue
+            }
+            ids.insert(id)
+        }
+        return ids
     }
 
     public init(options: CoralogixExporterOptions,
@@ -223,6 +238,9 @@ public class CoralogixExporter: SpanExporter {
                 return .success
             }
             
+            // Crash correlation ids present in this batch, read from the raw spans.
+            let crashIds = self.crashEventIds(in: uniqueSpans)
+
             let sdk = CoralogixRum.mobileSDK.sdkFramework
             if !sdk.isNative, let callback = self.options.beforeSendCallBack {
                 // Crash events skip the hybrid JS round trip: when a crash is exported the
@@ -235,7 +253,7 @@ public class CoralogixExporter: SpanExporter {
                 var result: SpanExporterResultCode = .success
                 if !crashSpans.isEmpty {
                     result = spanUploader.upload(crashSpans, endPoint: self.endPoint)
-                    recordCrashUpload(succeeded: result == .success)
+                    recordCrashUpload(ids: crashIds, succeeded: result == .success)
                 }
                 if !editableSpans.isEmpty {
                     let clonedSpans = editableSpans.deepCopy()
@@ -243,10 +261,9 @@ public class CoralogixExporter: SpanExporter {
                 }
                 return result
             }
-            let containsCrashEvent = cxSpansDictionary.contains { self.isCrashEvent($0) }
             let result = spanUploader.upload(cxSpansDictionary, endPoint: self.endPoint)
-            if containsCrashEvent {
-                recordCrashUpload(succeeded: result == .success)
+            if !crashIds.isEmpty {
+                recordCrashUpload(ids: crashIds, succeeded: result == .success)
             }
             return result
         }

--- a/Coralogix/Sources/Exporter/CoralogixExporter.swift
+++ b/Coralogix/Sources/Exporter/CoralogixExporter.swift
@@ -227,7 +227,8 @@ public class CoralogixExporter: SpanExporter {
             if !sdk.isNative, let callback = self.options.beforeSendCallBack {
                 // Crash events skip the hybrid JS round trip: when a crash is exported the
                 // process is usually about to terminate, and the extra native→JS→native hop
-                // loses the race. They upload verbatim; beforeSend cannot edit or drop them.
+                // loses the race. The hybrid beforeSend callback cannot edit or drop them;
+                // the native beforeSend option (applied during encoding) still can.
                 let crashSpans = cxSpansDictionary.filter { self.isCrashEvent($0) }
                 let editableSpans = cxSpansDictionary.filter { !self.isCrashEvent($0) }
 

--- a/Coralogix/Sources/Exporter/CoralogixExporter.swift
+++ b/Coralogix/Sources/Exporter/CoralogixExporter.swift
@@ -24,6 +24,26 @@ public class CoralogixExporter: SpanExporter {
     private var currentSessionSampledIn: Bool = true
     private let samplingStateLock = NSLock()
 
+    /// `true` once a batch containing at least one crash event (`error_context.is_crash`)
+    /// uploaded successfully in this process. CrashInstrumentation consults this to decide
+    /// whether the pending PLCrashReporter report may be purged — kept pessimistic on
+    /// failure so the report survives on disk and is retried on the next launch.
+    private var crashUploadConfirmed = false
+    private let crashUploadLock = NSLock()
+
+    var didUploadCrashEvents: Bool {
+        crashUploadLock.lock()
+        defer { crashUploadLock.unlock() }
+        return crashUploadConfirmed
+    }
+
+    private func recordCrashUpload(succeeded: Bool) {
+        guard succeeded else { return }
+        crashUploadLock.lock()
+        crashUploadConfirmed = true
+        crashUploadLock.unlock()
+    }
+
     public init(options: CoralogixExporterOptions,
                 sessionManager: SessionManager,
                 networkManager: NetworkProtocol,
@@ -205,13 +225,42 @@ public class CoralogixExporter: SpanExporter {
             
             let sdk = CoralogixRum.mobileSDK.sdkFramework
             if !sdk.isNative, let callback = self.options.beforeSendCallBack {
-                let clonedSpans = cxSpansDictionary.deepCopy()
-                callback(clonedSpans)
-                return .success
+                // Crash events skip the hybrid JS round trip: when a crash is exported the
+                // process is usually about to terminate, and the extra native→JS→native hop
+                // loses the race. They upload verbatim; beforeSend cannot edit or drop them.
+                let crashSpans = cxSpansDictionary.filter { self.isCrashEvent($0) }
+                let editableSpans = cxSpansDictionary.filter { !self.isCrashEvent($0) }
+
+                var result: SpanExporterResultCode = .success
+                if !crashSpans.isEmpty {
+                    result = spanUploader.upload(crashSpans, endPoint: self.endPoint)
+                    recordCrashUpload(succeeded: result == .success)
+                }
+                if !editableSpans.isEmpty {
+                    let clonedSpans = editableSpans.deepCopy()
+                    callback(clonedSpans)
+                }
+                return result
             }
-            return spanUploader.upload(cxSpansDictionary, endPoint: self.endPoint)
+            let containsCrashEvent = cxSpansDictionary.contains { self.isCrashEvent($0) }
+            let result = spanUploader.upload(cxSpansDictionary, endPoint: self.endPoint)
+            if containsCrashEvent {
+                recordCrashUpload(succeeded: result == .success)
+            }
+            return result
         }
         return .failure
+    }
+
+    /// Whether an encoded span carries `error_context.is_crash == true` — a crash reported
+    /// through the hybrid bridge or rebuilt from a pending PLCrashReporter report.
+    private func isCrashEvent(_ encodedSpan: [String: Any]) -> Bool {
+        guard let text = encodedSpan[Keys.text.rawValue] as? [String: Any],
+              let cxRum = text[Keys.cxRum.rawValue] as? [String: Any],
+              let errorContext = cxRum[Keys.errorContext.rawValue] as? [String: Any] else {
+            return false
+        }
+        return errorContext[Keys.isCrash.rawValue] as? Bool ?? false
     }
 
     public func flush(explicitTimeout: TimeInterval?) -> SpanExporterResultCode {

--- a/Coralogix/Sources/Instrumentation/CrashInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/CrashInstrumentation.swift
@@ -34,27 +34,42 @@ extension CoralogixRum {
         // Try loading the crash report.
         if crashReporter.hasPendingCrashReport() {
             if self.processPendingCrashReport(using: crashReporter) {
-                self.purgePendingReportAfterConfirmedUpload(crashReporter)
+                // Purge is deferred to completeCrashRecovery(): it must only happen
+                // after the upload is confirmed, and the uploader rejects requests
+                // until init finishes. Previously the purge was unconditional and ran
+                // before the span even left the batch queue, so a short-lived relaunch
+                // or an upload failure lost the crash permanently.
+                self.pendingCrashPurge = { crashReporter.purgePendingCrashReport() }
             } else {
                 // Nothing recoverable was emitted — drop the corrupt report so it
                 // isn't reprocessed (and re-fails) on every launch.
                 crashReporter.purgePendingCrashReport()
             }
         }
+
+        // Hybrid crash events persisted by a previous process (see CrashEventStore).
+        self.resendPendingStoredCrashEvents()
     }
 
-    /// Purges the pending PLCrashReporter report only once its event upload is
-    /// confirmed. On failure the report stays on disk and is retried on the next
-    /// launch (at-least-once delivery). Previously the purge was unconditional and
-    /// ran before the span even left the batch queue, so a short-lived relaunch or
-    /// an upload failure lost the crash permanently.
-    private func purgePendingReportAfterConfirmedUpload(_ crashReporter: PLCrashReporter) {
+    /// Final step of crash recovery, run right after init completes: force-flushes
+    /// the crash spans emitted during `initializeCrashInstrumentation` and, only
+    /// once their upload is confirmed, purges the pending PLCrashReporter report
+    /// and clears the hybrid crash-event store. Unconfirmed data stays on disk and
+    /// is retried on the next launch (at-least-once delivery).
+    internal func completeCrashRecovery() {
+        guard self.pendingCrashPurge != nil || self.didEmitStoredCrashEvents else { return }
         self.flush { [weak self] in
-            guard self?.coralogixExporter?.didUploadCrashEvents == true else {
-                Log.w("Crash-report upload not confirmed — keeping pending report for next launch")
+            guard let self else { return }
+            guard self.coralogixExporter?.didUploadCrashEvents == true else {
+                Log.w("Crash-report upload not confirmed — keeping pending crash data for next launch")
                 return
             }
-            crashReporter.purgePendingCrashReport()
+            self.pendingCrashPurge?()
+            self.pendingCrashPurge = nil
+            if self.didEmitStoredCrashEvents {
+                self.crashEventStore.clear()
+                self.didEmitStoredCrashEvents = false
+            }
         }
     }
 

--- a/Coralogix/Sources/Instrumentation/CrashInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/CrashInstrumentation.swift
@@ -132,7 +132,9 @@ extension CoralogixRum {
     /// Replaces the current-session attributes `makeSpan` stamped on the crash span
     /// with the session that was live when the crash happened. No-op when there is
     /// no previous-launch session on record — the span keeps the current session.
-    private func overrideSessionForCrashedSession(on span: any Span) {
+    /// Internal: the CrashEventStore resend path (ErrorInstrumentation) applies the
+    /// same attribution to recovered hybrid crash events.
+    internal func overrideSessionForCrashedSession(on span: any Span) {
         guard let sessionManager = self.coralogixExporter?.getSessionManager() else { return }
         for attr in sessionManager.lastLaunchSessionSpanAttributes() {
             span.setAttribute(key: attr.key, value: attr.value)

--- a/Coralogix/Sources/Instrumentation/CrashInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/CrashInstrumentation.swift
@@ -56,11 +56,13 @@ extension CoralogixRum {
     /// Final step of crash recovery, run right after init completes: force-flushes
     /// the crash spans emitted during `initializeCrashInstrumentation` and, only
     /// once their upload is confirmed, purges the pending PLCrashReporter report
-    /// and clears the hybrid crash-event store. Unconfirmed data stays on disk and
-    /// is retried on the next launch (at-least-once delivery).
+    /// and removes the re-sent events from the crash-event store. Removal is by
+    /// event id, so an event persisted after the resend (a fresh runtime crash)
+    /// is untouched. Unconfirmed data stays on disk and is retried on the next
+    /// launch (at-least-once delivery).
     internal func completeCrashRecovery() {
         crashRecoveryLock.lock()
-        let hasPendingWork = pendingCrashPurge != nil || didEmitStoredCrashEvents
+        let hasPendingWork = pendingCrashPurge != nil || !pendingRecoveryCrashEventIds.isEmpty
         crashRecoveryLock.unlock()
         guard hasPendingWork else { return }
 
@@ -73,15 +75,13 @@ extension CoralogixRum {
             // Snapshot-and-clear under the lock; run the purge (file IO) outside it.
             self.crashRecoveryLock.lock()
             let purge = self.pendingCrashPurge
-            let clearStore = self.didEmitStoredCrashEvents
+            let confirmedIds = self.pendingRecoveryCrashEventIds
             self.pendingCrashPurge = nil
-            self.didEmitStoredCrashEvents = false
+            self.pendingRecoveryCrashEventIds = []
             self.crashRecoveryLock.unlock()
 
             purge?()
-            if clearStore {
-                self.crashEventStore.clear()
-            }
+            self.crashEventStore.remove(ids: confirmedIds)
         }
     }
 

--- a/Coralogix/Sources/Instrumentation/CrashInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/CrashInstrumentation.swift
@@ -39,7 +39,9 @@ extension CoralogixRum {
                 // until init finishes. Previously the purge was unconditional and ran
                 // before the span even left the batch queue, so a short-lived relaunch
                 // or an upload failure lost the crash permanently.
+                crashRecoveryLock.lock()
                 self.pendingCrashPurge = { crashReporter.purgePendingCrashReport() }
+                crashRecoveryLock.unlock()
             } else {
                 // Nothing recoverable was emitted — drop the corrupt report so it
                 // isn't reprocessed (and re-fails) on every launch.
@@ -57,18 +59,28 @@ extension CoralogixRum {
     /// and clears the hybrid crash-event store. Unconfirmed data stays on disk and
     /// is retried on the next launch (at-least-once delivery).
     internal func completeCrashRecovery() {
-        guard self.pendingCrashPurge != nil || self.didEmitStoredCrashEvents else { return }
+        crashRecoveryLock.lock()
+        let hasPendingWork = pendingCrashPurge != nil || didEmitStoredCrashEvents
+        crashRecoveryLock.unlock()
+        guard hasPendingWork else { return }
+
         self.flush { [weak self] in
             guard let self else { return }
             guard self.coralogixExporter?.didUploadCrashEvents == true else {
                 Log.w("Crash-report upload not confirmed — keeping pending crash data for next launch")
                 return
             }
-            self.pendingCrashPurge?()
+            // Snapshot-and-clear under the lock; run the purge (file IO) outside it.
+            self.crashRecoveryLock.lock()
+            let purge = self.pendingCrashPurge
+            let clearStore = self.didEmitStoredCrashEvents
             self.pendingCrashPurge = nil
-            if self.didEmitStoredCrashEvents {
+            self.didEmitStoredCrashEvents = false
+            self.crashRecoveryLock.unlock()
+
+            purge?()
+            if clearStore {
                 self.crashEventStore.clear()
-                self.didEmitStoredCrashEvents = false
             }
         }
     }

--- a/Coralogix/Sources/Instrumentation/CrashInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/CrashInstrumentation.swift
@@ -33,7 +33,10 @@ extension CoralogixRum {
 
         // Try loading the crash report.
         if crashReporter.hasPendingCrashReport() {
-            if self.processPendingCrashReport(using: crashReporter) {
+            // Correlation id tying the emitted crash span to its upload confirmation,
+            // so the purge is gated on THIS report's own delivery.
+            let reportId = UUID().uuidString
+            if self.processPendingCrashReport(using: crashReporter, crashEventId: reportId) {
                 // Purge is deferred to completeCrashRecovery(): it must only happen
                 // after the upload is confirmed, and the uploader rejects requests
                 // until init finishes. Previously the purge was unconditional and ran
@@ -41,6 +44,7 @@ extension CoralogixRum {
                 // or an upload failure lost the crash permanently.
                 crashRecoveryLock.lock()
                 self.pendingCrashPurge = { crashReporter.purgePendingCrashReport() }
+                self.pendingCrashReportId = reportId
                 crashRecoveryLock.unlock()
             } else {
                 // Nothing recoverable was emitted — drop the corrupt report so it
@@ -54,12 +58,12 @@ extension CoralogixRum {
     }
 
     /// Final step of crash recovery, run right after init completes: force-flushes
-    /// the crash spans emitted during `initializeCrashInstrumentation` and, only
-    /// once their upload is confirmed, purges the pending PLCrashReporter report
-    /// and removes the re-sent events from the crash-event store. Removal is by
-    /// event id, so an event persisted after the resend (a fresh runtime crash)
-    /// is untouched. Unconfirmed data stays on disk and is retried on the next
-    /// launch (at-least-once delivery).
+    /// the crash spans emitted during `initializeCrashInstrumentation`, then decides
+    /// per-event what to clean up. Each recovered crash is confirmed independently by
+    /// its correlation id, so the PLCrashReporter report is purged only if its own
+    /// span uploaded, and only the stored events whose own upload succeeded are
+    /// removed. Anything unconfirmed stays on disk / on the pending report and is
+    /// retried on the next launch (at-least-once delivery).
     internal func completeCrashRecovery() {
         crashRecoveryLock.lock()
         let hasPendingWork = pendingCrashPurge != nil || !pendingRecoveryCrashEventIds.isEmpty
@@ -67,27 +71,38 @@ extension CoralogixRum {
         guard hasPendingWork else { return }
 
         self.flush { [weak self] in
-            guard let self else { return }
-            guard self.coralogixExporter?.didUploadCrashEvents == true else {
-                Log.w("Crash-report upload not confirmed — keeping pending crash data for next launch")
-                return
-            }
-            // Snapshot-and-clear under the lock; run the purge (file IO) outside it.
+            guard let self, let exporter = self.coralogixExporter else { return }
+
+            // Snapshot-and-clear the process-scoped recovery state under the lock;
+            // do the confirmation checks and file IO outside it. Cleared state is
+            // repopulated from the store / pending report on the next launch, so an
+            // unconfirmed item is retried rather than lost.
             self.crashRecoveryLock.lock()
             let purge = self.pendingCrashPurge
-            let confirmedIds = self.pendingRecoveryCrashEventIds
+            let reportId = self.pendingCrashReportId
+            let recoveryIds = self.pendingRecoveryCrashEventIds
             self.pendingCrashPurge = nil
+            self.pendingCrashReportId = nil
             self.pendingRecoveryCrashEventIds = []
             self.crashRecoveryLock.unlock()
 
-            purge?()
-            self.crashEventStore.remove(ids: confirmedIds)
+            // PLCrashReporter report: purge only if its own span uploaded.
+            if let reportId, exporter.didConfirmCrashUpload(id: reportId) {
+                purge?()
+            } else if reportId != nil {
+                Log.w("Crash-report upload not confirmed — keeping pending report for next launch")
+            }
+
+            // Stored hybrid crashes: remove only the ones whose own upload succeeded.
+            let confirmedStoreIds = recoveryIds.filter { exporter.didConfirmCrashUpload(id: $0) }
+            self.crashEventStore.remove(ids: confirmedStoreIds)
         }
     }
 
     /// Returns `true` when the report was parsed and emitted as a crash span,
-    /// `false` when the report could not be loaded or parsed.
-    private func processPendingCrashReport(using crashReporter: PLCrashReporter) -> Bool {
+    /// `false` when the report could not be loaded or parsed. `crashEventId`
+    /// correlates the emitted span with its upload confirmation.
+    private func processPendingCrashReport(using crashReporter: PLCrashReporter, crashEventId: String) -> Bool {
         do {
             let data = try crashReporter.loadPendingCrashReportDataAndReturnError()
             
@@ -103,6 +118,7 @@ extension CoralogixRum {
             self.overrideSessionForCrashedSession(on: span)
             self.overrideViewForCrashedSession(on: span)
 
+            span.setAttribute(key: Keys.crashEventId.rawValue, value: crashEventId)
             span.setAttribute(key: Keys.exceptionType.rawValue, value: report.signalInfo.name)
             if let crashTimestamp {
                 span.setAttribute(key: Keys.crashTimestamp.rawValue, value: "\(crashTimestamp.timeIntervalSince1970.milliseconds)")

--- a/Coralogix/Sources/Instrumentation/CrashInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/CrashInstrumentation.swift
@@ -30,16 +30,37 @@ extension CoralogixRum {
         }
         
         crashReporter.enable()
-        
+
         // Try loading the crash report.
         if crashReporter.hasPendingCrashReport() {
-            self.processPendingCrashReport(using: crashReporter)
-            // Purge the report.
+            if self.processPendingCrashReport(using: crashReporter) {
+                self.purgePendingReportAfterConfirmedUpload(crashReporter)
+            } else {
+                // Nothing recoverable was emitted — drop the corrupt report so it
+                // isn't reprocessed (and re-fails) on every launch.
+                crashReporter.purgePendingCrashReport()
+            }
+        }
+    }
+
+    /// Purges the pending PLCrashReporter report only once its event upload is
+    /// confirmed. On failure the report stays on disk and is retried on the next
+    /// launch (at-least-once delivery). Previously the purge was unconditional and
+    /// ran before the span even left the batch queue, so a short-lived relaunch or
+    /// an upload failure lost the crash permanently.
+    private func purgePendingReportAfterConfirmedUpload(_ crashReporter: PLCrashReporter) {
+        self.flush { [weak self] in
+            guard self?.coralogixExporter?.didUploadCrashEvents == true else {
+                Log.w("Crash-report upload not confirmed — keeping pending report for next launch")
+                return
+            }
             crashReporter.purgePendingCrashReport()
         }
     }
-    
-    private func processPendingCrashReport(using crashReporter: PLCrashReporter) {
+
+    /// Returns `true` when the report was parsed and emitted as a crash span,
+    /// `false` when the report could not be loaded or parsed.
+    private func processPendingCrashReport(using crashReporter: PLCrashReporter) -> Bool {
         do {
             let data = try crashReporter.loadPendingCrashReportDataAndReturnError()
             
@@ -86,8 +107,10 @@ extension CoralogixRum {
             } else {
                 span.end()
             }
+            return true
         } catch let error {
             Log.e("CrashReporter failed to load and parse with error: \(error)")
+            return false
         }
     }
 

--- a/Coralogix/Sources/Instrumentation/ErrorInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/ErrorInstrumentation.swift
@@ -159,7 +159,12 @@ extension CoralogixRum {
         if let arch { event[Keys.arch.rawValue] = arch }
         if let buildId { event[Keys.buildId.rawValue] = buildId }
         if let stackTraceType { event[Keys.stackTraceType.rawValue] = stackTraceType }
-        if let customAttributes { event[Keys.data.rawValue] = customAttributes }
+        // Stored as a JSON string (not the raw dictionary): callers can pass values
+        // JSONSerialization rejects (e.g. Date), which would abort the whole store
+        // write and silently drop the crash backup.
+        if let json = Helper.jsonAttributeString(dict: customAttributes) {
+            event[Keys.data.rawValue] = json
+        }
         crashEventStore.append(event)
     }
 
@@ -182,11 +187,14 @@ extension CoralogixRum {
                 arch: event[Keys.arch.rawValue] as? String,
                 buildId: event[Keys.buildId.rawValue] as? String,
                 stackTraceType: event[Keys.stackTraceType.rawValue] as? String,
-                customAttributes: event[Keys.data.rawValue] as? [String: Any],
+                customAttributes: (event[Keys.data.rawValue] as? String)
+                    .flatMap { Helper.convertJsonStringToDict(jsonString: $0) },
                 crashTimestamp: event[Keys.crashTimestamp.rawValue] as? String
             )
         }
+        crashRecoveryLock.lock()
         self.didEmitStoredCrashEvents = true
+        crashRecoveryLock.unlock()
     }
 
     func logWith(severity: CoralogixLogSeverity,

--- a/Coralogix/Sources/Instrumentation/ErrorInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/ErrorInstrumentation.swift
@@ -110,17 +110,18 @@ extension CoralogixRum {
                                      stackTraceType: String? = nil,
                                      customAttributes: [String: Any]? = nil) {
         guard isErrorsEnabled else { return }
+        var persistedEventId: String?
         if isCrash {
             // Persisted BEFORE the span is created: the process is usually about to
             // die, and only a disk write is guaranteed to finish in time. The stored
-            // copy is cleared once an upload is confirmed — or re-sent next launch.
-            self.persistCrashEvent(message: message,
-                                   stackTraceJson: stackTraceJson,
-                                   errorType: errorType,
-                                   arch: arch,
-                                   buildId: buildId,
-                                   stackTraceType: stackTraceType,
-                                   customAttributes: customAttributes)
+            // copy is removed once an upload is confirmed — or re-sent next launch.
+            persistedEventId = self.persistCrashEvent(message: message,
+                                                      stackTraceJson: stackTraceJson,
+                                                      errorType: errorType,
+                                                      arch: arch,
+                                                      buildId: buildId,
+                                                      stackTraceType: stackTraceType,
+                                                      customAttributes: customAttributes)
         }
         self.writeError(
             domain: "",
@@ -136,9 +137,13 @@ extension CoralogixRum {
         if isCrash {
             // A crash report usually precedes process death — don't leave the event
             // in the batch queue (up to 2s) where it would die with the process.
+            // On confirmation, remove only THIS event: the store may still hold an
+            // unconfirmed backlog from a previous launch awaiting its own delivery.
             self.flush { [weak self] in
                 guard let self, self.coralogixExporter?.didUploadCrashEvents == true else { return }
-                self.crashEventStore.clear()
+                if let persistedEventId {
+                    self.crashEventStore.remove(ids: [persistedEventId])
+                }
             }
         }
     }
@@ -149,7 +154,7 @@ extension CoralogixRum {
                                    arch: String?,
                                    buildId: String?,
                                    stackTraceType: String?,
-                                   customAttributes: [String: Any]?) {
+                                   customAttributes: [String: Any]?) -> String {
         var event: [String: Any] = [
             Keys.errorMessage.rawValue: message,
             Keys.crashTimestamp.rawValue: String(Date().timeIntervalSince1970.milliseconds)
@@ -165,7 +170,7 @@ extension CoralogixRum {
         if let json = Helper.jsonAttributeString(dict: customAttributes) {
             event[Keys.data.rawValue] = json
         }
-        crashEventStore.append(event)
+        return crashEventStore.append(event)
     }
 
     /// Re-emits crash events persisted by a previous process whose upload was never
@@ -192,8 +197,9 @@ extension CoralogixRum {
                 crashTimestamp: event[Keys.crashTimestamp.rawValue] as? String
             )
         }
+        let resentIds = Set(pending.compactMap { $0[CrashEventStore.eventIdKey] as? String })
         crashRecoveryLock.lock()
-        self.didEmitStoredCrashEvents = true
+        self.pendingRecoveryCrashEventIds = resentIds
         crashRecoveryLock.unlock()
     }
 

--- a/Coralogix/Sources/Instrumentation/ErrorInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/ErrorInstrumentation.swift
@@ -121,6 +121,11 @@ extension CoralogixRum {
             stackTraceType: stackTraceType,
             customAttributes: customAttributes
         )
+        if isCrash {
+            // A crash report usually precedes process death — don't leave the event
+            // in the batch queue (up to 2s) where it would die with the process.
+            self.flush()
+        }
     }
 
     func logWith(severity: CoralogixLogSeverity,

--- a/Coralogix/Sources/Instrumentation/ErrorInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/ErrorInstrumentation.swift
@@ -110,6 +110,18 @@ extension CoralogixRum {
                                      stackTraceType: String? = nil,
                                      customAttributes: [String: Any]? = nil) {
         guard isErrorsEnabled else { return }
+        if isCrash {
+            // Persisted BEFORE the span is created: the process is usually about to
+            // die, and only a disk write is guaranteed to finish in time. The stored
+            // copy is cleared once an upload is confirmed — or re-sent next launch.
+            self.persistCrashEvent(message: message,
+                                   stackTraceJson: stackTraceJson,
+                                   errorType: errorType,
+                                   arch: arch,
+                                   buildId: buildId,
+                                   stackTraceType: stackTraceType,
+                                   customAttributes: customAttributes)
+        }
         self.writeError(
             domain: "",
             message: message,
@@ -124,8 +136,57 @@ extension CoralogixRum {
         if isCrash {
             // A crash report usually precedes process death — don't leave the event
             // in the batch queue (up to 2s) where it would die with the process.
-            self.flush()
+            self.flush { [weak self] in
+                guard let self, self.coralogixExporter?.didUploadCrashEvents == true else { return }
+                self.crashEventStore.clear()
+            }
         }
+    }
+
+    private func persistCrashEvent(message: String,
+                                   stackTraceJson: String?,
+                                   errorType: String?,
+                                   arch: String?,
+                                   buildId: String?,
+                                   stackTraceType: String?,
+                                   customAttributes: [String: Any]?) {
+        var event: [String: Any] = [
+            Keys.errorMessage.rawValue: message,
+            Keys.crashTimestamp.rawValue: String(Date().timeIntervalSince1970.milliseconds)
+        ]
+        if let stackTraceJson { event[Keys.stackTrace.rawValue] = stackTraceJson }
+        if let errorType { event[Keys.errorType.rawValue] = errorType }
+        if let arch { event[Keys.arch.rawValue] = arch }
+        if let buildId { event[Keys.buildId.rawValue] = buildId }
+        if let stackTraceType { event[Keys.stackTraceType.rawValue] = stackTraceType }
+        if let customAttributes { event[Keys.data.rawValue] = customAttributes }
+        crashEventStore.append(event)
+    }
+
+    /// Re-emits crash events persisted by a previous process whose upload was never
+    /// confirmed — the hybrid analogue of PLCrashReporter's pending report. Emits
+    /// spans only; upload confirmation and store clearing happen in
+    /// `completeCrashRecovery()` once init has finished. The re-emitted event keeps
+    /// the original `crash_timestamp`; session attribution follows the same
+    /// prev-session stitching as PLCR crash reports.
+    internal func resendPendingStoredCrashEvents() {
+        let pending = crashEventStore.loadAll()
+        guard !pending.isEmpty else { return }
+        for event in pending {
+            self.writeError(
+                domain: "",
+                message: event[Keys.errorMessage.rawValue] as? String ?? "",
+                stackTraceJson: event[Keys.stackTrace.rawValue] as? String,
+                errorType: event[Keys.errorType.rawValue] as? String,
+                isCrash: true,
+                arch: event[Keys.arch.rawValue] as? String,
+                buildId: event[Keys.buildId.rawValue] as? String,
+                stackTraceType: event[Keys.stackTraceType.rawValue] as? String,
+                customAttributes: event[Keys.data.rawValue] as? [String: Any],
+                crashTimestamp: event[Keys.crashTimestamp.rawValue] as? String
+            )
+        }
+        self.didEmitStoredCrashEvents = true
     }
 
     func logWith(severity: CoralogixLogSeverity,
@@ -182,12 +243,16 @@ extension CoralogixRum {
                             arch: String? = nil,
                             buildId: String? = nil,
                             stackTraceType: String? = nil,
-                            customAttributes: [String: Any]? = nil) {
+                            customAttributes: [String: Any]? = nil,
+                            crashTimestamp: String? = nil) {
         var span = makeSpan(event: .error, source: .console, severity: .error)
         span.setAttribute(key: Keys.domain.rawValue, value: domain)
         if let code { span.setAttribute(key: Keys.code.rawValue, value: code) }
         span.setAttribute(key: Keys.errorMessage.rawValue, value: message)
         span.setAttribute(key: Keys.isCrash.rawValue, value: isCrash)
+        if let crashTimestamp, !crashTimestamp.isEmpty {
+            span.setAttribute(key: Keys.crashTimestamp.rawValue, value: crashTimestamp)
+        }
         if let errorType { span.setAttribute(key: Keys.errorType.rawValue, value: errorType) }
         if let stackTraceJson { span.setAttribute(key: Keys.stackTrace.rawValue, value: stackTraceJson) }
         if let userInfo, !userInfo.isEmpty {

--- a/Coralogix/Sources/Instrumentation/ErrorInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/ErrorInstrumentation.swift
@@ -132,18 +132,19 @@ extension CoralogixRum {
             arch: arch,
             buildId: buildId,
             stackTraceType: stackTraceType,
-            customAttributes: customAttributes
+            customAttributes: customAttributes,
+            crashEventId: persistedEventId
         )
         if isCrash {
             // A crash report usually precedes process death — don't leave the event
             // in the batch queue (up to 2s) where it would die with the process.
-            // On confirmation, remove only THIS event: the store may still hold an
-            // unconfirmed backlog from a previous launch awaiting its own delivery.
+            // Remove only THIS event, and only once ITS OWN upload is confirmed:
+            // the store may hold an unconfirmed backlog from a previous launch, and
+            // an earlier crash's success must not delete a later crash that failed.
             self.flush { [weak self] in
-                guard let self, self.coralogixExporter?.didUploadCrashEvents == true else { return }
-                if let persistedEventId {
-                    self.crashEventStore.remove(ids: [persistedEventId])
-                }
+                guard let self, let persistedEventId,
+                      self.coralogixExporter?.didConfirmCrashUpload(id: persistedEventId) == true else { return }
+                self.crashEventStore.remove(ids: [persistedEventId])
             }
         }
     }
@@ -194,7 +195,8 @@ extension CoralogixRum {
                 stackTraceType: event[Keys.stackTraceType.rawValue] as? String,
                 customAttributes: (event[Keys.data.rawValue] as? String)
                     .flatMap { Helper.convertJsonStringToDict(jsonString: $0) },
-                crashTimestamp: event[Keys.crashTimestamp.rawValue] as? String
+                crashTimestamp: event[Keys.crashTimestamp.rawValue] as? String,
+                crashEventId: event[CrashEventStore.eventIdKey] as? String
             )
         }
         let resentIds = Set(pending.compactMap { $0[CrashEventStore.eventIdKey] as? String })
@@ -258,7 +260,8 @@ extension CoralogixRum {
                             buildId: String? = nil,
                             stackTraceType: String? = nil,
                             customAttributes: [String: Any]? = nil,
-                            crashTimestamp: String? = nil) {
+                            crashTimestamp: String? = nil,
+                            crashEventId: String? = nil) {
         // `crashTimestamp` is set only for events recovered from CrashEventStore on
         // the launch after a crash. Anchor those to the original crash time and to
         // the session that was live when the process died — the same attribution
@@ -275,6 +278,11 @@ extension CoralogixRum {
         if let code { span.setAttribute(key: Keys.code.rawValue, value: code) }
         span.setAttribute(key: Keys.errorMessage.rawValue, value: message)
         span.setAttribute(key: Keys.isCrash.rawValue, value: isCrash)
+        // Correlation id for per-event upload confirmation (read by the exporter,
+        // not mapped into cx_rum, so it stays off the wire).
+        if let crashEventId {
+            span.setAttribute(key: Keys.crashEventId.rawValue, value: crashEventId)
+        }
         if let crashTimestamp, !crashTimestamp.isEmpty {
             span.setAttribute(key: Keys.crashTimestamp.rawValue, value: crashTimestamp)
         }

--- a/Coralogix/Sources/Instrumentation/ErrorInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/ErrorInstrumentation.swift
@@ -245,7 +245,18 @@ extension CoralogixRum {
                             stackTraceType: String? = nil,
                             customAttributes: [String: Any]? = nil,
                             crashTimestamp: String? = nil) {
-        var span = makeSpan(event: .error, source: .console, severity: .error)
+        // `crashTimestamp` is set only for events recovered from CrashEventStore on
+        // the launch after a crash. Anchor those to the original crash time and to
+        // the session that was live when the process died — the same attribution
+        // PLCrashReporter reports get in processPendingCrashReport. Without it the
+        // event would surface under the relaunch time and the recovery session.
+        let recoveredCrashDate = crashTimestamp
+            .flatMap { Double($0) }
+            .map { Date(timeIntervalSince1970: $0 / 1000.0) }
+        var span = makeSpan(event: .error, source: .console, severity: .error, startTime: recoveredCrashDate)
+        if recoveredCrashDate != nil {
+            self.overrideSessionForCrashedSession(on: span)
+        }
         span.setAttribute(key: Keys.domain.rawValue, value: domain)
         if let code { span.setAttribute(key: Keys.code.rawValue, value: code) }
         span.setAttribute(key: Keys.errorMessage.rawValue, value: message)
@@ -267,6 +278,10 @@ extension CoralogixRum {
         // Note: hybrid error paths (Flutter/RN) intentionally omit the code attribute — there is
         // no meaningful error code in these contexts. Native paths pass an explicit code when relevant.
         recordScreenshotForSpan(to: &span)
-        span.end()
+        if let recoveredCrashDate {
+            span.end(time: recoveredCrashDate)
+        } else {
+            span.end()
+        }
     }
 }

--- a/Coralogix/Sources/Model/Contexts/ErrorContext.swift
+++ b/Coralogix/Sources/Model/Contexts/ErrorContext.swift
@@ -135,6 +135,12 @@ struct ErrorContext {
                 errorContext[Keys.data.rawValue] = data
             }
 
+            // Set for crash events re-sent from a previous process (CrashEventStore):
+            // preserves the real crash time, since the span itself is stamped at resend.
+            if !self.crashTimestamp.isEmpty {
+                errorContext[Keys.crashTimestamp.rawValue] = self.crashTimestamp
+            }
+
             errorContext[Keys.isCrash.rawValue] = self.isCrash
         }
         return errorContext

--- a/Coralogix/Sources/Utils/CrashEventStore.swift
+++ b/Coralogix/Sources/Utils/CrashEventStore.swift
@@ -13,6 +13,11 @@ import CoralogixInternal
 /// Mirrors PLCrashReporter's pending-report model: the stored copy is removed
 /// only after an upload is confirmed, otherwise it is re-sent on the next launch.
 final class CrashEventStore {
+    /// Store-internal identity field, stamped by `append`. Removal is by id so a
+    /// confirmed upload deletes only its own event — never an unconfirmed backlog
+    /// entry from an earlier launch that happens to share the store.
+    static let eventIdKey = "store_event_id"
+
     private let fileUrl: URL
     private let lock = NSLock()
     /// Crashes are near-singular events; the cap only bounds pathological growth
@@ -28,21 +33,45 @@ final class CrashEventStore {
         self.fileUrl = folder.appendingPathComponent("pending_crash_events.json")
     }
 
-    func append(_ event: [String: Any]) {
+    /// Persists the event and returns the identity to pass to `remove(ids:)`
+    /// once its upload is confirmed.
+    @discardableResult
+    func append(_ event: [String: Any]) -> String {
         lock.lock()
         defer { lock.unlock() }
+        let id = UUID().uuidString
+        var stamped = event
+        stamped[Self.eventIdKey] = id
         var events = readAllLocked()
-        events.append(event)
+        events.append(stamped)
         if events.count > maxStoredEvents {
             events.removeFirst(events.count - maxStoredEvents)
         }
         writeLocked(events)
+        return id
     }
 
     func loadAll() -> [[String: Any]] {
         lock.lock()
         defer { lock.unlock() }
         return readAllLocked()
+    }
+
+    /// Removes only the events with the given identities, keeping any other
+    /// entries (e.g. an unconfirmed backlog from a previous launch) intact.
+    func remove(ids: Set<String>) {
+        guard !ids.isEmpty else { return }
+        lock.lock()
+        defer { lock.unlock() }
+        let remaining = readAllLocked().filter { event in
+            guard let id = event[Self.eventIdKey] as? String else { return true }
+            return !ids.contains(id)
+        }
+        if remaining.isEmpty {
+            try? FileManager.default.removeItem(at: fileUrl)
+        } else {
+            writeLocked(remaining)
+        }
     }
 
     func clear() {

--- a/Coralogix/Sources/Utils/CrashEventStore.swift
+++ b/Coralogix/Sources/Utils/CrashEventStore.swift
@@ -1,0 +1,74 @@
+//
+//  CrashEventStore.swift
+//  Coralogix
+//
+
+import Foundation
+import CoralogixInternal
+
+/// Durable storage for crash events reported through the hybrid bridge
+/// (`reportError(... isCrash: true)`). A crash usually precedes process death,
+/// so the event is persisted to disk *before* any upload attempt — a disk write
+/// completes reliably inside the handover window, a network round trip does not.
+/// Mirrors PLCrashReporter's pending-report model: the stored copy is removed
+/// only after an upload is confirmed, otherwise it is re-sent on the next launch.
+final class CrashEventStore {
+    private let fileUrl: URL
+    private let lock = NSLock()
+    /// Crashes are near-singular events; the cap only bounds pathological growth
+    /// when uploads keep failing across many launches.
+    private let maxStoredEvents = 10
+
+    init(directory: URL? = nil) {
+        let base = directory
+            ?? FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? FileManager.default.temporaryDirectory
+        let folder = base.appendingPathComponent("CoralogixRum", isDirectory: true)
+        try? FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+        self.fileUrl = folder.appendingPathComponent("pending_crash_events.json")
+    }
+
+    func append(_ event: [String: Any]) {
+        lock.lock()
+        defer { lock.unlock() }
+        var events = readAllLocked()
+        events.append(event)
+        if events.count > maxStoredEvents {
+            events.removeFirst(events.count - maxStoredEvents)
+        }
+        writeLocked(events)
+    }
+
+    func loadAll() -> [[String: Any]] {
+        lock.lock()
+        defer { lock.unlock() }
+        return readAllLocked()
+    }
+
+    func clear() {
+        lock.lock()
+        defer { lock.unlock() }
+        try? FileManager.default.removeItem(at: fileUrl)
+    }
+
+    private func readAllLocked() -> [[String: Any]] {
+        guard let data = try? Data(contentsOf: fileUrl),
+              let events = (try? JSONSerialization.jsonObject(with: data)) as? [[String: Any]] else {
+            return []
+        }
+        return events
+    }
+
+    private func writeLocked(_ events: [[String: Any]]) {
+        guard JSONSerialization.isValidJSONObject(events),
+              let data = try? JSONSerialization.data(withJSONObject: events) else {
+            Log.e("[CrashEventStore] crash event is not JSON-serializable, skipping persist")
+            return
+        }
+        do {
+            try data.write(to: fileUrl, options: .atomic)
+        } catch {
+            Log.e("[CrashEventStore] failed to persist crash events: \(error)")
+        }
+    }
+}

--- a/Coralogix/Sources/Utils/CrashEventStore.swift
+++ b/Coralogix/Sources/Utils/CrashEventStore.swift
@@ -52,8 +52,14 @@ final class CrashEventStore {
     }
 
     private func readAllLocked() -> [[String: Any]] {
-        guard let data = try? Data(contentsOf: fileUrl),
-              let events = (try? JSONSerialization.jsonObject(with: data)) as? [[String: Any]] else {
+        guard let data = try? Data(contentsOf: fileUrl) else {
+            return []
+        }
+        guard let events = (try? JSONSerialization.jsonObject(with: data)) as? [[String: Any]] else {
+            // A corrupt store is unrecoverable — discard it so it isn't rescanned
+            // (and re-fails) on every launch.
+            Log.e("[CrashEventStore] pending file is corrupt, discarding")
+            try? FileManager.default.removeItem(at: fileUrl)
             return []
         }
         return events

--- a/CoralogixInternal.podspec
+++ b/CoralogixInternal.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "CoralogixInternal"
-  spec.version      = "2.10.3"
+  spec.version      = "2.11.0"
   spec.summary      = "Coralogix Internal Package. This module is not for public use."
 
   spec.description  = <<-DESC

--- a/CoralogixInternal/Sources/Keys.swift
+++ b/CoralogixInternal/Sources/Keys.swift
@@ -171,6 +171,9 @@ public enum Keys: String {
     case click
     case errorMessage = "error_message"
     case isCrash = "is_crash"
+    // Internal correlation id for crash-upload confirmation. Set as a span
+    // attribute only; not mapped into cx_rum, so it never reaches the wire.
+    case crashEventId = "crash_event_id"
     case buildId = "build_id"
     case stackTraceType = "stack_trace_type"
     case virt = "virt"

--- a/CoralogixInternal/Sources/Utils.swift
+++ b/CoralogixInternal/Sources/Utils.swift
@@ -16,7 +16,7 @@ public enum ImageFormat {
 }
 
 public enum Global: String {
-    case sdk = "2.10.3"
+    case sdk = "2.11.0"
     case swiftVersion = "5.9"
     case coralogixPath = "/browser/v1beta/logs"
     case sessionReplayPath = "/browser/alpha/sessionrecording"

--- a/CoralogixInternal/Sources/Utils.swift
+++ b/CoralogixInternal/Sources/Utils.swift
@@ -24,6 +24,9 @@ public enum Global: String {
     public enum BatchSpan: Int {
         case maxExportBatchSize = 50
         case scheduleDelay = 2
+        // Upper bound for a forced flush (CoralogixRum.flush) — long enough for one
+        // synchronous upload attempt, short enough not to stall a dying process.
+        case forceFlushTimeout = 5
     }
     
     static let monitoredPaths: Set<String> = [

--- a/SessionReplay.podspec
+++ b/SessionReplay.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "SessionReplay"
-  spec.version      = "2.10.3"
+  spec.version      = "2.11.0"
   spec.summary      = "Coralogix Session-Replay pod for iOS."
 
   spec.description  = <<-DESC
@@ -23,7 +23,7 @@ Pod::Spec.new do |spec|
   spec.static_framework = true
 
   spec.source_files  = 'SessionReplay/Sources/**/*.swift'
-  spec.dependency 'CoralogixInternal', '2.10.3'
+  spec.dependency 'CoralogixInternal', '2.11.0'
   
     spec.test_spec 'Tests' do |test|
         test.source_files = 'Tests/SessionReplayTests/**/*.swift'

--- a/Tests/CoralogixRumTests/CrashDeliveryTests.swift
+++ b/Tests/CoralogixRumTests/CrashDeliveryTests.swift
@@ -211,6 +211,37 @@ final class CrashDeliveryTests: XCTestCase {
         XCTAssertTrue(store.loadAll().isEmpty)
     }
 
+    func test_crashEventStore_discardsCorruptFile() throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let store = CrashEventStore(directory: dir)
+        let file = dir.appendingPathComponent("CoralogixRum/pending_crash_events.json")
+        try XCTUnwrap("not-json".data(using: .utf8)).write(to: file)
+
+        XCTAssertTrue(store.loadAll().isEmpty)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: file.path),
+                       "a corrupt store must be discarded so it isn't rescanned every launch")
+    }
+
+    func test_reportCrash_persistsEvenWithNonJsonSafeCustomAttributes() {
+        coralogixRum = CoralogixRum(options: makeSamplingOptions(sampleRate: 100, exclude: []))
+        let uploader = StubUploader()
+        uploader.result = .failure
+        coralogixRum.coralogixExporter?.spanUploader = uploader
+        let store = makeTempStore()
+        coralogixRum.crashEventStore = store
+
+        coralogixRum.reportError(message: "fatal-with-date-attr",
+                                 stackTrace: [],
+                                 errorType: "Error",
+                                 isCrash: true,
+                                 customAttributes: ["when": Date(), "tag": "x"])
+
+        let persisted = store.loadAll()
+        XCTAssertEqual(persisted.count, 1,
+                       "attributes JSONSerialization rejects must not abort the crash persist")
+        XCTAssertEqual(persisted.first?[Keys.errorMessage.rawValue] as? String, "fatal-with-date-attr")
+    }
+
     func test_reportCrash_persistsToDisk_evenWhenUploadFails() {
         coralogixRum = CoralogixRum(options: makeSamplingOptions(sampleRate: 100, exclude: []))
         let uploader = StubUploader()

--- a/Tests/CoralogixRumTests/CrashDeliveryTests.swift
+++ b/Tests/CoralogixRumTests/CrashDeliveryTests.swift
@@ -180,4 +180,121 @@ final class CrashDeliveryTests: XCTestCase {
         rum.flush { flushed.fulfill() }
         wait(for: [flushed], timeout: 2)
     }
+
+    // MARK: - Crash-event persistence (CrashEventStore)
+
+    private func makeTempStore() -> CrashEventStore {
+        return CrashEventStore(
+            directory: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        )
+    }
+
+    /// Spins the run loop until `condition` holds or `timeout` elapses.
+    private func waitUntil(timeout: TimeInterval = 5, _ condition: () -> Bool) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while !condition() && Date() < deadline {
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        }
+        return condition()
+    }
+
+    func test_crashEventStore_roundtripAndClear() {
+        let store = makeTempStore()
+        XCTAssertTrue(store.loadAll().isEmpty)
+
+        store.append(["error_message": "boom", "crash_timestamp": "123"])
+        let loaded = store.loadAll()
+        XCTAssertEqual(loaded.count, 1)
+        XCTAssertEqual(loaded.first?["error_message"] as? String, "boom")
+
+        store.clear()
+        XCTAssertTrue(store.loadAll().isEmpty)
+    }
+
+    func test_reportCrash_persistsToDisk_evenWhenUploadFails() {
+        coralogixRum = CoralogixRum(options: makeSamplingOptions(sampleRate: 100, exclude: []))
+        let uploader = StubUploader()
+        uploader.result = .failure
+        coralogixRum.coralogixExporter?.spanUploader = uploader
+        let store = makeTempStore()
+        coralogixRum.crashEventStore = store
+
+        coralogixRum.reportError(message: "fatal-js-error",
+                                 stackTrace: [],
+                                 errorType: "Error",
+                                 isCrash: true)
+
+        // Persisting happens synchronously inside reportError, before any upload
+        // attempt — this is the delivery guarantee for a dying process.
+        let persisted = store.loadAll()
+        XCTAssertEqual(persisted.count, 1)
+        XCTAssertEqual(persisted.first?[Keys.errorMessage.rawValue] as? String, "fatal-js-error")
+        XCTAssertNotNil(persisted.first?[Keys.crashTimestamp.rawValue])
+
+        // The upload failed, so the stored copy must survive for the next launch.
+        _ = waitUntil(timeout: 2) { !uploader.uploadedBatches.isEmpty }
+        XCTAssertEqual(store.loadAll().count, 1)
+    }
+
+    func test_reportCrash_clearsStore_onceUploadIsConfirmed() {
+        coralogixRum = CoralogixRum(options: makeSamplingOptions(sampleRate: 100, exclude: []))
+        let uploader = StubUploader()
+        coralogixRum.coralogixExporter?.spanUploader = uploader
+        let store = makeTempStore()
+        coralogixRum.crashEventStore = store
+
+        coralogixRum.reportError(message: "fatal-js-error",
+                                 stackTrace: [],
+                                 errorType: "Error",
+                                 isCrash: true)
+
+        XCTAssertTrue(waitUntil { store.loadAll().isEmpty },
+                      "the stored copy must be cleared after the upload is confirmed")
+        XCTAssertTrue(coralogixRum.coralogixExporter?.didUploadCrashEvents == true)
+    }
+
+    func test_resendStoredCrashEvents_uploadsWithOriginalTimestamp_andClearsOnConfirm() throws {
+        coralogixRum = CoralogixRum(options: makeSamplingOptions(sampleRate: 100, exclude: []))
+        let uploader = StubUploader()
+        coralogixRum.coralogixExporter?.spanUploader = uploader
+        let store = makeTempStore()
+        coralogixRum.crashEventStore = store
+        store.append([
+            Keys.errorMessage.rawValue: "crash-from-previous-launch",
+            Keys.errorType.rawValue: "Error",
+            Keys.crashTimestamp.rawValue: "1700000000000"
+        ])
+
+        coralogixRum.resendPendingStoredCrashEvents()
+        coralogixRum.completeCrashRecovery()
+
+        XCTAssertTrue(waitUntil { store.loadAll().isEmpty },
+                      "confirmed recovery upload must clear the store")
+        // The recovery flush also drains other queued spans (e.g. the init span) —
+        // locate the crash event rather than assuming batch order.
+        let uploaded = try XCTUnwrap(uploader.uploadedEvents.first(where: { isCrashEvent($0) }))
+        let text = uploaded[Keys.text.rawValue] as? [String: Any]
+        let cxRum = text?[Keys.cxRum.rawValue] as? [String: Any]
+        let errorContext = cxRum?[Keys.errorContext.rawValue] as? [String: Any]
+        XCTAssertEqual(errorContext?[Keys.errorMessage.rawValue] as? String, "crash-from-previous-launch")
+        XCTAssertEqual(errorContext?[Keys.crashTimestamp.rawValue] as? String, "1700000000000",
+                       "re-sent events must keep the original crash time")
+    }
+
+    func test_resendStoredCrashEvents_keepsStore_whenUploadFails() {
+        coralogixRum = CoralogixRum(options: makeSamplingOptions(sampleRate: 100, exclude: []))
+        let uploader = StubUploader()
+        uploader.result = .failure
+        coralogixRum.coralogixExporter?.spanUploader = uploader
+        let store = makeTempStore()
+        coralogixRum.crashEventStore = store
+        store.append([Keys.errorMessage.rawValue: "crash-from-previous-launch"])
+
+        coralogixRum.resendPendingStoredCrashEvents()
+        coralogixRum.completeCrashRecovery()
+
+        _ = waitUntil(timeout: 2) { !uploader.uploadedBatches.isEmpty }
+        XCTAssertEqual(store.loadAll().count, 1,
+                       "unconfirmed recovery must keep the stored copy for the next launch")
+    }
 }

--- a/Tests/CoralogixRumTests/CrashDeliveryTests.swift
+++ b/Tests/CoralogixRumTests/CrashDeliveryTests.swift
@@ -1,0 +1,183 @@
+//
+//  CrashDeliveryTests.swift
+//
+//  Crash events (`error_context.is_crash`) must survive process death:
+//  - hybrid path: they bypass the beforeSend JS round trip and upload directly,
+//    since the process is usually dying when a crash is exported
+//  - the exporter confirms a successful crash upload (`didUploadCrashEvents`),
+//    which gates purging the pending PLCrashReporter report on next launch
+//  - `CoralogixRum.flush()` force-exports spans still queued in the batch
+//    processor instead of waiting out the schedule delay
+//
+
+import XCTest
+import CoralogixInternal
+import Foundation
+
+@testable import Coralogix
+
+final class CrashDeliveryTests: XCTestCase {
+
+    private var coralogixRum: CoralogixRum!
+
+    override func tearDownWithError() throws {
+        coralogixRum?.shutdown()
+        coralogixRum = nil
+    }
+
+    // MARK: - Fixtures
+
+    /// Test-only `SpanUploading` with a configurable result that records every batch.
+    private final class StubUploader: SpanUploading {
+        var result: SpanExporterResultCode = .success
+        private(set) var uploadedBatches: [[[String: Any]]] = []
+        func upload(_ spans: [[String: Any]], endPoint: String) -> SpanExporterResultCode {
+            uploadedBatches.append(spans)
+            return result
+        }
+        var uploadedEvents: [[String: Any]] { uploadedBatches.flatMap { $0 } }
+    }
+
+    /// An error-event `SpanData` that survives the encoding pipeline
+    /// (`CxRumBuilder.build()` requires session attributes) and carries the
+    /// `is_crash` flag under test.
+    private func makeErrorSpan(isCrash: Bool) -> SpanData {
+        let attributes: [String: AttributeValue] = [
+            Keys.eventType.rawValue: AttributeValue(CoralogixEventType.error.rawValue),
+            Keys.severity.rawValue: AttributeValue("5"),
+            Keys.source.rawValue: AttributeValue("console"),
+            Keys.environment.rawValue: AttributeValue("test"),
+            Keys.sessionId.rawValue: AttributeValue("session_001"),
+            Keys.sessionCreationDate.rawValue: AttributeValue("1609459200"),
+            Keys.errorMessage.rawValue: AttributeValue("crash-delivery-test"),
+            Keys.isCrash.rawValue: AttributeValue.bool(isCrash)
+        ]
+        return SpanData(traceId: TraceId.random(),
+                        spanId: SpanId.random(),
+                        name: "errorSpan_isCrash_\(isCrash)",
+                        kind: .client,
+                        startTime: Date(),
+                        attributes: attributes,
+                        endTime: Date(),
+                        hasEnded: true)
+    }
+
+    private func isCrashEvent(_ event: [String: Any]) -> Bool {
+        let text = event[Keys.text.rawValue] as? [String: Any]
+        let cxRum = text?[Keys.cxRum.rawValue] as? [String: Any]
+        let errorContext = cxRum?[Keys.errorContext.rawValue] as? [String: Any]
+        return errorContext?[Keys.isCrash.rawValue] as? Bool ?? false
+    }
+
+    private func makeHybridRum(beforeSend: @escaping ([[String: Any]]) -> Void) -> CoralogixRum {
+        var opts = makeSamplingOptions(sampleRate: 100, exclude: [])
+        opts.beforeSendCallBack = beforeSend
+        return CoralogixRum(options: opts, sdkFramework: .reactNative(version: "2.0.0"))
+    }
+
+    // MARK: - Hybrid beforeSend bypass
+
+    func test_hybridExport_crashEventBypassesBeforeSend_andUploadsDirectly() throws {
+        var captured: [[String: Any]] = []
+        coralogixRum = makeHybridRum { captured.append(contentsOf: $0) }
+        let exporter = try XCTUnwrap(coralogixRum.coralogixExporter)
+        let uploader = StubUploader()
+        exporter.spanUploader = uploader
+
+        let result = exporter.export(
+            spans: [makeErrorSpan(isCrash: true), makeSamplingSpan(eventType: .networkRequest)],
+            explicitTimeout: nil
+        )
+
+        XCTAssertEqual(result, .success)
+        XCTAssertEqual(uploader.uploadedEvents.count, 1,
+                       "the crash event must upload directly, without the JS round trip")
+        XCTAssertTrue(isCrashEvent(try XCTUnwrap(uploader.uploadedEvents.first)))
+        XCTAssertEqual(captured.count, 1,
+                       "the non-crash event must still take the beforeSend path")
+        XCTAssertFalse(isCrashEvent(try XCTUnwrap(captured.first)))
+        XCTAssertTrue(exporter.didUploadCrashEvents,
+                      "a successful direct upload must confirm crash delivery")
+    }
+
+    func test_hybridExport_nonCrashError_stillTakesBeforeSendPath() throws {
+        var captured: [[String: Any]] = []
+        coralogixRum = makeHybridRum { captured.append(contentsOf: $0) }
+        let exporter = try XCTUnwrap(coralogixRum.coralogixExporter)
+        let uploader = StubUploader()
+        exporter.spanUploader = uploader
+
+        let result = exporter.export(spans: [makeErrorSpan(isCrash: false)], explicitTimeout: nil)
+
+        XCTAssertEqual(result, .success)
+        XCTAssertTrue(uploader.uploadedEvents.isEmpty,
+                      "non-crash errors must not upload before the JS edit")
+        XCTAssertEqual(captured.count, 1)
+        XCTAssertFalse(exporter.didUploadCrashEvents)
+    }
+
+    func test_hybridExport_failedCrashUpload_isNotConfirmed_andPropagatesFailure() throws {
+        coralogixRum = makeHybridRum { _ in }
+        let exporter = try XCTUnwrap(coralogixRum.coralogixExporter)
+        let uploader = StubUploader()
+        uploader.result = .failure
+        exporter.spanUploader = uploader
+
+        let result = exporter.export(spans: [makeErrorSpan(isCrash: true)], explicitTimeout: nil)
+
+        XCTAssertEqual(result, .failure)
+        XCTAssertFalse(exporter.didUploadCrashEvents,
+                       "a failed upload must keep the purge gate closed so the pending report is retried")
+    }
+
+    // MARK: - Native path confirmation
+
+    func test_nativeExport_confirmsCrashUpload_onSuccess() throws {
+        coralogixRum = CoralogixRum(options: makeSamplingOptions(sampleRate: 100, exclude: []))
+        let exporter = try XCTUnwrap(coralogixRum.coralogixExporter)
+        let uploader = StubUploader()
+        exporter.spanUploader = uploader
+
+        let result = exporter.export(spans: [makeErrorSpan(isCrash: true)], explicitTimeout: nil)
+
+        XCTAssertEqual(result, .success)
+        XCTAssertEqual(uploader.uploadedEvents.count, 1)
+        XCTAssertTrue(isCrashEvent(try XCTUnwrap(uploader.uploadedEvents.first)))
+        XCTAssertTrue(exporter.didUploadCrashEvents)
+    }
+
+    // MARK: - flush()
+
+    func test_flush_forceExportsQueuedSpans_withoutWaitingForScheduleDelay() throws {
+        coralogixRum = CoralogixRum(options: makeSamplingOptions(sampleRate: 100, exclude: []))
+        let exporter = try XCTUnwrap(coralogixRum.coralogixExporter)
+        exporter.spanUploader = StubUploader()
+
+        var exportedSpanNames: [String] = []
+        CoralogixExporter.testExportCallback = { spans in
+            exportedSpanNames.append(contentsOf: spans.map { $0.name })
+        }
+        defer { CoralogixExporter.testExportCallback = nil }
+
+        coralogixRum.log(severity: .info, message: "queued-before-flush", data: nil, labels: nil)
+        XCTAssertTrue(exportedSpanNames.isEmpty,
+                      "the span must still be sitting in the batch queue before the flush")
+
+        let flushed = expectation(description: "flush completion")
+        coralogixRum.flush { flushed.fulfill() }
+        wait(for: [flushed], timeout: 10)
+
+        XCTAssertFalse(exportedSpanNames.isEmpty,
+                       "flush must drive queued spans into export without waiting for the schedule delay")
+    }
+
+    func test_flush_beforeInit_callsCompletionImmediately() {
+        // A CoralogixRum that never completed startup (sampled out) must not hang callers.
+        let rum = CoralogixRum(options: makeSamplingOptions(sampleRate: 0, exclude: []))
+        CoralogixRum.isInitialized = false
+
+        let flushed = expectation(description: "flush completion")
+        rum.flush { flushed.fulfill() }
+        wait(for: [flushed], timeout: 2)
+    }
+}

--- a/Tests/CoralogixRumTests/CrashDeliveryTests.swift
+++ b/Tests/CoralogixRumTests/CrashDeliveryTests.swift
@@ -211,6 +211,40 @@ final class CrashDeliveryTests: XCTestCase {
         XCTAssertTrue(store.loadAll().isEmpty)
     }
 
+    func test_crashEventStore_removeByIds_keepsOtherEvents() {
+        let store = makeTempStore()
+        let keepId = store.append(["error_message": "keep"])
+        let dropId = store.append(["error_message": "drop"])
+
+        store.remove(ids: [dropId])
+
+        let remaining = store.loadAll()
+        XCTAssertEqual(remaining.count, 1)
+        XCTAssertEqual(remaining.first?["error_message"] as? String, "keep")
+        XCTAssertEqual(remaining.first?[CrashEventStore.eventIdKey] as? String, keepId)
+    }
+
+    func test_reportCrash_confirmedUpload_keepsUnconfirmedBacklog() {
+        coralogixRum = CoralogixRum(options: makeSamplingOptions(sampleRate: 100, exclude: []))
+        let uploader = StubUploader()
+        coralogixRum.coralogixExporter?.spanUploader = uploader
+        let store = makeTempStore()
+        coralogixRum.crashEventStore = store
+        // Undelivered backlog from a previous launch whose recovery upload failed.
+        store.append([Keys.errorMessage.rawValue: "old-unconfirmed-crash"])
+
+        coralogixRum.reportError(message: "fresh-crash",
+                                 stackTrace: [],
+                                 errorType: "Error",
+                                 isCrash: true)
+
+        XCTAssertTrue(waitUntil { store.loadAll().count == 1 },
+                      "the confirmed fresh crash must be removed — and only it")
+        XCTAssertEqual(store.loadAll().first?[Keys.errorMessage.rawValue] as? String,
+                       "old-unconfirmed-crash",
+                       "an unconfirmed backlog entry must survive another event's confirmation")
+    }
+
     func test_crashEventStore_discardsCorruptFile() throws {
         let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         let store = CrashEventStore(directory: dir)

--- a/Tests/CoralogixRumTests/CrashDeliveryTests.swift
+++ b/Tests/CoralogixRumTests/CrashDeliveryTests.swift
@@ -265,6 +265,14 @@ final class CrashDeliveryTests: XCTestCase {
             Keys.crashTimestamp.rawValue: "1700000000000"
         ])
 
+        var recoveredSpanStart: Date?
+        CoralogixExporter.testExportCallback = { spans in
+            if let crashSpan = spans.first(where: { $0.attributes[Keys.isCrash.rawValue]?.description == "true" }) {
+                recoveredSpanStart = crashSpan.startTime
+            }
+        }
+        defer { CoralogixExporter.testExportCallback = nil }
+
         coralogixRum.resendPendingStoredCrashEvents()
         coralogixRum.completeCrashRecovery()
 
@@ -279,6 +287,12 @@ final class CrashDeliveryTests: XCTestCase {
         XCTAssertEqual(errorContext?[Keys.errorMessage.rawValue] as? String, "crash-from-previous-launch")
         XCTAssertEqual(errorContext?[Keys.crashTimestamp.rawValue] as? String, "1700000000000",
                        "re-sent events must keep the original crash time")
+        // The recovered span itself is anchored to the crash time (not resend time),
+        // mirroring the PLCrashReporter treatment — this is what puts the event
+        // under the crash's own timestamp in the platform.
+        let spanStart = try XCTUnwrap(recoveredSpanStart)
+        XCTAssertEqual(spanStart.timeIntervalSince1970, 1_700_000_000.0, accuracy: 0.001,
+                       "re-sent crash span must start at the original crash time")
     }
 
     func test_resendStoredCrashEvents_keepsStore_whenUploadFails() {

--- a/Tests/CoralogixRumTests/CrashDeliveryTests.swift
+++ b/Tests/CoralogixRumTests/CrashDeliveryTests.swift
@@ -4,7 +4,7 @@
 //  Crash events (`error_context.is_crash`) must survive process death:
 //  - hybrid path: they bypass the beforeSend JS round trip and upload directly,
 //    since the process is usually dying when a crash is exported
-//  - the exporter confirms a successful crash upload (`didUploadCrashEvents`),
+//  - the exporter confirms each crash upload per correlation id (`didConfirmCrashUpload(id:)`),
 //    which gates purging the pending PLCrashReporter report on next launch
 //  - `CoralogixRum.flush()` force-exports spans still queued in the batch
 //    processor instead of waiting out the schedule delay
@@ -41,8 +41,8 @@ final class CrashDeliveryTests: XCTestCase {
     /// An error-event `SpanData` that survives the encoding pipeline
     /// (`CxRumBuilder.build()` requires session attributes) and carries the
     /// `is_crash` flag under test.
-    private func makeErrorSpan(isCrash: Bool) -> SpanData {
-        let attributes: [String: AttributeValue] = [
+    private func makeErrorSpan(isCrash: Bool, crashEventId: String = "crash-id") -> SpanData {
+        var attributes: [String: AttributeValue] = [
             Keys.eventType.rawValue: AttributeValue(CoralogixEventType.error.rawValue),
             Keys.severity.rawValue: AttributeValue("5"),
             Keys.source.rawValue: AttributeValue("console"),
@@ -52,6 +52,9 @@ final class CrashDeliveryTests: XCTestCase {
             Keys.errorMessage.rawValue: AttributeValue("crash-delivery-test"),
             Keys.isCrash.rawValue: AttributeValue.bool(isCrash)
         ]
+        if isCrash {
+            attributes[Keys.crashEventId.rawValue] = AttributeValue(crashEventId)
+        }
         return SpanData(traceId: TraceId.random(),
                         spanId: SpanId.random(),
                         name: "errorSpan_isCrash_\(isCrash)",
@@ -96,8 +99,16 @@ final class CrashDeliveryTests: XCTestCase {
         XCTAssertEqual(captured.count, 1,
                        "the non-crash event must still take the beforeSend path")
         XCTAssertFalse(isCrashEvent(try XCTUnwrap(captured.first)))
-        XCTAssertTrue(exporter.didUploadCrashEvents,
+        XCTAssertTrue(exporter.didConfirmCrashUpload(id: "crash-id"),
                       "a successful direct upload must confirm crash delivery")
+
+        // The correlation id must NOT reach the wire — it's an internal span
+        // attribute used only for confirmation, not mapped into cx_rum.
+        let uploadedDescription = String(describing: uploader.uploadedEvents)
+        XCTAssertFalse(uploadedDescription.contains("crash-id"),
+                       "crash_event_id must not appear in the uploaded payload")
+        XCTAssertFalse(uploadedDescription.contains(Keys.crashEventId.rawValue),
+                       "crash_event_id key must not appear in the uploaded payload")
     }
 
     func test_hybridExport_nonCrashError_stillTakesBeforeSendPath() throws {
@@ -113,7 +124,7 @@ final class CrashDeliveryTests: XCTestCase {
         XCTAssertTrue(uploader.uploadedEvents.isEmpty,
                       "non-crash errors must not upload before the JS edit")
         XCTAssertEqual(captured.count, 1)
-        XCTAssertFalse(exporter.didUploadCrashEvents)
+        XCTAssertFalse(exporter.didConfirmCrashUpload(id: "crash-id"))
     }
 
     func test_hybridExport_failedCrashUpload_isNotConfirmed_andPropagatesFailure() throws {
@@ -126,8 +137,31 @@ final class CrashDeliveryTests: XCTestCase {
         let result = exporter.export(spans: [makeErrorSpan(isCrash: true)], explicitTimeout: nil)
 
         XCTAssertEqual(result, .failure)
-        XCTAssertFalse(exporter.didUploadCrashEvents,
+        XCTAssertFalse(exporter.didConfirmCrashUpload(id: "crash-id"),
                        "a failed upload must keep the purge gate closed so the pending report is retried")
+    }
+
+    func test_secondCrashFailingUpload_isNotConfirmed_afterFirstCrashSucceeded() throws {
+        // Regression for the process-wide-flag bug: a crash that uploads OK must not
+        // let a *later* crash whose upload fails be treated as delivered.
+        coralogixRum = CoralogixRum(options: makeSamplingOptions(sampleRate: 100, exclude: []))
+        let exporter = try XCTUnwrap(coralogixRum.coralogixExporter)
+        let uploader = StubUploader()
+        exporter.spanUploader = uploader
+
+        // Crash A uploads successfully.
+        uploader.result = .success
+        _ = exporter.export(spans: [makeErrorSpan(isCrash: true, crashEventId: "crash-A")], explicitTimeout: nil)
+        XCTAssertTrue(exporter.didConfirmCrashUpload(id: "crash-A"))
+
+        // Crash B's upload fails.
+        uploader.result = .failure
+        _ = exporter.export(spans: [makeErrorSpan(isCrash: true, crashEventId: "crash-B")], explicitTimeout: nil)
+
+        XCTAssertFalse(exporter.didConfirmCrashUpload(id: "crash-B"),
+                       "B's failed upload must not inherit A's confirmation")
+        XCTAssertTrue(exporter.didConfirmCrashUpload(id: "crash-A"),
+                      "A stays confirmed independently")
     }
 
     // MARK: - Native path confirmation
@@ -143,7 +177,7 @@ final class CrashDeliveryTests: XCTestCase {
         XCTAssertEqual(result, .success)
         XCTAssertEqual(uploader.uploadedEvents.count, 1)
         XCTAssertTrue(isCrashEvent(try XCTUnwrap(uploader.uploadedEvents.first)))
-        XCTAssertTrue(exporter.didUploadCrashEvents)
+        XCTAssertTrue(exporter.didConfirmCrashUpload(id: "crash-id"))
     }
 
     // MARK: - flush()
@@ -315,7 +349,6 @@ final class CrashDeliveryTests: XCTestCase {
 
         XCTAssertTrue(waitUntil { store.loadAll().isEmpty },
                       "the stored copy must be cleared after the upload is confirmed")
-        XCTAssertTrue(coralogixRum.coralogixExporter?.didUploadCrashEvents == true)
     }
 
     func test_resendStoredCrashEvents_uploadsWithOriginalTimestamp_andClearsOnConfirm() throws {


### PR DESCRIPTION
> **Draft** — opened to align on the delivery-reliability approach before polishing. Pre-merge checklist items still pending are listed at the bottom. Rebased onto master 2.10.3 (includes the CX-49308 crash-attribution fix, which this PR extends to hybrid crash events).

## Problem

Customers report RN crashes only *sometimes* reaching the platform. Capture works — delivery doesn't, and the intermittency comes from four independent failure branches:

1. **No durability for hybrid crash events**: a `reportError(isCrash: true)` event lives only in the in-memory 2s batch queue and races a single no-retry POST against process death. Native crashes get PLCrashReporter's store-then-send-on-relaunch model; JS crashes got nothing.
2. **No native crash at all when the user force-quits**: if the frozen app is killed (SIGKILL) during the RN plugin's handover window, PLCR has nothing to store either — nothing ever arrives.
3. **Purge-before-delivery**: `purgePendingCrashReport()` ran right after the crash span was *created*, before it survived the batch queue, the optional beforeSend JS round trip, and the no-retry upload. Any failure after the purge lost the crash permanently.
4. **Hybrid beforeSend round trip**: `export()` hands every span to JS and uploads only after `sendBeforeSendData` returns it — two extra bridge hops inside the death window.

Companion RN-plugin PR: coralogix/cx-react-native-plugin#140 (fatal-error handover flushes before invoking RN's default handler).

## Changes

**The guarantee — disk, not network:**
- **`CrashEventStore`** (new): hybrid crash events are persisted to an atomic JSON file **synchronously, before the span/upload attempt** — a disk write reliably completes inside the handover window; a network round trip does not. The stored copy is cleared only once an upload is confirmed; otherwise it is re-emitted on the next launch.
- **Recovered events are anchored to the crash, not the recovery** (extends CX-49308): the re-emitted span starts/ends at the persisted `crash_timestamp` and carries the crashed session's identity via `overrideSessionForCrashedSession` — so a crash from yesterday surfaces in the platform under *yesterday's* time and *its own* session, exactly like PLCrashReporter reports do since 2.10.2.
- **Upload-gated recovery**: both the PLCR pending-report purge and the stored-event clear happen in `completeCrashRecovery()`, which runs right after init finishes and only fires once the exporter confirms a crash upload (`didUploadCrashEvents`). Note: recovery must run *after* init — `SpanUploader` rejects requests while `isInitialized` is false, so an in-init flush can never confirm anything.

**The fast path (crash visible immediately, no relaunch needed):**
- **`CoralogixRum.flush(completion:)`** (new public API): force-flushes the SDK's own tracer provider (stored at `setupTracer`) and fires `completion` after the synchronous upload attempt. Reporting an `is_crash` error triggers it automatically.
- **beforeSend bypass for crash events**: encoded spans with `error_context.is_crash == true` upload directly (verbatim) instead of taking the JS round trip; a lock-guarded flag records the confirmed upload on both hybrid and native paths.

## On-device validation (RN example app, iOS Release build, simulator, real EU2 ingest)

- **Fast path**: uncaught JS `throw` → event with `is_crash: true` queryable on EU2 seconds later, store cleared before process death.
- **Failure + recovery**: crash with telemetry pointed at a dead port → upload fails → event persisted; relaunch with working network → delivered with **record timestamp = crash time (08:13:10)**, not upload time (08:13:44), attributed to the **crashed session**, store cleared + PLCR report purged only after the confirmed upload. With an invalid API key (simulated persistent failure), the pending file survived multiple relaunches and an app reinstall, then delivered on the first launch with a valid key — ~18h after the crash, still carrying the original crash time.

## Semantics changes to sign off on

- **beforeSend can no longer edit or drop crash events** on the hybrid path — delivery beats editability for a dying process.
- **At-least-once delivery**: if an upload succeeded but the process died before the store/report was cleared, the next launch re-sends → possible duplicate crash event. Open question: dedupe backend-side, or client-side via `crash_timestamp`+`pid`?
- `didUploadCrashEvents` is process-wide, not per-event — acceptable at recovery time (the pending data is effectively the only crash in the pipeline); can be tightened to span-id tracking if wanted.

## Tests

`CrashDeliveryTests` (12 tests): hybrid bypass + confirmation, beforeSend still applies to non-crash events, failed upload keeps the purge gate closed, native-path confirmation, `flush()` force-export + pre-init no-hang, store roundtrip, persist-before-upload even when the upload fails, clear-on-confirmed-upload, resend anchored to the original crash time, and keep-on-failed-recovery.

Full suite green: `CoralogixRumTests`, `CoralogixInternalTests`, `SessionReplayTests` (iPhone 17 Pro sim).

## Pending before undraft

- [ ] `/bump-version` — **minor** (new public API `flush`) + CHANGELOG entry + README public-API section
- [ ] Decide the duplicate-delivery question above
- [ ] Companion RN PR e2e (coralogix/cx-react-native-plugin#140) — manual validation above covers it; consider automating as Detox release-mode suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017QECYYAvsKpjuU3rkXbHoe