### PR TITLE
ci(publish-pods): poll Trunk before failing so a landed-but-lagging push isn't a false failure

### DIFF
--- a/.github/workflows/publish-pods.yml
+++ b/.github/workflows/publish-pods.yml
@@ -64,6 +64,28 @@ jobs:
           # Escape the tag for literal use in the version-match regexes below
           # (a bare semver like 2.10.0 contains regex-special dots).
           TAG_RE=$(printf '%s' "$TAG_RAW" | sed 's/[^[:alnum:]]/\\&/g')
+          # `pod trunk info` and the CDN spec index lag the actual registration by
+          # seconds to minutes, so checking once right after a push races propagation
+          # and reports a false failure even when the spec already landed server-side
+          # (the GitHub commit API frequently times out client-side after the push
+          # succeeds). Poll instead of checking once; return 0 as soon as it appears.
+          landed_on_trunk() {
+            local pod="$1"
+            local tries=6
+            local delay=30
+            local i=1
+            while :; do
+              if pod trunk info "$pod" | grep -Eq "^[[:space:]]*-[[:space:]]*${TAG_RE}([[:space:]]|\(|$)"; then
+                return 0
+              fi
+              if [ "$i" -ge "$tries" ]; then
+                return 1
+              fi
+              echo "⏳ ${pod} ${TAG_RAW} not on Trunk yet (check ${i}/${tries}); waiting ${delay}s for propagation..."
+              sleep "$delay"
+              i=$((i + 1))
+            done
+          }
           if pod trunk info CoralogixInternal | grep -Eq "^[[:space:]]*-[[:space:]]*${TAG_RE}([[:space:]]|\(|$)"; then
             echo "ℹ️  CoralogixInternal ${TAG_RAW} already on Trunk. Skipping push."
           else
@@ -77,7 +99,7 @@ jobs:
               echo "✅ CoralogixInternal.podspec pushed!"
             elif echo "$push_output" | grep -q "Unable to accept duplicate entry"; then
               echo "⚠️ Duplicate entry detected for CoralogixInternal (already on Trunk)."
-            elif pod trunk info CoralogixInternal | grep -Eq "^[[:space:]]*-[[:space:]]*${TAG_RE}([[:space:]]|\(|$)"; then
+            elif landed_on_trunk CoralogixInternal; then
               # A client-side failure (e.g. "Calling the GitHub commit API timed out")
               # frequently still lands the spec server-side. Trust Trunk, not the exit code.
               echo "✅ CoralogixInternal ${TAG_RAW} is on Trunk — push landed despite a client error."
@@ -124,6 +146,28 @@ jobs:
           # Escape the tag for literal use in the version-match regexes below
           # (a bare semver like 2.10.0 contains regex-special dots).
           TAG_RE=$(printf '%s' "$TAG_RAW" | sed 's/[^[:alnum:]]/\\&/g')
+          # `pod trunk info` and the CDN spec index lag the actual registration by
+          # seconds to minutes, so checking once right after a push races propagation
+          # and reports a false failure even when the spec already landed server-side
+          # (the GitHub commit API frequently times out client-side after the push
+          # succeeds). Poll instead of checking once; return 0 as soon as it appears.
+          landed_on_trunk() {
+            local pod="$1"
+            local tries=6
+            local delay=30
+            local i=1
+            while :; do
+              if pod trunk info "$pod" | grep -Eq "^[[:space:]]*-[[:space:]]*${TAG_RE}([[:space:]]|\(|$)"; then
+                return 0
+              fi
+              if [ "$i" -ge "$tries" ]; then
+                return 1
+              fi
+              echo "⏳ ${pod} ${TAG_RAW} not on Trunk yet (check ${i}/${tries}); waiting ${delay}s for propagation..."
+              sleep "$delay"
+              i=$((i + 1))
+            done
+          }
           if pod trunk info SessionReplay | grep -Eq "^[[:space:]]*-[[:space:]]*${TAG_RE}([[:space:]]|\(|$)"; then
             echo "ℹ️ SessionReplay ${TAG_RAW} already on Trunk. Skipping push."
           else
@@ -154,7 +198,7 @@ jobs:
 
               # A client-side failure (e.g. "Calling the GitHub commit API timed out")
               # frequently still lands the spec server-side. Trust Trunk, not the exit code.
-              if pod trunk info SessionReplay | grep -Eq "^[[:space:]]*-[[:space:]]*${TAG_RE}([[:space:]]|\(|$)"; then
+              if landed_on_trunk SessionReplay; then
                 echo "✅ SessionReplay ${TAG_RAW} is on Trunk — push landed despite a client error."
                 pushed=true
                 break
@@ -190,6 +234,28 @@ jobs:
           # Escape the tag for literal use in the version-match regexes below
           # (a bare semver like 2.10.0 contains regex-special dots).
           TAG_RE=$(printf '%s' "$TAG_RAW" | sed 's/[^[:alnum:]]/\\&/g')
+          # `pod trunk info` and the CDN spec index lag the actual registration by
+          # seconds to minutes, so checking once right after a push races propagation
+          # and reports a false failure even when the spec already landed server-side
+          # (the GitHub commit API frequently times out client-side after the push
+          # succeeds). Poll instead of checking once; return 0 as soon as it appears.
+          landed_on_trunk() {
+            local pod="$1"
+            local tries=6
+            local delay=30
+            local i=1
+            while :; do
+              if pod trunk info "$pod" | grep -Eq "^[[:space:]]*-[[:space:]]*${TAG_RE}([[:space:]]|\(|$)"; then
+                return 0
+              fi
+              if [ "$i" -ge "$tries" ]; then
+                return 1
+              fi
+              echo "⏳ ${pod} ${TAG_RAW} not on Trunk yet (check ${i}/${tries}); waiting ${delay}s for propagation..."
+              sleep "$delay"
+              i=$((i + 1))
+            done
+          }
           if pod trunk info Coralogix | grep -Eq "^[[:space:]]*-[[:space:]]*${TAG_RE}([[:space:]]|\(|$)"; then
             echo "ℹ️ Coralogix ${TAG_RAW} already on Trunk. Skipping push."
           else
@@ -220,7 +286,7 @@ jobs:
 
               # A client-side failure (e.g. "Calling the GitHub commit API timed out")
               # frequently still lands the spec server-side. Trust Trunk, not the exit code.
-              if pod trunk info Coralogix | grep -Eq "^[[:space:]]*-[[:space:]]*${TAG_RE}([[:space:]]|\(|$)"; then
+              if landed_on_trunk Coralogix; then
                 echo "✅ Coralogix ${TAG_RAW} is on Trunk — push landed despite a client error."
                 pushed=true
                 break


### PR DESCRIPTION
# User description
## Problem

The `Publish CocoaPods` job went red on the **2.10.2** release even though all three pods published successfully. `Coralogix 2.10.2` landed on Trunk at `10:21:20 UTC`; the `pod trunk push` client then returned a non-zero exit ~9s later (the GitHub commit API times out client-side on the `--verbose` output — the log even shows a `write error: Broken pipe`).

The workflow already has a "trust Trunk, not the exit code" guard, but it checked `pod trunk info` **exactly once, immediately** after the failed push. The Trunk/CDN spec index lags the actual registration by seconds to minutes, so that single check lost the race and the job failed — a false alarm on a release that actually succeeded.

## Fix

Replace the single-shot check with a bounded poll (`landed_on_trunk`: up to 6 checks, 30s apart ≈ 2.5-min propagation window) in all three push steps (`CoralogixInternal`, `SessionReplay`, `Coralogix`).

- Spec landed but lagging → the poll sees it → job passes, correctly.
- Spec genuinely never lands (real build failure) → the poll times out → job fails, correctly.

No behavior change on the happy path (exit 0) or the duplicate-entry path.

## Validation

- YAML parses (10 steps intact).
- Every `run:` block passes `bash -n`.
- Unit-tested the poll logic with stubbed `pod`/`sleep`: found-on-1st ✅, appears-on-3rd (lag) ✅, appears-on-6th ✅, never-appears → correctly fails ✅.

## Notes

- CI-only change — no SDK code, so no version bump / CHANGELOG / README needed.
- Release workflows run from the workflow file on the released commit, so this protects the **next** release once merged; it does not retroactively affect the 2.10.2 run.
- 2.10.2 is fully published and usable — nothing to re-publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add polling around <code>pod trunk info</code> in the Publish CocoaPods workflow to wait up to six checks before treating a non-zero push as a failure. Document the <code>landed_on_trunk</code> helper and use it after each push to ensure a spec that landed server-side is recognized even if the push command timed out.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/235?tool=ast&topic=Push+retry+flow>Push retry flow</a>
        </td><td>Apply the new helper in the CoralogixInternal, SessionReplay, and Coralogix push steps so a client-side timeout only fails the job when the spec never appears on Trunk after the bounded poll.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/publish-pods.yml</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/235?tool=ast&topic=Trunk+polling+guard>Trunk polling guard</a>
        </td><td>Introduce <code>landed_on_trunk</code> polling helper that retries <code>pod trunk info</code> up to six times with 30 s spacing so transient propagation delays do not trigger false failures.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/publish-pods.yml</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/coralogix/cx-ios-sdk/235?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>