### PR TITLE
fix: freeze active view onto spans at creation so view_context matches event time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Release-mechanics commits (version bumps, podspec/script tweaks, README edits) a
 omitted; the focus here is user-facing behavior changes. Tickets are referenced as
 `CX-XXXXX` (Jira) or `ALPH-XXXX` (legacy). Pull request numbers are in parentheses.
 
+## [2.10.4] - 2026-07-16
+
+### Fixed
+- Events now report the screen that was on-screen when they occurred, instead of whatever screen happened to be active up to two seconds later when the batch was exported. Previously the view name (and view number / page URL) were read from the live view state at export time, so events that fired around a screen transition — logs, user interactions, mobile vitals, custom measurements, errors, and network requests — were frequently tagged with an empty or wrong view. The active view is now frozen onto each event the moment it is recorded.
+
 ## [2.10.3] - 2026-07-14
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ omitted; the focus here is user-facing behavior changes. Tickets are referenced 
 
 ### Fixed
 - Events now report the screen that was on-screen when they occurred, instead of whatever screen happened to be active up to two seconds later when the batch was exported. Previously the view name (and view number / page URL) were read from the live view state at export time, so events that fired around a screen transition — logs, user interactions, mobile vitals, custom measurements, errors, and network requests — were frequently tagged with an empty or wrong view. The active view is now frozen onto each event the moment it is recorded.
+- Crash reports again carry the screen the app was on when it crashed. A crash is recorded on the following launch, where no view has appeared yet, so it now recovers the crash-time screen from the previous session instead of reporting an empty view.
 
 ## [2.10.3] - 2026-07-14
 

--- a/Coralogix.podspec
+++ b/Coralogix.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "Coralogix"
-  spec.version      = "2.10.3"
+  spec.version      = "2.10.4"
   spec.summary      = "Coralogix OpenTelemetry pod for iOS."
 
   spec.description  = <<-DESC
@@ -29,7 +29,7 @@ Pod::Spec.new do |spec|
 
   spec.static_framework = true
   spec.dependency 'PLCrashReporter', '~> 1.12'
-  spec.dependency 'CoralogixInternal', '2.10.3'
+  spec.dependency 'CoralogixInternal', '2.10.4'
 
   spec.test_spec 'Tests' do |test|
     test.source_files = 'Tests/CoralogixRumTests/**/*.swift'

--- a/Coralogix/Sources/CoralogixRum.swift
+++ b/Coralogix/Sources/CoralogixRum.swift
@@ -556,6 +556,18 @@ public class CoralogixRum {
     internal func addRumCorrelationMetadata(to span: inout any Span) {
         addSessionAndPrevSessionMetadata(to: &span)
         addUserMetadata(to: &span)
+        addViewMetadata(to: &span)
+    }
+
+    /// Freezes the active view onto the span at creation so export attributes it to the screen
+    /// it happened on, not the live view up to 2s later. Name is always stamped (empty when no
+    /// view) so its presence marks an SDK span; absent → CxRumBuilder reads the live ViewManager.
+    internal func addViewMetadata(to span: inout any Span) {
+        guard let viewManager = self.coralogixExporter?.getViewManager() else { return }
+        span.setAttribute(key: Keys.spanViewName.rawValue, value: viewManager.currentViewName ?? Keys.undefined.rawValue)
+        if let viewNumber = viewManager.getViewNumber() {
+            span.setAttribute(key: Keys.spanViewNumber.rawValue, value: AttributeValue.int(viewNumber))
+        }
     }
 
     private func addSessionAndPrevSessionMetadata(to span: inout any Span) {

--- a/Coralogix/Sources/Instrumentation/CrashInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/CrashInstrumentation.swift
@@ -53,6 +53,7 @@ extension CoralogixRum {
             let crashTimestamp = report.systemInfo.timestamp
             let span = makeSpan(event: .error, source: .console, severity: .error, startTime: crashTimestamp)
             self.overrideSessionForCrashedSession(on: span)
+            self.overrideViewForCrashedSession(on: span)
 
             span.setAttribute(key: Keys.exceptionType.rawValue, value: report.signalInfo.name)
             if let crashTimestamp {
@@ -99,6 +100,18 @@ extension CoralogixRum {
         for attr in sessionManager.lastLaunchSessionSpanAttributes() {
             span.setAttribute(key: attr.key, value: attr.value)
         }
+    }
+
+    /// Replaces the view `makeSpan` froze onto the crash span — the relaunch process's
+    /// live view, which is empty this early in init — with the view that was on-screen
+    /// when the crash happened, recovered from the keychain into `ViewManager.prevViewName`.
+    /// No-op when the crashed session never showed a view, so the span keeps the empty
+    /// frozen view rather than inventing one.
+    /// Internal (rather than private) so unit tests can exercise it directly.
+    internal func overrideViewForCrashedSession(on span: any Span) {
+        guard let prevView = self.coralogixExporter?.getViewManager().getPrevDictionary()[Keys.view.rawValue] as? String,
+              !prevView.isEmpty else { return }
+        span.setAttribute(key: Keys.spanViewName.rawValue, value: prevView)
     }
     
     private func createStackTrace(report: PLCrashReport, span: any Span) {

--- a/Coralogix/Sources/Instrumentation/NavigationInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/NavigationInstrumentation.swift
@@ -24,14 +24,18 @@ extension CoralogixRum {
         if cxView.state == .notifyOnAppear,
            let viewManager = coralogixExporter?.getViewManager() {
             if viewManager.isUniqueView(name: cxView.name) {
-                // Only send mobile vitals if instrumentation is enabled
+                // Flush vitals first (freezes ORIGIN, synchronously), then advance so the
+                // navigation span freezes the DESTINATION.
                 if options?.shouldInitInstrumentation(instrumentation: .mobileVitals) == true {
                     metricsManager.flushAll()
                 }
-                
+
+                coralogixExporter?.set(cxView: cxView)
+
                 var span = makeSpan(event: .navigation, source: .console, severity: .info)
                 handleAppearStateIfNeeded(cxView: cxView, span: &span)
                 span.end()
+                return
             }
         }
         coralogixExporter?.set(cxView: cxView)

--- a/Coralogix/Sources/Instrumentation/NetworkInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/NetworkInstrumentation.swift
@@ -178,12 +178,20 @@ extension CoralogixRum {
         // (CX-37986). `sessionSpanAttributes()` routes through `getSessionMetadata()`
         // so the 1-hour rotation check fires at span-emission time and the prev-session
         // breadcrumbs land here too, matching CoralogixRum.addSessionAndPrevSessionMetadata.
-        guard let sessionManager = getCurrentInstance()?.sessionManager else {
+        guard let instance = getCurrentInstance(), let sessionManager = instance.sessionManager else {
             Log.w("[Coralogix] ⚠️ Network span missing session attributes — CoralogixRum instance or sessionManager is nil. Span will still be exported without session_id.")
             return
         }
         for attr in sessionManager.sessionSpanAttributes() {
             spanBuilder.setAttribute(key: attr.key, value: attr.value)
+        }
+
+        // Freeze the view at request-start (the screen that launched it). See addViewMetadata.
+        if let viewManager = instance.coralogixExporter?.getViewManager() {
+            spanBuilder.setAttribute(key: Keys.spanViewName.rawValue, value: viewManager.currentViewName ?? Keys.undefined.rawValue)
+            if let viewNumber = viewManager.getViewNumber() {
+                spanBuilder.setAttribute(key: Keys.spanViewNumber.rawValue, value: AttributeValue.int(viewNumber))
+            }
         }
     }
     

--- a/Coralogix/Sources/Model/CxRum.swift
+++ b/Coralogix/Sources/Model/CxRum.swift
@@ -36,4 +36,6 @@ struct CxRum {
     // view appears (early-launch spans omit it).
     let isNavigationEvent: Bool
     let viewNumber: Int?
+    // View frozen at span creation; nil → CxRumPayloadBuilder falls back to the live ViewManager.
+    let viewName: String?
 }

--- a/Coralogix/Sources/Model/CxRumBuilder.swift
+++ b/Coralogix/Sources/Model/CxRumBuilder.swift
@@ -66,7 +66,14 @@ class CxRumBuilder {
         if sessionContext.sessionCreationDate > timeStamp {
             timeStamp = sessionContext.sessionCreationDate
         }
-        
+
+        // Frozen view wins (native AND hybrid go through makeSpan → addViewMetadata); only
+        // non-SDK spans lack it and fall back to the live ViewManager. view_number is frozen
+        // alongside the name, so a present name means the frozen number is authoritative.
+        let frozenViewName = otel.getAttribute(forKey: Keys.spanViewName.rawValue) as? String
+        let frozenViewNumber = Self.frozenViewNumber(from: otel)
+        let resolvedViewNumber = frozenViewName == nil ? viewManager.getViewNumber() : frozenViewNumber
+
         return CxRum(timeStamp: timeStamp,
                      networkRequestContext: NetworkRequestContext(otel: otel),
                      versionMetadata: versionMetadata,
@@ -92,8 +99,17 @@ class CxRumBuilder {
                      fingerPrint: FingerprintManager(using: KeychainManager()).fingerprint,
                      // CX-44687: pure function of current event type — no cross-event state.
                      isNavigationEvent: eventContext.type == .navigation,
-                     viewNumber: viewManager.getViewNumber()
+                     viewNumber: resolvedViewNumber,
+                     viewName: frozenViewName
         )
+    }
+
+    /// `getAttribute` returns the `AttributeValue` String description; accept Int too for mocks.
+    private static func frozenViewNumber(from otel: SpanDataProtocol) -> Int? {
+        guard let raw = otel.getAttribute(forKey: Keys.spanViewNumber.rawValue) else { return nil }
+        if let intValue = raw as? Int { return intValue }
+        if let stringValue = raw as? String { return Int(stringValue) }
+        return nil
     }
     
     private func updateSessionCounters(for eventContext: EventContext) {

--- a/Coralogix/Sources/Model/CxRumPayloadBuilder.swift
+++ b/Coralogix/Sources/Model/CxRumPayloadBuilder.swift
@@ -58,13 +58,19 @@ struct CxRumPayloadBuilder {
     }
     
     private func addViewManagerContext(to result: inout [String: Any]) {
-        if let viewManager = self.viewManager {
-            if let sessionContext = rum.sessionContext,
-               sessionContext.isPidEqualToOldPid == true {
-                result[Keys.viewContext.rawValue] = viewManager.getPrevDictionary()
-            } else {
-                result[Keys.viewContext.rawValue] = viewManager.getDictionary()
-            }
+        // Frozen view wins; only non-SDK spans (no frozen view) fall back to the live ViewManager.
+        // Native and hybrid (RN/Flutter setView-fed) events both carry a frozen view.
+        if let viewName = rum.viewName {
+            result[Keys.viewContext.rawValue] = [Keys.view.rawValue: viewName]
+            return
+        }
+
+        guard let viewManager = self.viewManager else { return }
+        if let sessionContext = rum.sessionContext,
+           sessionContext.isPidEqualToOldPid == true {
+            result[Keys.viewContext.rawValue] = viewManager.getPrevDictionary()
+        } else {
+            result[Keys.viewContext.rawValue] = viewManager.getDictionary()
         }
     }
     

--- a/Coralogix/Sources/Model/InstrumentationData.swift
+++ b/Coralogix/Sources/Model/InstrumentationData.swift
@@ -195,7 +195,10 @@ struct OtelSpan {
             if let p = net[Keys.responsePayload.rawValue] { attrs[AttrKey.networkResponsePayload] = p }
         }
 
-        if let pageUrl = viewManager?.getDictionary()[Keys.view.rawValue] as? String, !pageUrl.isEmpty {
+        // Page from the frozen view_context so it agrees with text.cx_rum; else live ViewManager.
+        let pageUrl = (cxRumDict[Keys.viewContext.rawValue] as? [String: Any])?[Keys.view.rawValue] as? String
+            ?? viewManager?.getDictionary()[Keys.view.rawValue] as? String
+        if let pageUrl = pageUrl, !pageUrl.isEmpty {
             attrs[AttrKey.pageUrl]       = pageUrl
             attrs[AttrKey.pageFragments] = pageUrl
         }
@@ -302,10 +305,9 @@ struct OtelSpan {
             }
         }
 
-        // Page context — iOS uses the visible view-controller name as the page URL.
-        // Guard against empty string returned when no view is active.
-        if let pageUrl = viewManager?.getDictionary()[Keys.view.rawValue] as? String,
-           !pageUrl.isEmpty {
+        // Page from the frozen view (cxRum.viewName); else live ViewManager. Empty = no view.
+        let pageUrl = cxRum.viewName ?? (viewManager?.getDictionary()[Keys.view.rawValue] as? String)
+        if let pageUrl = pageUrl, !pageUrl.isEmpty {
             attrs[AttrKey.pageUrl]       = pageUrl
             attrs[AttrKey.pageFragments] = pageUrl
         }

--- a/Coralogix/Sources/Utils/ViewManager.swift
+++ b/Coralogix/Sources/Utils/ViewManager.swift
@@ -109,6 +109,14 @@ public class ViewManager {
         return syncSafe { self.viewNumber }
     }
 
+    /// Active view name, or nil when none — unlike `getDictionary()`'s `""` sentinel.
+    var currentViewName: String? {
+        return syncSafe {
+            guard let name = self.visibleView?.name, !name.isEmpty else { return nil }
+            return name
+        }
+    }
+
     // CX-44687: nil → delete the keychain entry, non-nil → write the value. Avoids
     // the empty-string-as-nil sentinel that would (a) collide with a future presence-
     // check caller and (b) leave stale data if the protocol impl ever no-ops on

--- a/CoralogixInternal.podspec
+++ b/CoralogixInternal.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "CoralogixInternal"
-  spec.version      = "2.10.3"
+  spec.version      = "2.10.4"
   spec.summary      = "Coralogix Internal Package. This module is not for public use."
 
   spec.description  = <<-DESC

--- a/CoralogixInternal/Sources/Keys.swift
+++ b/CoralogixInternal/Sources/Keys.swift
@@ -143,6 +143,9 @@ public enum Keys: String {
     // rawValue is "view_number". Confusing them at a callsite would silently
     // store the counter under the wrong slot and break the restore path.
     case storedViewNumber = "viewNumber"
+    // Span-attr slots (not wire keys): view frozen at creation, read back at export.
+    case spanViewName = "cx.span.view_name"
+    case spanViewNumber = "cx.span.view_number"
     case threads
     case httpResponseBodySize = "http_response_body_size"
     case stackTrace

--- a/CoralogixInternal/Sources/Utils.swift
+++ b/CoralogixInternal/Sources/Utils.swift
@@ -16,7 +16,7 @@ public enum ImageFormat {
 }
 
 public enum Global: String {
-    case sdk = "2.10.3"
+    case sdk = "2.10.4"
     case swiftVersion = "5.9"
     case coralogixPath = "/browser/v1beta/logs"
     case sessionReplayPath = "/browser/alpha/sessionrecording"

--- a/SessionReplay.podspec
+++ b/SessionReplay.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "SessionReplay"
-  spec.version      = "2.10.3"
+  spec.version      = "2.10.4"
   spec.summary      = "Coralogix Session-Replay pod for iOS."
 
   spec.description  = <<-DESC
@@ -23,7 +23,7 @@ Pod::Spec.new do |spec|
   spec.static_framework = true
 
   spec.source_files  = 'SessionReplay/Sources/**/*.swift'
-  spec.dependency 'CoralogixInternal', '2.10.3'
+  spec.dependency 'CoralogixInternal', '2.10.4'
   
     spec.test_spec 'Tests' do |test|
         test.source_files = 'Tests/SessionReplayTests/**/*.swift'

--- a/Tests/CoralogixRumTests/BeforeSendInstrumentationDataTests.swift
+++ b/Tests/CoralogixRumTests/BeforeSendInstrumentationDataTests.swift
@@ -724,4 +724,42 @@ final class BeforeSendInstrumentationDataTests: XCTestCase {
         XCTAssertEqual(attrs["cx_rum.view_number"] as? Int, textViewNumber,
                        "view_number must mirror cx_rum → otelSpan.attributes when present, and be absent on both sides when not")
     }
+
+    // MARK: - Hybrid (RN/Flutter): frozen setView screen survives to both destinations
+
+    // Hybrid events reach the SDK through makeSpan (log/reportError/reportMobileVitals/
+    // reportHybridNetworkRequest), which freezes the current view — the JS/Dart screen the
+    // host set via setView(). This pins that a network event which fired on "JSScreenA"
+    // exports view_context = "JSScreenA" and its instrumentation_data page agrees, even after
+    // the JS side navigates on (live ViewManager = "JSScreenB") before the batch exports.
+    func test_hybrid_frozenSetViewScreen_winsOverLiveViewManager_inBothDestinations() throws {
+        // Span carries the view frozen at event time (what addViewMetadata stamped).
+        mockSpanData = MockSpanData(
+            attributes: [
+                Keys.severity.rawValue: AttributeValue("3"),
+                Keys.eventType.rawValue: AttributeValue(CoralogixEventType.networkRequest.rawValue),
+                Keys.source.rawValue: AttributeValue("fetch"),
+                Keys.sessionId.rawValue: AttributeValue("session_001"),
+                Keys.sessionCreationDate.rawValue: AttributeValue(1609459200),
+                SemanticAttributes.httpUrl.rawValue: AttributeValue("https://example.com/orig"),
+                SemanticAttributes.httpMethod.rawValue: AttributeValue("GET"),
+                Keys.spanViewName.rawValue: AttributeValue("JSScreenA"),
+                Keys.spanViewNumber.rawValue: AttributeValue.int(2)
+            ],
+            startTime: Date(), endTime: Date(), spanId: "20", traceId: "30",
+            name: "testSpan", kind: 2, statusCode: ["status": "ok"], resources: [:]
+        )
+        // The JS side has since navigated on — live ViewManager holds a later screen.
+        mockViewManager.set(cxView: CXView(state: .notifyOnAppear, name: "JSScreenB"))
+
+        let result = try runSpan { $0 }
+
+        let viewContext = try XCTUnwrap(result.text[Keys.viewContext.rawValue] as? [String: Any])
+        XCTAssertEqual(viewContext[Keys.view.rawValue] as? String, "JSScreenA",
+                       "hybrid event must report the setView screen frozen at event time, not the live view at export")
+        XCTAssertEqual(result.text[Keys.viewNumber.rawValue] as? Int, 2,
+                       "hybrid view_number must be the frozen value, not the live count")
+        XCTAssertEqual(result.otel["cx_rum.page_context.page_url"] as? String, "JSScreenA",
+                       "instrumentation_data page must agree with the frozen view_context")
+    }
 }

--- a/Tests/CoralogixRumTests/CrashInstrumentationTests.swift
+++ b/Tests/CoralogixRumTests/CrashInstrumentationTests.swift
@@ -1,0 +1,73 @@
+//
+//  CrashInstrumentationTests.swift
+//
+//
+//  Created by Coralogix DEV TEAM on 16/07/2026.
+//
+
+import XCTest
+import CoralogixInternal
+@testable import Coralogix
+
+final class CrashInstrumentationTests: XCTestCase {
+    private var options: CoralogixExporterOptions!
+
+    override func setUpWithError() throws {
+        options = CoralogixExporterOptions(
+            coralogixDomain: CoralogixDomain.US2,
+            userContext: nil,
+            environment: "PROD",
+            application: "TestApp-Crash",
+            version: "1.0",
+            publicKey: "token",
+            sessionSampleRate: 100,
+            debug: true
+        )
+    }
+
+    override func tearDownWithError() throws {
+        CoralogixRum.isInitialized = false
+        options = nil
+        RunLoop.main.run(until: Date().addingTimeInterval(0.05))
+    }
+
+    // A crash is recorded on the *next* launch, where the live view is empty this early in
+    // init — so makeSpan freezes the empty sentinel onto the crash span. The span must be
+    // corrected to the screen the app was on when it crashed (recovered from the keychain
+    // into prevViewName), otherwise the crash reports an empty view_context.
+    func test_overrideViewForCrashedSession_stampsCrashTimeView_overBlankRelaunchView() throws {
+        let rum = CoralogixRum(options: options)
+        let viewManager = try XCTUnwrap(rum.coralogixExporter?.getViewManager())
+
+        let span = rum.makeSpan(event: .error, source: .console, severity: .error)
+        XCTAssertEqual(frozenViewName(of: span), Keys.undefined.rawValue,
+                       "precondition: a relaunch crash span starts with the empty frozen view")
+
+        // The crashed session's last screen, recovered from the keychain at ViewManager init.
+        viewManager.prevViewName = "CheckoutBeforeCrash"
+
+        rum.overrideViewForCrashedSession(on: span)
+
+        XCTAssertEqual(frozenViewName(of: span), "CheckoutBeforeCrash",
+                       "crash span must report the crash-time view, not the blank relaunch view")
+    }
+
+    // No screen was ever shown in the crashed session (crash before first appear): there is
+    // nothing to recover, so the empty frozen view is left untouched rather than invented.
+    func test_overrideViewForCrashedSession_noPrevView_keepsEmptyFrozenView() throws {
+        let rum = CoralogixRum(options: options)
+        let viewManager = try XCTUnwrap(rum.coralogixExporter?.getViewManager())
+        viewManager.prevViewName = nil
+
+        let span = rum.makeSpan(event: .error, source: .console, severity: .error)
+        rum.overrideViewForCrashedSession(on: span)
+
+        XCTAssertEqual(frozenViewName(of: span), Keys.undefined.rawValue,
+                       "with no crash-time view on record, the empty frozen view is left untouched")
+    }
+
+    private func frozenViewName(of span: any Span) -> String? {
+        guard let data = (span as? any ReadableSpan)?.toSpanData() else { return nil }
+        return data.attributes[Keys.spanViewName.rawValue]?.description
+    }
+}

--- a/Tests/CoralogixRumTests/CxRumBuilderTests.swift
+++ b/Tests/CoralogixRumTests/CxRumBuilderTests.swift
@@ -402,6 +402,106 @@ class CxRumBuilderTests: XCTestCase {
                             options: options)
     }
 
+    // MARK: - View frozen at creation wins over the live ViewManager at export
+
+    func test_build_viewName_frozenAttributeWins_overLiveViewManager() {
+        // Live ViewManager has moved to a different screen since the event fired.
+        let live = MockViewManager(keyChain: MockKeyChain())
+        live.set(cxView: CXView(state: .notifyOnAppear, name: "HomeAfterNavigation"))
+
+        guard let cxRum = makeFrozenSUT(frozenViewName: "CheckoutAtEventTime", viewManager: live)?.build() else {
+            return XCTFail("build() returned nil")
+        }
+        XCTAssertEqual(cxRum.viewName, "CheckoutAtEventTime")
+
+        var builder = CxRumPayloadBuilder(rum: cxRum, viewManager: live)
+        let payload = builder.build()
+        let vc = payload[Keys.viewContext.rawValue] as? [String: Any]
+        XCTAssertEqual(vc?[Keys.view.rawValue] as? String, "CheckoutAtEventTime",
+                       "view_context must reflect the screen frozen at event time, not the live view at export")
+    }
+
+    func test_build_viewNumber_frozenAttributeWins_andParsesFromStringDescription() {
+        let live = MockViewManager(keyChain: MockKeyChain())
+        live.set(cxView: CXView(state: .notifyOnAppear, name: "Home")) // live number would be 0
+
+        guard let cxRum = makeFrozenSUT(frozenViewName: "Checkout", frozenViewNumber: 7, viewManager: live)?.build() else {
+            return XCTFail("build() returned nil")
+        }
+        XCTAssertEqual(cxRum.viewNumber, 7,
+                       "frozen view_number must win and parse back from its AttributeValue String description")
+    }
+
+    func test_build_viewName_frozenEmptyString_staysEmptyEvenIfViewAppearsByExport() {
+        let live = MockViewManager(keyChain: MockKeyChain())
+        live.set(cxView: CXView(state: .notifyOnAppear, name: "AppearedByExportTime"))
+
+        // Event fired before any view appeared: the SDK freezes "" (Keys.undefined).
+        guard let cxRum = makeFrozenSUT(frozenViewName: "", viewManager: live)?.build() else {
+            return XCTFail("build() returned nil")
+        }
+        var builder = CxRumPayloadBuilder(rum: cxRum, viewManager: live)
+        let payload = builder.build()
+        let vc = payload[Keys.viewContext.rawValue] as? [String: Any]
+        XCTAssertEqual(vc?[Keys.view.rawValue] as? String, "",
+                       "a pre-first-view event stays empty and must not be back-filled from the live view at export")
+    }
+
+    func test_build_noFrozenView_fallsBackToLiveViewManager() {
+        let live = MockViewManager(keyChain: MockKeyChain())
+        live.set(cxView: CXView(state: .notifyOnAppear, name: "Home"))
+        live.set(cxView: CXView(state: .notifyOnAppear, name: "Settings")) // number 1
+
+        // No frozen attribute on the span (e.g. a hybrid-bridge span).
+        guard let cxRum = makeFrozenSUT(frozenViewName: nil, viewManager: live)?.build() else {
+            return XCTFail("build() returned nil")
+        }
+        XCTAssertNil(cxRum.viewName, "hybrid/external spans carry no frozen view")
+
+        var builder = CxRumPayloadBuilder(rum: cxRum, viewManager: live)
+        let payload = builder.build()
+        let vc = payload[Keys.viewContext.rawValue] as? [String: Any]
+        XCTAssertEqual(vc?[Keys.view.rawValue] as? String, "Settings",
+                       "with no frozen view, view_context falls back to the live ViewManager (pre-freeze parity)")
+        XCTAssertEqual(cxRum.viewNumber, 1, "view_number also falls back to the live ViewManager")
+    }
+
+    private func makeFrozenSUT(eventType: String = "log",
+                               frozenViewName: String?,
+                               frozenViewNumber: Int? = nil,
+                               viewManager: ViewManager) -> CxRumBuilder? {
+        var attrs: [String: Any] = [
+            Keys.severity.rawValue: AttributeValue("3"),
+            Keys.eventType.rawValue: AttributeValue(eventType),
+            Keys.source.rawValue: AttributeValue("console"),
+            Keys.environment.rawValue: AttributeValue("prod"),
+            Keys.sessionId.rawValue: AttributeValue("session_001"),
+            Keys.sessionCreationDate.rawValue: AttributeValue(1609459200)
+        ]
+        // Mirror production: view name is a string attribute, view number an int — both come
+        // back through getAttribute as their String description.
+        if let frozenViewName { attrs[Keys.spanViewName.rawValue] = AttributeValue(frozenViewName) }
+        if let frozenViewNumber { attrs[Keys.spanViewNumber.rawValue] = AttributeValue.int(frozenViewNumber) }
+
+        let otel = MockSpanData(attributes: attrs,
+                                startTime: Date(), endTime: Date(),
+                                spanId: "20", traceId: "30", name: "testSpan", kind: 1)
+
+        let options = CoralogixExporterOptions(coralogixDomain: CoralogixDomain.US2,
+                                               userContext: nil,
+                                               environment: "PROD",
+                                               application: "TestApp-iOS",
+                                               version: "1.0",
+                                               publicKey: "token",
+                                               debug: true)
+        return CxRumBuilder(otel: otel,
+                            versionMetadata: VersionMetadata(appName: "Test", appVersion: "1.0"),
+                            sessionManager: mockSessionManager,
+                            viewManager: viewManager,
+                            networkManager: NetworkManager(),
+                            options: options)
+    }
+
     // Convenience overload that lets the new tests vary event type without touching the
     // original makeSUT() / its existing callers (which pin a "log" event for snapshot tests).
     private func makeSUT(currentTime: Date, eventType: String) -> CxRumBuilder? {

--- a/Tests/CoralogixRumTests/InstrumentationDataTests.swift
+++ b/Tests/CoralogixRumTests/InstrumentationDataTests.swift
@@ -437,7 +437,8 @@ final class InstrumentationDataTests: XCTestCase {
         errorMessage: String = "",
         hasRecording: Bool = false,
         isNavigationEvent: Bool = false,
-        viewNumber: Int? = nil
+        viewNumber: Int? = nil,
+        viewName: String? = nil
     ) -> CxRum {
         let eventSpan = MockSpanData(attributes: [
             Keys.eventType.rawValue: AttributeValue(eventType.rawValue),
@@ -494,7 +495,8 @@ final class InstrumentationDataTests: XCTestCase {
             measurementContext: nil,
             fingerPrint: "test-fingerprint",
             isNavigationEvent: isNavigationEvent,
-            viewNumber: viewNumber
+            viewNumber: viewNumber,
+            viewName: viewName
         )
     }
 }

--- a/Tests/CoralogixRumTests/ViewManagerTests.swift
+++ b/Tests/CoralogixRumTests/ViewManagerTests.swift
@@ -54,9 +54,26 @@ final class ViewManagerTests: XCTestCase {
     func testGetDictionary() {
         let view = CXView(state: .notifyOnAppear, name: "View1")
         viewManager.set(cxView: view)
-        
+
         let dict = viewManager.getDictionary()
         XCTAssertEqual(dict[Keys.view.rawValue] as? String, "View1")
+    }
+
+    func testCurrentViewName_nilWhenNoViewActive() {
+        // Unlike getDictionary()'s "" sentinel, currentViewName distinguishes "no view" as nil
+        // so callers can omit the frozen attribute instead of stamping an empty string.
+        XCTAssertNil(viewManager.currentViewName)
+    }
+
+    func testCurrentViewName_returnsActiveViewName() {
+        viewManager.set(cxView: CXView(state: .notifyOnAppear, name: "Checkout"))
+        XCTAssertEqual(viewManager.currentViewName, "Checkout")
+    }
+
+    func testCurrentViewName_nilAfterViewDisappears() {
+        viewManager.set(cxView: CXView(state: .notifyOnAppear, name: "Checkout"))
+        viewManager.set(cxView: nil)
+        XCTAssertNil(viewManager.currentViewName)
     }
     
     func testGetPrevDictionary() {


### PR DESCRIPTION
# User description
## Problem

`view_context` / `view_number` were resolved at **export time** from the live `ViewManager` — up to 2s / 50 spans after the event actually fired. Events that cluster around screen transitions (taps that navigate, mobile vitals flushed on navigation, logs / errors / custom measurements) were frequently tagged with an **empty** view (`Keys.undefined = ""`) or the **wrong** (next) screen. Network requests looked mostly fine because they settle on a stable screen, which is why the empties were disproportionately on the other event types.

## Fix

Freeze the active view onto each span **when it is created**, and read it back at export:

- `CoralogixRum.addViewMetadata` stamps `cx.span.view_name` / `cx.span.view_number` via `addRumCorrelationMetadata` — covering all `makeSpan` events (log, error, user-interaction, mobile-vitals, custom-measurement, life-cycle, internal, screenshot) **and** custom spans.
- `NetworkInstrumentation.spanCustomizationStatic` freezes the view at request-start (the screen that launched the request).
- `CxRumBuilder` reads the frozen attribute; `CxRumPayloadBuilder` and `InstrumentationData` use it, falling back to the live `ViewManager` only for non-SDK spans.
- `trackNavigation` reordered so vitals freeze the **origin** view while the navigation span freezes the **destination**.
- The name is always stamped (empty string when no view), so its *presence* marks an SDK span; pre-first-view events stay correctly empty rather than being back-filled from a later screen.

## Hybrid (React Native / Flutter)

Fully covered and improved. The host feeds the JS/Dart screen through `setView()` → `trackNavigation` → native `ViewManager`, and every hybrid event is created through `makeSpan` (`reportHybridNetworkRequest → getSpan() → makeSpan`, `log`, `reportError`, `reportMobileVitalsMeasurement`). So hybrid events freeze the correct screen at event time too.

## Testing

- New: frozen-wins-over-live (core regression), empty-stays-empty, non-SDK fallback (`CxRumBuilderTests`); `currentViewName` (`ViewManagerTests`); hybrid `setView` screen survives to both `view_context` and `instrumentation_data` page (`BeforeSendInstrumentationDataTests`).
- All three test targets green (754 `CoralogixRumTests` + `CoralogixInternalTests` + `SessionReplayTests`).

## Version

Bumped 2.10.3 → **2.10.4** (patch — bug fix, no API change) across the three podspecs + `Global.sdk`; CHANGELOG entry added.

## Note

No Jira ticket is linked (branch created without one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Freeze the active view onto spans at creation so <code>CoralogixRum</code>, <code>NetworkInstrumentation</code>, and <code>ViewManager</code> attribute <code>view_context</code> and page metadata to the screen that was actually on-screen when the event occurred. Update <code>CxRumBuilder</code>, <code>CxRumPayloadBuilder</code>, and <code>InstrumentationData</code> to prefer the frozen view and only fall back to the live manager for non-SDK spans, while navigation ordering keeps origin and destination view attribution correct.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tomer.haryoffi@coralog...</td><td>fix: freeze active vie...</td><td>July 16, 2026</td></tr>
<tr><td>dan.gavrielov@coralogi...</td><td>fix(session-replay): m...</td><td>June 15, 2026</td></tr></table></details>
<sub><a href="https://baz.co/changes/coralogix/cx-ios-sdk/237?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>