### PR TITLE
fix(CX-49308): attribute crashes to the crashed session and crash-time timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ omitted; the focus here is user-facing behavior changes. Tickets are referenced 
 ## [2.10.2] - 2026-07-13
 
 ### Fixed
-- A crash is captured by PLCrashReporter and only turned into a RUM event on the *next* app launch — after a new session has already started. The crash event was being reported under that new session and stamped with the relaunch time instead of the moment of the crash. Crashes are now attributed to the session that was active when they happened and carry the actual crash timestamp, so they land in the right session and at the right point on the timeline.
+- Crash reports are now attributed to the session active at the time of the crash (not the next app launch's session), and use the actual crash timestamp instead of the relaunch time.
 
 ## [2.10.1] - 2026-07-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Release-mechanics commits (version bumps, podspec/script tweaks, README edits) a
 omitted; the focus here is user-facing behavior changes. Tickets are referenced as
 `CX-XXXXX` (Jira) or `ALPH-XXXX` (legacy). Pull request numbers are in parentheses.
 
+## [2.10.2] - 2026-07-13
+
+### Fixed
+- A crash is captured by PLCrashReporter and only turned into a RUM event on the *next* app launch — after a new session has already started. The crash event was being reported under that new session and stamped with the relaunch time instead of the moment of the crash. Crashes are now attributed to the session that was active when they happened and carry the actual crash timestamp, so they land in the right session and at the right point on the timeline.
+
 ## [2.10.1] - 2026-07-09
 
 ### Fixed

--- a/Coralogix.podspec
+++ b/Coralogix.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "Coralogix"
-  spec.version      = "2.10.1"
+  spec.version      = "2.10.2"
   spec.summary      = "Coralogix OpenTelemetry pod for iOS."
 
   spec.description  = <<-DESC
@@ -29,7 +29,7 @@ Pod::Spec.new do |spec|
 
   spec.static_framework = true
   spec.dependency 'PLCrashReporter', '~> 1.12'
-  spec.dependency 'CoralogixInternal', '2.10.1'
+  spec.dependency 'CoralogixInternal', '2.10.2'
 
   spec.test_spec 'Tests' do |test|
     test.source_files = 'Tests/CoralogixRumTests/**/*.swift'

--- a/Coralogix/Sources/CoralogixRum.swift
+++ b/Coralogix/Sources/CoralogixRum.swift
@@ -608,9 +608,12 @@ public class CoralogixRum {
         }
     }
 
-    internal func makeSpan(event: CoralogixEventType, source: Keys, severity: CoralogixLogSeverity) -> any Span {
+    internal func makeSpan(event: CoralogixEventType, source: Keys, severity: CoralogixLogSeverity, startTime: Date? = nil) -> any Span {
         let builder = tracerProvider().spanBuilder(spanName: Keys.iosSdk.rawValue)
         Self.applyAutoInstrumentationParentPolicy(builder: builder, event: event)
+        if let startTime {
+            _ = builder.setStartTime(time: startTime)
+        }
         var span = builder.startSpan()
         span.setAttribute(key: Keys.eventType.rawValue, value: event.rawValue)
         span.setAttribute(key: Keys.source.rawValue, value: source.rawValue)

--- a/Coralogix/Sources/Instrumentation/CrashInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/CrashInstrumentation.swift
@@ -45,9 +45,17 @@ extension CoralogixRum {
             
             // Retrieving crash reporter data.
             let report = try PLCrashReport(data: data)
-            let span = makeSpan(event: .error, source: .console, severity: .error)
+
+            // A crash is captured on the *next* launch, after a fresh session has
+            // already been created. Anchor the span to the crash time (not relaunch
+            // time) and burn it under the session that was live when it crashed —
+            // recovered from the keychain into SessionManager at init.
+            let crashTimestamp = report.systemInfo.timestamp
+            let span = makeSpan(event: .error, source: .console, severity: .error, startTime: crashTimestamp)
+            self.overrideSessionForCrashedSession(on: span)
+
             span.setAttribute(key: Keys.exceptionType.rawValue, value: report.signalInfo.name)
-            if let crashTimestamp = report.systemInfo.timestamp {
+            if let crashTimestamp {
                 span.setAttribute(key: Keys.crashTimestamp.rawValue, value: "\(crashTimestamp.timeIntervalSince1970.milliseconds)")
             }
             span.setAttribute(key: Keys.processName.rawValue, value: report.processInfo.processName)
@@ -73,9 +81,23 @@ extension CoralogixRum {
             } else {
                 Log.e("CrashReporter: can't convert report to text")
             }
-            span.end()
+            if let crashTimestamp {
+                span.end(time: crashTimestamp)
+            } else {
+                span.end()
+            }
         } catch let error {
             Log.e("CrashReporter failed to load and parse with error: \(error)")
+        }
+    }
+
+    /// Replaces the current-session attributes `makeSpan` stamped on the crash span
+    /// with the session that was live when the crash happened. No-op when there is
+    /// no previous-launch session on record — the span keeps the current session.
+    private func overrideSessionForCrashedSession(on span: any Span) {
+        guard let sessionManager = self.coralogixExporter?.getSessionManager() else { return }
+        for attr in sessionManager.lastLaunchSessionSpanAttributes() {
+            span.setAttribute(key: attr.key, value: attr.value)
         }
     }
     

--- a/Coralogix/Sources/Utils/SessionManager.swift
+++ b/Coralogix/Sources/Utils/SessionManager.swift
@@ -161,6 +161,29 @@ public class SessionManager {
         return attrs
     }
 
+    /// Session-identity attributes for the session that was live in the *previous*
+    /// process launch, recovered from the keychain into `sessionMetadata.old*` at
+    /// init (before the keychain was overwritten with this launch's identity).
+    /// Empty when there is no prior launch on record.
+    ///
+    /// Crash instrumentation overrides the crash span's `session_id` /
+    /// `session_creation_date` with these: a crash captured on relaunch belongs to
+    /// the session that actually crashed, not the freshly-created one. This is the
+    /// only in-memory copy of the crashed session's identity — the keychain itself
+    /// already holds the current launch's session by the time crashes are processed.
+    func lastLaunchSessionSpanAttributes() -> [(key: String, value: String)] {
+        sessionLock.lock()
+        let oldSessionId = self.sessionMetadata?.oldSessionId
+        let oldCreationDate = self.sessionMetadata?.oldSessionTimeInterval
+        sessionLock.unlock()
+
+        guard let oldSessionId, let oldCreationDate else { return [] }
+        return [
+            (Keys.sessionId.rawValue, oldSessionId),
+            (Keys.sessionCreationDate.rawValue, String(Int(oldCreationDate)))
+        ]
+    }
+
     public func getErrorCount() -> Int {
         countersLock.lock()
         defer { countersLock.unlock() }

--- a/CoralogixInternal.podspec
+++ b/CoralogixInternal.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "CoralogixInternal"
-  spec.version      = "2.10.1"
+  spec.version      = "2.10.2"
   spec.summary      = "Coralogix Internal Package. This module is not for public use."
 
   spec.description  = <<-DESC

--- a/CoralogixInternal/Sources/Logging/OSLogger.swift
+++ b/CoralogixInternal/Sources/Logging/OSLogger.swift
@@ -9,6 +9,11 @@ public final class OSLogger: CXLogger {
     public static let defaultSubsystem = "com.coralogix.rum"
     public static let defaultCategory = "default"
 
+    /// os_log truncates a single entry beyond an internal size limit (~1 KB on
+    /// the legacy path used pre-iOS 14). Messages larger than this fall back to
+    /// print() so they survive intact — see `log(...)`.
+    private static let maxOSLogMessageBytes = 1024
+
     private let subsystem: String
     private let category: String
     private let legacyLog: OSLog
@@ -30,6 +35,18 @@ public final class OSLogger: CXLogger {
                     function: String,
                     line: Int) {
         let formatted = "\(level.emojiPrefix) \(Self.format(message: message(), metadata: metadata))"
+
+        // os_log clips a single oversized entry (e.g. a crash span's full thread
+        // stacks), so for large messages fall back to print(), which has no size
+        // limit and keeps the payload intact as one blob. This path is only
+        // reachable when logging is enabled (Log.emit gates on isDebug), so it
+        // never runs in a release/production app. Normal-sized logs keep going
+        // through os_log to retain levels, subsystem/category, and Console.app
+        // capture on detached devices.
+        if Self.exceedsOSLogLimit(formatted) {
+            print(formatted)
+            return
+        }
 
         if #available(iOS 14.0, *) {
             let logger = modernLogger()
@@ -56,6 +73,13 @@ public final class OSLogger: CXLogger {
         let made = os.Logger(subsystem: subsystem, category: category)
         Self.modernCache[key] = made
         return made
+    }
+
+    /// Whether `formatted` is large enough that os_log would truncate it and the
+    /// logger should fall back to print(). Extracted so the size policy is testable
+    /// without capturing os_log/stdout side effects.
+    static func exceedsOSLogLimit(_ formatted: String) -> Bool {
+        formatted.utf8.count > maxOSLogMessageBytes
     }
 
     private static func format(message: String, metadata: [String: Any]?) -> String {

--- a/CoralogixInternal/Sources/Utils.swift
+++ b/CoralogixInternal/Sources/Utils.swift
@@ -16,7 +16,7 @@ public enum ImageFormat {
 }
 
 public enum Global: String {
-    case sdk = "2.10.1"
+    case sdk = "2.10.2"
     case swiftVersion = "5.9"
     case coralogixPath = "/browser/v1beta/logs"
     case sessionReplayPath = "/browser/alpha/sessionrecording"

--- a/Example/DemoAppSwift/MainViewController.swift
+++ b/Example/DemoAppSwift/MainViewController.swift
@@ -179,9 +179,16 @@ final class MainViewController: UITableViewController {
             copyButton.trailingAnchor.constraint(equalTo: card.trailingAnchor, constant: -12)
         ])
 
-        // Size header explicitly
+        // Size the header to fit its Auto Layout content so the session ID isn't clipped.
         let headerWidth = view.bounds.width
-        container.frame = CGRect(x: 0, y: 0, width: headerWidth, height: 80)
+        container.frame = CGRect(x: 0, y: 0, width: headerWidth, height: 0)
+        container.layoutIfNeeded()
+        let fittingHeight = container.systemLayoutSizeFitting(
+            CGSize(width: headerWidth, height: UIView.layoutFittingCompressedSize.height),
+            withHorizontalFittingPriority: .required,
+            verticalFittingPriority: .fittingSizeLevel
+        ).height
+        container.frame = CGRect(x: 0, y: 0, width: headerWidth, height: fittingHeight)
         tableView.tableHeaderView = container
     }
 

--- a/SessionReplay.podspec
+++ b/SessionReplay.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "SessionReplay"
-  spec.version      = "2.10.1"
+  spec.version      = "2.10.2"
   spec.summary      = "Coralogix Session-Replay pod for iOS."
 
   spec.description  = <<-DESC
@@ -23,7 +23,7 @@ Pod::Spec.new do |spec|
   spec.static_framework = true
 
   spec.source_files  = 'SessionReplay/Sources/**/*.swift'
-  spec.dependency 'CoralogixInternal', '2.10.1'
+  spec.dependency 'CoralogixInternal', '2.10.2'
   
     spec.test_spec 'Tests' do |test|
         test.source_files = 'Tests/SessionReplayTests/**/*.swift'

--- a/Tests/CoralogixInternalTests/LoggerTests.swift
+++ b/Tests/CoralogixInternalTests/LoggerTests.swift
@@ -293,4 +293,21 @@ final class LoggerTests: XCTestCase {
 
         XCTAssertEqual(rec.entries.count, 0, "Log.e(Error)/Log.error(Error) must be gated at the façade, not rely on the underlying logger")
     }
+
+    // MARK: - OSLogger oversized-message fallback
+
+    // os_log truncates a single oversized entry, so OSLogger routes messages
+    // above the limit to print() instead. These pin the size policy that decides
+    // which path a message takes.
+
+    func test_exceedsOSLogLimit_falseForShortMessage() {
+        XCTAssertFalse(OSLogger.exceedsOSLogLimit("🟪 a short debug line"),
+            "normal-sized logs must keep going through os_log")
+    }
+
+    func test_exceedsOSLogLimit_trueForOversizedMessage() {
+        let oversized = String(repeating: "a", count: 4096)
+        XCTAssertTrue(OSLogger.exceedsOSLogLimit(oversized),
+            "a payload larger than the os_log limit must fall back to print() so it isn't truncated")
+    }
 }

--- a/Tests/CoralogixRumTests/CxRumBuilderTests.swift
+++ b/Tests/CoralogixRumTests/CxRumBuilderTests.swift
@@ -332,7 +332,7 @@ class CxRumBuilderTests: XCTestCase {
                      "view_number must be entirely absent from the payload when no view has appeared yet")
     }
 
-    // MARK: - CX-49308: crash span timestamp is anchored to the crash time
+    // MARK: - Crash span timestamp is anchored to the crash time
     //
     // The RUM event timestamp is derived from the span start time, but build()
     // clamps it up to session_creation_date. These pin the coupling behind the

--- a/Tests/CoralogixRumTests/CxRumBuilderTests.swift
+++ b/Tests/CoralogixRumTests/CxRumBuilderTests.swift
@@ -332,6 +332,76 @@ class CxRumBuilderTests: XCTestCase {
                      "view_number must be entirely absent from the payload when no view has appeared yet")
     }
 
+    // MARK: - CX-49308: crash span timestamp is anchored to the crash time
+    //
+    // The RUM event timestamp is derived from the span start time, but build()
+    // clamps it up to session_creation_date. These pin the coupling behind the
+    // crash fix: only when the crash span is attributed to the session that was
+    // live *before* the crash (creation date < crash time) does the crash-time
+    // timestamp survive. Leaving it under the relaunch session drags it forward.
+
+    func test_build_crashSpan_keepsCrashTimestamp_whenSessionPredatesCrash() {
+        let crashTime = Date(timeIntervalSince1970: 1_700_000_000)
+        let sessionCreatedBeforeCrash = crashTime.addingTimeInterval(-120).timeIntervalSince1970
+
+        guard let cxRum = makeCrashSUT(startTime: crashTime,
+                                       sessionId: "crashed-session",
+                                       sessionCreationDate: sessionCreatedBeforeCrash)?.build() else {
+            return XCTFail("build() returned nil")
+        }
+
+        XCTAssertEqual(cxRum.sessionContext?.sessionId, "crashed-session",
+            "Crash span must be attributed to the session that crashed")
+        XCTAssertEqual(cxRum.timeStamp, crashTime.timeIntervalSince1970, accuracy: 0.001,
+            "Crash event must report the crash time, not be clamped forward to the session creation date")
+    }
+
+    func test_build_crashSpan_timestampClampedForward_whenSessionPostdatesCrash() {
+        // Pre-fix behaviour: the crash is left under the relaunch session, whose
+        // creation date is AFTER the crash. build() then clamps the crash time
+        // forward — which is why the session fix is a prerequisite for the timestamp.
+        let crashTime = Date(timeIntervalSince1970: 1_700_000_000)
+        let sessionCreatedAfterCrash = crashTime.addingTimeInterval(120).timeIntervalSince1970
+
+        guard let cxRum = makeCrashSUT(startTime: crashTime,
+                                       sessionId: "relaunch-session",
+                                       sessionCreationDate: sessionCreatedAfterCrash)?.build() else {
+            return XCTFail("build() returned nil")
+        }
+
+        XCTAssertEqual(cxRum.timeStamp, sessionCreatedAfterCrash, accuracy: 0.001,
+            "A relaunch session created after the crash drags the crash timestamp forward — the bug the session fix prevents")
+    }
+
+    private func makeCrashSUT(startTime: Date,
+                              sessionId: String,
+                              sessionCreationDate: TimeInterval) -> CxRumBuilder? {
+        let otel = MockSpanData(attributes: [
+            Keys.severity.rawValue: AttributeValue("5"),
+            Keys.eventType.rawValue: AttributeValue("error"),
+            Keys.source.rawValue: AttributeValue("console"),
+            Keys.environment.rawValue: AttributeValue("prod"),
+            Keys.sessionId.rawValue: AttributeValue(sessionId),
+            Keys.sessionCreationDate.rawValue: AttributeValue("\(Int(sessionCreationDate))")
+        ], startTime: startTime, endTime: startTime, spanId: "20", traceId: "30", name: "testSpan", kind: 1)
+
+        let userContext = UserContext(userId: "12345", userName: "John Doe",
+                                      userEmail: "john.doe@example.com", userMetadata: [:])
+        let options = CoralogixExporterOptions(coralogixDomain: CoralogixDomain.US2,
+                                               userContext: userContext,
+                                               environment: "PROD",
+                                               application: "TestApp-iOS",
+                                               version: "1.0",
+                                               publicKey: "token",
+                                               debug: true)
+        return CxRumBuilder(otel: otel,
+                            versionMetadata: VersionMetadata(appName: "Test", appVersion: "1.0"),
+                            sessionManager: mockSessionManager,
+                            viewManager: mockViewManager,
+                            networkManager: NetworkManager(),
+                            options: options)
+    }
+
     // Convenience overload that lets the new tests vary event type without touching the
     // original makeSUT() / its existing callers (which pin a "log" event for snapshot tests).
     private func makeSUT(currentTime: Date, eventType: String) -> CxRumBuilder? {

--- a/Tests/CoralogixRumTests/SessionManagerTests.swift
+++ b/Tests/CoralogixRumTests/SessionManagerTests.swift
@@ -261,7 +261,7 @@ class SessionManagerTests: XCTestCase {
             "Rotation must retain the stale session ID as the previous session so spans carry correct prev_session_id attribution")
     }
 
-    // MARK: - CX-49308: crash attribution to the previous-launch session
+    // MARK: - Crash attribution to the previous-launch session
     //
     // A crash is captured on the *next* launch, after a fresh session has already
     // been created. `lastLaunchSessionSpanAttributes` surfaces the session that was

--- a/Tests/CoralogixRumTests/SessionManagerTests.swift
+++ b/Tests/CoralogixRumTests/SessionManagerTests.swift
@@ -260,4 +260,41 @@ class SessionManagerTests: XCTestCase {
         XCTAssertEqual(prev?.sessionId, staleSessionId,
             "Rotation must retain the stale session ID as the previous session so spans carry correct prev_session_id attribution")
     }
+
+    // MARK: - CX-49308: crash attribution to the previous-launch session
+    //
+    // A crash is captured on the *next* launch, after a fresh session has already
+    // been created. `lastLaunchSessionSpanAttributes` surfaces the session that was
+    // live in the previous launch (recovered from the keychain into
+    // `sessionMetadata.old*` at init) so crash instrumentation can burn the crash
+    // under the session that actually crashed.
+
+    func testLastLaunchSessionSpanAttributes_returnsPreviousLaunchSession() {
+        guard var metadata = sessionManager.sessionMetadata else {
+            XCTFail("Session metadata should not be nil")
+            return
+        }
+        metadata.oldSessionId = "crashed-session-abc"
+        metadata.oldSessionTimeInterval = TimeInterval(1_600_000_000)
+        sessionManager.sessionMetadata = metadata
+
+        let attrs = Dictionary(uniqueKeysWithValues: sessionManager.lastLaunchSessionSpanAttributes())
+        XCTAssertEqual(attrs[Keys.sessionId.rawValue], "crashed-session-abc",
+            "Crash span must carry the crashed session id, not the session created on relaunch")
+        XCTAssertEqual(attrs[Keys.sessionCreationDate.rawValue], "1600000000",
+            "Crash span must carry the crashed session's creation date")
+    }
+
+    func testLastLaunchSessionSpanAttributes_emptyWhenNoPreviousLaunch() {
+        guard var metadata = sessionManager.sessionMetadata else {
+            XCTFail("Session metadata should not be nil")
+            return
+        }
+        metadata.oldSessionId = nil
+        metadata.oldSessionTimeInterval = nil
+        sessionManager.sessionMetadata = metadata
+
+        XCTAssertTrue(sessionManager.lastLaunchSessionSpanAttributes().isEmpty,
+            "With no previous-launch session on record, no override attributes should be produced")
+    }
 }


### PR DESCRIPTION
# User description
## What

A crash captured by PLCrashReporter is only turned into a RUM event on the **next** app launch — after a fresh session has already been created. Two things were wrong with the resulting crash event:

1. **Session** — it was reported under the *new* session, not the session that was live when the crash happened.
2. **Timestamp** — the span started at relaunch time, so the crash landed at the wrong point on the timeline. The crashed session's id survived only in `sessionMetadata.old*` (keychain-loaded at init) and was never emitted.

Fixes **CX-49308** (P1).

## How

- **`SessionManager.lastLaunchSessionSpanAttributes()`** (new, internal) — surfaces the previous-launch session's `session_id` / `session_creation_date`, recovered from the keychain into `sessionMetadata.old*` at init.
- **`CoralogixRum.makeSpan`** — gains an optional `startTime` so a span can be anchored to a past instant.
- **`CrashInstrumentation.processPendingCrashReport`** — passes `report.systemInfo.timestamp` to `makeSpan`, ends the span at the same instant, and overrides the crash span's session attributes with the crashed session.

### Why both fixes ship together
The RUM event timestamp is derived from the span start time, but `CxRumBuilder` then **clamps it up to `session_creation_date`**. Anchoring the span to the crash time only holds once the session is also the crashed one (whose creation predates the crash) — otherwise the new session's later creation date drags the timestamp back to relaunch time. A test pins this coupling.

## Design note
Chose a direct session override over the dormant `shouldRestorePreviousSession` pid-match restore path — more robust (no dependency on the pid heuristic firing) and a cleaner payload (no redundant `prev_session` block).

## Known limitation (out of scope)
`hasRecording` on a crash span still reflects the current session, not the crashed one. Noted on the ticket as a follow-up.

## Testing
- 4 new unit tests (`SessionManagerTests`, `CxRumBuilderTests`) covering the accessor, the crash-time timestamp, and the timestamp/session clamp coupling.
- Full `CoralogixRumTests` suite: **740 tests, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Align crash reporting with the session that actually failed by having <code>SessionManager</code> surface the previous launch’s identity and letting <code>CrashInstrumentation</code>/<code>CoralogixRum.makeSpan</code> anchor OTLP spans to the crash timestamp so replays report the correct session and time. Harden logging and shipping pieces by guarding <code>OSLogger</code> against os_log truncation, updating package versions, and sizing the demo header to show its session ID without clipping.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/234?tool=ast&topic=Demo+header+sizing>Demo header sizing</a>
        </td><td>Ensure the demo app’s session header measures itself via Auto Layout so the session ID label is fully visible when displayed in the table header.<details><summary>Modified files (1)</summary><ul><li>Example/DemoAppSwift/MainViewController.swift</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>chore(): auto-size dem...</td><td>July 13, 2026</td></tr>
<tr><td>NatanCoralogix</td><td>UI test (#85)</td><td>July 29, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/234?tool=ast&topic=Logger+overflow+guard>Logger overflow guard</a>
        </td><td>Keep oversized debug payloads intact by routing entries above the <code>OSLogger</code> os_log byte limit through <code>print()</code> and locking down the detection logic with dedicated logger tests so crash-thread dumps survive instrumentation without truncation.<details><summary>Modified files (2)</summary><ul><li>CoralogixInternal/Sources/Logging/OSLogger.swift</li>
<li>Tests/CoralogixInternalTests/LoggerTests.swift</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>chore(): fall back to ...</td><td>July 13, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/234?tool=ast&topic=Crash+session+fix>Crash session fix</a>
        </td><td>Anchor crash spans to the real failure flow by overriding instrumentation attributes with <code>SessionManager.lastLaunchSessionSpanAttributes()</code>, passing the PLCrashReporter timestamp through <code>CoralogixRum.makeSpan</code>, and ending spans at crash time so the exported RUM event stays tied to the crashed session; surface the regression fix in the changelog and validate it with <code>CxRumBuilderTests</code>/<code>SessionManagerTests</code>.<details><summary>Modified files (6)</summary><ul><li>CHANGELOG.md</li>
<li>Coralogix/Sources/CoralogixRum.swift</li>
<li>Coralogix/Sources/Instrumentation/CrashInstrumentation.swift</li>
<li>Coralogix/Sources/Utils/SessionManager.swift</li>
<li>Tests/CoralogixRumTests/CxRumBuilderTests.swift</li>
<li>Tests/CoralogixRumTests/SessionManagerTests.swift</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>chore(): address PR re...</td><td>July 14, 2026</td></tr>
<tr><td>dan.gavrielov@coralogi...</td><td>fix(session-replay): m...</td><td>June 15, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/234?tool=ast&topic=Release+metadata>Release metadata</a>
        </td><td>Ship version 2.10.2 across the internal, public, and replay pods plus the shared <code>Global.sdk</code> constant so downstream consumers pull in the crash/session fixes and matching dependencies.<details><summary>Modified files (4)</summary><ul><li>Coralogix.podspec</li>
<li>CoralogixInternal.podspec</li>
<li>CoralogixInternal/Sources/Utils.swift</li>
<li>SessionReplay.podspec</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>chore(): bump version ...</td><td>July 13, 2026</td></tr>
<tr><td>dan.gavrielov@coralogi...</td><td>fix(session-replay): m...</td><td>June 15, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/coralogix/cx-ios-sdk/234?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>