### PR TITLE
fix(BUGV2-6662): honor Dart/RN wire traceId in hybrid network path so iOS matches the wire traceparent

### DIFF
--- a/.github/workflows/publish-pods.yml
+++ b/.github/workflows/publish-pods.yml
@@ -64,6 +64,28 @@ jobs:
           # Escape the tag for literal use in the version-match regexes below
           # (a bare semver like 2.10.0 contains regex-special dots).
           TAG_RE=$(printf '%s' "$TAG_RAW" | sed 's/[^[:alnum:]]/\\&/g')
+          # `pod trunk info` and the CDN spec index lag the actual registration by
+          # seconds to minutes, so checking once right after a push races propagation
+          # and reports a false failure even when the spec already landed server-side
+          # (the GitHub commit API frequently times out client-side after the push
+          # succeeds). Poll instead of checking once; return 0 as soon as it appears.
+          landed_on_trunk() {
+            local pod="$1"
+            local tries=6
+            local delay=30
+            local i=1
+            while :; do
+              if pod trunk info "$pod" | grep -Eq "^[[:space:]]*-[[:space:]]*${TAG_RE}([[:space:]]|\(|$)"; then
+                return 0
+              fi
+              if [ "$i" -ge "$tries" ]; then
+                return 1
+              fi
+              echo "⏳ ${pod} ${TAG_RAW} not on Trunk yet (check ${i}/${tries}); waiting ${delay}s for propagation..."
+              sleep "$delay"
+              i=$((i + 1))
+            done
+          }
           if pod trunk info CoralogixInternal | grep -Eq "^[[:space:]]*-[[:space:]]*${TAG_RE}([[:space:]]|\(|$)"; then
             echo "ℹ️  CoralogixInternal ${TAG_RAW} already on Trunk. Skipping push."
           else
@@ -77,7 +99,7 @@ jobs:
               echo "✅ CoralogixInternal.podspec pushed!"
             elif echo "$push_output" | grep -q "Unable to accept duplicate entry"; then
               echo "⚠️ Duplicate entry detected for CoralogixInternal (already on Trunk)."
-            elif pod trunk info CoralogixInternal | grep -Eq "^[[:space:]]*-[[:space:]]*${TAG_RE}([[:space:]]|\(|$)"; then
+            elif landed_on_trunk CoralogixInternal; then
               # A client-side failure (e.g. "Calling the GitHub commit API timed out")
               # frequently still lands the spec server-side. Trust Trunk, not the exit code.
               echo "✅ CoralogixInternal ${TAG_RAW} is on Trunk — push landed despite a client error."
@@ -124,6 +146,28 @@ jobs:
           # Escape the tag for literal use in the version-match regexes below
           # (a bare semver like 2.10.0 contains regex-special dots).
           TAG_RE=$(printf '%s' "$TAG_RAW" | sed 's/[^[:alnum:]]/\\&/g')
+          # `pod trunk info` and the CDN spec index lag the actual registration by
+          # seconds to minutes, so checking once right after a push races propagation
+          # and reports a false failure even when the spec already landed server-side
+          # (the GitHub commit API frequently times out client-side after the push
+          # succeeds). Poll instead of checking once; return 0 as soon as it appears.
+          landed_on_trunk() {
+            local pod="$1"
+            local tries=6
+            local delay=30
+            local i=1
+            while :; do
+              if pod trunk info "$pod" | grep -Eq "^[[:space:]]*-[[:space:]]*${TAG_RE}([[:space:]]|\(|$)"; then
+                return 0
+              fi
+              if [ "$i" -ge "$tries" ]; then
+                return 1
+              fi
+              echo "⏳ ${pod} ${TAG_RAW} not on Trunk yet (check ${i}/${tries}); waiting ${delay}s for propagation..."
+              sleep "$delay"
+              i=$((i + 1))
+            done
+          }
           if pod trunk info SessionReplay | grep -Eq "^[[:space:]]*-[[:space:]]*${TAG_RE}([[:space:]]|\(|$)"; then
             echo "ℹ️ SessionReplay ${TAG_RAW} already on Trunk. Skipping push."
           else
@@ -154,7 +198,7 @@ jobs:
 
               # A client-side failure (e.g. "Calling the GitHub commit API timed out")
               # frequently still lands the spec server-side. Trust Trunk, not the exit code.
-              if pod trunk info SessionReplay | grep -Eq "^[[:space:]]*-[[:space:]]*${TAG_RE}([[:space:]]|\(|$)"; then
+              if landed_on_trunk SessionReplay; then
                 echo "✅ SessionReplay ${TAG_RAW} is on Trunk — push landed despite a client error."
                 pushed=true
                 break
@@ -190,6 +234,28 @@ jobs:
           # Escape the tag for literal use in the version-match regexes below
           # (a bare semver like 2.10.0 contains regex-special dots).
           TAG_RE=$(printf '%s' "$TAG_RAW" | sed 's/[^[:alnum:]]/\\&/g')
+          # `pod trunk info` and the CDN spec index lag the actual registration by
+          # seconds to minutes, so checking once right after a push races propagation
+          # and reports a false failure even when the spec already landed server-side
+          # (the GitHub commit API frequently times out client-side after the push
+          # succeeds). Poll instead of checking once; return 0 as soon as it appears.
+          landed_on_trunk() {
+            local pod="$1"
+            local tries=6
+            local delay=30
+            local i=1
+            while :; do
+              if pod trunk info "$pod" | grep -Eq "^[[:space:]]*-[[:space:]]*${TAG_RE}([[:space:]]|\(|$)"; then
+                return 0
+              fi
+              if [ "$i" -ge "$tries" ]; then
+                return 1
+              fi
+              echo "⏳ ${pod} ${TAG_RAW} not on Trunk yet (check ${i}/${tries}); waiting ${delay}s for propagation..."
+              sleep "$delay"
+              i=$((i + 1))
+            done
+          }
           if pod trunk info Coralogix | grep -Eq "^[[:space:]]*-[[:space:]]*${TAG_RE}([[:space:]]|\(|$)"; then
             echo "ℹ️ Coralogix ${TAG_RAW} already on Trunk. Skipping push."
           else
@@ -220,7 +286,7 @@ jobs:
 
               # A client-side failure (e.g. "Calling the GitHub commit API timed out")
               # frequently still lands the spec server-side. Trust Trunk, not the exit code.
-              if pod trunk info Coralogix | grep -Eq "^[[:space:]]*-[[:space:]]*${TAG_RE}([[:space:]]|\(|$)"; then
+              if landed_on_trunk Coralogix; then
                 echo "✅ Coralogix ${TAG_RAW} is on Trunk — push landed despite a client error."
                 pushed=true
                 break

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Release-mechanics commits (version bumps, podspec/script tweaks, README edits) a
 omitted; the focus here is user-facing behavior changes. Tickets are referenced as
 `CX-XXXXX` (Jira) or `ALPH-XXXX` (legacy). Pull request numbers are in parentheses.
 
+## [2.10.3] - 2026-07-14
+
+### Fixed
+- On the hybrid (Flutter / React Native) path, a network request's RUM span now carries the same trace ID that was injected into its outgoing `traceparent` header, so the mobile request correlates with its backend trace. Previously iOS only applied the reported trace/span IDs when a global custom span was active and dropped the per-request IDs otherwise, leaving ordinary requests on a separate, unstitchable trace (Android already applied them).
+
 ## [2.10.2] - 2026-07-13
 
 ### Fixed

--- a/Coralogix.podspec
+++ b/Coralogix.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "Coralogix"
-  spec.version      = "2.10.2"
+  spec.version      = "2.10.3"
   spec.summary      = "Coralogix OpenTelemetry pod for iOS."
 
   spec.description  = <<-DESC
@@ -29,7 +29,7 @@ Pod::Spec.new do |spec|
 
   spec.static_framework = true
   spec.dependency 'PLCrashReporter', '~> 1.12'
-  spec.dependency 'CoralogixInternal', '2.10.2'
+  spec.dependency 'CoralogixInternal', '2.10.3'
 
   spec.test_spec 'Tests' do |test|
     test.source_files = 'Tests/CoralogixRumTests/**/*.swift'

--- a/Coralogix/Sources/Instrumentation/NetworkInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/NetworkInstrumentation.swift
@@ -251,6 +251,30 @@ extension CoralogixRum {
     
     // MARK: - Hybrid Network API
 
+    /// Resolves the (traceId, spanId) the exported RUM span should carry for a hybrid network request.
+    ///
+    /// Hybrid layers (Flutter `CxDioInterceptor`, React Native) inject the `traceparent` on the wire
+    /// themselves and report the ids they used. A request made while a global custom span is active
+    /// reports them under `customTraceId`/`customSpanId`; every other request reports the per-request
+    /// wire ids under `traceId`/`spanId`. Prefer the custom-span pair, then fall back to the per-request
+    /// pair, so the exported span's trace id matches the `traceparent` actually sent to the backend and
+    /// the mobile request stitches to its backend trace. Resolved as a pair to avoid mixing a trace id
+    /// from one source with a span id from another. Android resolves the same way; iOS previously read
+    /// only `customTraceId`/`customSpanId`, dropping the wire ids for ordinary requests.
+    internal static func resolveHybridTraceContext(from dictionary: [String: Any]) -> (traceId: String, spanId: String) {
+        func nonEmpty(_ key: Keys) -> String? {
+            guard let value = dictionary[key.rawValue] as? String, !value.isEmpty else { return nil }
+            return value
+        }
+        if let traceId = nonEmpty(.customTraceId), let spanId = nonEmpty(.customSpanId) {
+            return (traceId, spanId)
+        }
+        if let traceId = nonEmpty(.traceId), let spanId = nonEmpty(.spanId) {
+            return (traceId, spanId)
+        }
+        return ("", "")
+    }
+
     /// Implementation called by `CoralogixRum.setNetworkRequestContext(dictionary:)`.
     internal func reportHybridNetworkRequest(_ dictionary: [String: Any]) {
         guard validateHybridNetworkRequest(dictionary) else { return }
@@ -272,8 +296,9 @@ extension CoralogixRum {
         span.setAttribute(key: SemanticAttributes.httpResponseBodySize.rawValue, value: dictionary[Keys.httpResponseBodySize.rawValue] as? Int ?? 0)
         span.setAttribute(key: SemanticAttributes.httpTarget.rawValue, value: dictionary[Keys.fragments.rawValue] as? String ?? "")
         span.setAttribute(key: SemanticAttributes.httpScheme.rawValue, value: dictionary[Keys.schema.rawValue] as? String ?? "")
-        span.setAttribute(key: Keys.customSpanId.rawValue, value: dictionary[Keys.customSpanId.rawValue] as? String ?? "")
-        span.setAttribute(key: Keys.customTraceId.rawValue, value: dictionary[Keys.customTraceId.rawValue] as? String ?? "")
+        let traceContext = Self.resolveHybridTraceContext(from: dictionary)
+        span.setAttribute(key: Keys.customSpanId.rawValue, value: traceContext.spanId)
+        span.setAttribute(key: Keys.customTraceId.rawValue, value: traceContext.traceId)
 
         let requestUrl = dictionary[Keys.url.rawValue] as? String ?? ""
         var options: CoralogixExporterOptions?

--- a/CoralogixInternal.podspec
+++ b/CoralogixInternal.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "CoralogixInternal"
-  spec.version      = "2.10.2"
+  spec.version      = "2.10.3"
   spec.summary      = "Coralogix Internal Package. This module is not for public use."
 
   spec.description  = <<-DESC

--- a/CoralogixInternal/Sources/Utils.swift
+++ b/CoralogixInternal/Sources/Utils.swift
@@ -16,7 +16,7 @@ public enum ImageFormat {
 }
 
 public enum Global: String {
-    case sdk = "2.10.2"
+    case sdk = "2.10.3"
     case swiftVersion = "5.9"
     case coralogixPath = "/browser/v1beta/logs"
     case sessionReplayPath = "/browser/alpha/sessionrecording"

--- a/SessionReplay.podspec
+++ b/SessionReplay.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "SessionReplay"
-  spec.version      = "2.10.2"
+  spec.version      = "2.10.3"
   spec.summary      = "Coralogix Session-Replay pod for iOS."
 
   spec.description  = <<-DESC
@@ -23,7 +23,7 @@ Pod::Spec.new do |spec|
   spec.static_framework = true
 
   spec.source_files  = 'SessionReplay/Sources/**/*.swift'
-  spec.dependency 'CoralogixInternal', '2.10.2'
+  spec.dependency 'CoralogixInternal', '2.10.3'
   
     spec.test_spec 'Tests' do |test|
         test.source_files = 'Tests/SessionReplayTests/**/*.swift'

--- a/Tests/CoralogixRumTests/HybridNetworkTraceContextTests.swift
+++ b/Tests/CoralogixRumTests/HybridNetworkTraceContextTests.swift
@@ -2,7 +2,7 @@
 //  HybridNetworkTraceContextTests.swift
 //  Coralogix
 //
-//  Created by Tomer Har Yoffi on 14/07/2026.
+//  Created by Coralogix DEV TEAM on 14/07/2026.
 //
 
 import XCTest

--- a/Tests/CoralogixRumTests/HybridNetworkTraceContextTests.swift
+++ b/Tests/CoralogixRumTests/HybridNetworkTraceContextTests.swift
@@ -1,0 +1,116 @@
+//
+//  HybridNetworkTraceContextTests.swift
+//  Coralogix
+//
+//  Created by Tomer Har Yoffi on 14/07/2026.
+//
+
+import XCTest
+import CoralogixInternal
+@testable import Coralogix
+
+/// Hybrid (Flutter/React Native) network requests inject the `traceparent` on the wire from an upper
+/// layer and report the ids they used to native. The exported RUM span must carry those same ids so it
+/// stitches to the backend trace. These tests pin the resolution precedence and the end-to-end path
+/// from the hybrid payload through to `Helper.getTraceAndSpanId` (what the exporter reads).
+final class HybridNetworkTraceContextTests: XCTestCase {
+
+    // MARK: - resolveHybridTraceContext precedence
+
+    /// The active-custom-span pair wins when present, even if per-request wire ids are also supplied.
+    func testCustomTraceContextPreferredOverWireIds() {
+        let dict: [String: Any] = [
+            Keys.customTraceId.rawValue: "custom-trace",
+            Keys.customSpanId.rawValue: "custom-span",
+            Keys.traceId.rawValue: "wire-trace",
+            Keys.spanId.rawValue: "wire-span"
+        ]
+
+        let result = CoralogixRum.resolveHybridTraceContext(from: dict)
+
+        XCTAssertEqual(result.traceId, "custom-trace")
+        XCTAssertEqual(result.spanId, "custom-span")
+    }
+
+    /// The fix: for an ordinary request (no active custom span) the Dart/JS layer reports the wire ids
+    /// under `traceId`/`spanId`. These must be honored — previously iOS dropped them.
+    func testFallsBackToWireIdsWhenCustomAbsent() {
+        let dict: [String: Any] = [
+            Keys.traceId.rawValue: "wire-trace",
+            Keys.spanId.rawValue: "wire-span"
+        ]
+
+        let result = CoralogixRum.resolveHybridTraceContext(from: dict)
+
+        XCTAssertEqual(result.traceId, "wire-trace",
+                       "Per-request wire traceId reported under 'traceId' must be used when customTraceId is absent")
+        XCTAssertEqual(result.spanId, "wire-span")
+    }
+
+    /// Empty-string custom ids (native default when the JS layer omits them) must not shadow the wire ids.
+    func testFallsBackToWireIdsWhenCustomAreEmptyStrings() {
+        let dict: [String: Any] = [
+            Keys.customTraceId.rawValue: "",
+            Keys.customSpanId.rawValue: "",
+            Keys.traceId.rawValue: "wire-trace",
+            Keys.spanId.rawValue: "wire-span"
+        ]
+
+        let result = CoralogixRum.resolveHybridTraceContext(from: dict)
+
+        XCTAssertEqual(result.traceId, "wire-trace")
+        XCTAssertEqual(result.spanId, "wire-span")
+    }
+
+    /// Ids are resolved as a pair: a lone custom traceId (no matching span id) must not be used; the
+    /// resolver drops to the next complete pair so the exported span never mixes ids from two sources.
+    func testPartialCustomPairFallsBackToWirePair() {
+        let dict: [String: Any] = [
+            Keys.customTraceId.rawValue: "custom-trace",
+            // customSpanId intentionally absent
+            Keys.traceId.rawValue: "wire-trace",
+            Keys.spanId.rawValue: "wire-span"
+        ]
+
+        let result = CoralogixRum.resolveHybridTraceContext(from: dict)
+
+        XCTAssertEqual(result.traceId, "wire-trace")
+        XCTAssertEqual(result.spanId, "wire-span")
+    }
+
+    /// No ids at all → empty pair, so `getTraceAndSpanId` falls back to the native OTel span id (unchanged behavior).
+    func testReturnsEmptyPairWhenNoIdsProvided() {
+        let result = CoralogixRum.resolveHybridTraceContext(from: [Keys.url.rawValue: "https://example.com"])
+
+        XCTAssertEqual(result.traceId, "")
+        XCTAssertEqual(result.spanId, "")
+    }
+
+    // MARK: - End-to-end: resolved ids reach the exporter via getTraceAndSpanId
+
+    /// Guards the whole chain: reportHybridNetworkRequest sets customTraceId/customSpanId from the
+    /// resolved pair, and the exporter reads them back via getTraceAndSpanId. A wire-id-only payload
+    /// must surface the wire ids on the exported span — not a fresh native id (the BUGV2-6662 symptom).
+    func testWireIdsSurfaceOnExportedSpan() {
+        let resolved = CoralogixRum.resolveHybridTraceContext(from: [
+            Keys.traceId.rawValue: "wire-trace",
+            Keys.spanId.rawValue: "wire-span"
+        ])
+
+        let span = MockSpanData(
+            attributes: [
+                Keys.customTraceId.rawValue: AttributeValue(resolved.traceId),
+                Keys.customSpanId.rawValue: AttributeValue(resolved.spanId)
+            ],
+            startTime: Date(), endTime: Date(),
+            spanId: "native-span", traceId: "native-trace",
+            name: "HTTP GET", kind: 3
+        )
+
+        let result = Helper.getTraceAndSpanId(otel: span)
+
+        XCTAssertEqual(result.traceId, "wire-trace",
+                       "Exported span must carry the wire traceId, not the native auto-generated one")
+        XCTAssertEqual(result.spanId, "wire-span")
+    }
+}

--- a/Tests/CoralogixRumTests/HybridNetworkTraceContextTests.swift
+++ b/Tests/CoralogixRumTests/HybridNetworkTraceContextTests.swift
@@ -90,7 +90,7 @@ final class HybridNetworkTraceContextTests: XCTestCase {
 
     /// Guards the whole chain: reportHybridNetworkRequest sets customTraceId/customSpanId from the
     /// resolved pair, and the exporter reads them back via getTraceAndSpanId. A wire-id-only payload
-    /// must surface the wire ids on the exported span — not a fresh native id (the BUGV2-6662 symptom).
+    /// must surface the wire ids on the exported span — not a fresh, native auto-generated id that was never on the wire.
     func testWireIdsSurfaceOnExportedSpan() {
         let resolved = CoralogixRum.resolveHybridTraceContext(from: [
             Keys.traceId.rawValue: "wire-trace",


### PR DESCRIPTION
# User description
## Ticket
[BUGV2-6662](https://coralogix.atlassian.net/browse/BUGV2-6662) — *Inconsistent Mobile-to-Backend Tracing on iOS (RUM SDK)* (P2/Sev-2, customer Tide, Flutter/Dio). Follow-up to the deployed PIPEV2-3241 work.

## Problem
For hybrid apps (Flutter `CxDioInterceptor`, React Native), the upper layer injects the `traceparent` on the wire itself and reports the ids it used to native. For an ordinary request those arrive under `traceId`/`spanId`; only a request wrapped in an **active global custom span** additionally sends `customTraceId`/`customSpanId`.

iOS read **only** the `customTraceId`/`customSpanId` pair (`reportHybridNetworkRequest`), and `Helper.getTraceAndSpanId` reads only those attributes — otherwise it falls back to the native auto-generated OTel span id. So ordinary requests exported a RUM network span whose trace id was **never on the wire** → the mobile request could not stitch to its backend trace. Android already honors the reported ids, which is why Android worked and iOS didn't.

## Fix (iOS only)
Resolve the exported span's trace/span id as a **pair**, with the same precedence Android uses:

`customTraceId`/`customSpanId` → `traceId`/`spanId` → native fallback

Extracted into a pure `resolveHybridTraceContext(from:)` so it is directly testable; `reportHybridNetworkRequest` sets the span attributes from it. `Helper.getTraceAndSpanId` is intentionally left unchanged (its existing behavior — honoring only `customTraceId`/`customSpanId` — is pinned by a test).

No Flutter/RN change needed — the Dart layer already sends the ids.

## Tests
New `HybridNetworkTraceContextTests` (6 tests): custom pair preferred, wire-id fallback (the fix), empty-string custom ids fall through, partial pair falls through, empty when nothing supplied, and an end-to-end check that a wire-id-only payload surfaces the wire id via `Helper.getTraceAndSpanId` (the exporter's reader) — not a fresh native id. All green, plus no regression across the adjacent hybrid/network suites.

## Housekeeping
- Patch bump **2.10.2 → 2.10.3** across the three podspecs + `Global.sdk`.
- CHANGELOG entry added.
- No public API change → no README change.

## Scope note
If a customer's Dio traffic routes through `NSURLSession`, native swizzling can *also* emit a duplicate/orphan span — a separate double-instrumentation issue tracked independently, not addressed here. This change fixes the confirmed, iOS-specific trace-id drop that affects the hybrid path regardless of transport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BUGV2-6662]: https://coralogix.atlassian.net/browse/BUGV2-6662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Recover the trace IDs hybrid frameworks already inject on the wire by resolving and applying the reported pair when exporting RUM spans so mobile-to-backend stitching works on iOS. Test the new resolution path with <code>HybridNetworkTraceContextTests</code> and verify <code>Helper.getTraceAndSpanId</code> surfaces the resolved IDs from <code>reportHybridNetworkRequest</code>.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/236?tool=ast&topic=Hybrid+tracing>Hybrid tracing</a>
        </td><td>Ensure hybrid network spans resolve <code>traceId</code>/<code>spanId</code> pairs through <code>resolveHybridTraceContext</code> and surface those IDs via <code>reportHybridNetworkRequest</code> so backend traces stitch, while defending the path with <code>HybridNetworkTraceContextTests</code> and the exporter’s <code>Helper.getTraceAndSpanId</code> reader.<details><summary>Modified files (2)</summary><ul><li>Coralogix/Sources/Instrumentation/NetworkInstrumentation.swift</li>
<li>Tests/CoralogixRumTests/HybridNetworkTraceContextTests.swift</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>test: drop personal na...</td><td>July 14, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/coralogix/cx-ios-sdk/236?tool=ast&topic=Release+update>Release update</a>
        </td><td>Update version metadata across pods and <code>Global.sdk</code>, document the fix, and poll pod trunk info in the publish workflow to avoid premature failures when pushing the new <code>2.10.3</code> release.<details><summary>Modified files (6)</summary><ul><li>.github/workflows/publish-pods.yml</li>
<li>CHANGELOG.md</li>
<li>Coralogix.podspec</li>
<li>CoralogixInternal.podspec</li>
<li>CoralogixInternal/Sources/Utils.swift</li>
<li>SessionReplay.podspec</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>chore(): bump version ...</td><td>July 14, 2026</td></tr>
<tr><td>dan.gavrielov@coralogi...</td><td>fix(session-replay): m...</td><td>June 15, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/coralogix/cx-ios-sdk/236?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>