### PR TITLE
fix(CX-45948): mask navigation-bar title during transitions to stop Session Replay leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Release-mechanics commits (version bumps, podspec/script tweaks, README edits) a
 omitted; the focus here is user-facing behavior changes. Tickets are referenced as
 `CX-XXXXX` (Jira) or `ALPH-XXXX` (legacy). Pull request numbers are in parentheses.
 
+## [2.11.2] - 2026-07-22
+
+### Fixed
+- Session Replay no longer leaks the navigation-bar title during screen transitions on iOS 18.5. UIKit composites the title cross-fade with a snapshot layer that the view-based masking couldn't see; the bar is now masked by geometry whenever its title matches a `maskText` pattern. Also closes a rare one-frame sliver where view-controller content was still settling after a push/pop.
+
 ## [2.11.1] - 2026-07-20
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ omitted; the focus here is user-facing behavior changes. Tickets are referenced 
 ## [2.11.2] - 2026-07-22
 
 ### Fixed
-- Session Replay no longer leaks the navigation-bar title during screen transitions on iOS 18.5. UIKit composites the title cross-fade with a snapshot layer that the view-based masking couldn't see; the bar is now masked by geometry whenever its title matches a `maskText` pattern. Also closes a rare one-frame sliver where view-controller content was still settling after a push/pop.
+- Session Replay no longer leaks navigation-bar titles that should be masked, or a thin edge of screen content, during screen transitions on iOS 18.5.
 
 ## [2.11.1] - 2026-07-20
 

--- a/Coralogix.podspec
+++ b/Coralogix.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "Coralogix"
-  spec.version      = "2.11.1"
+  spec.version      = "2.11.2"
   spec.summary      = "Coralogix OpenTelemetry pod for iOS."
 
   spec.description  = <<-DESC
@@ -29,7 +29,7 @@ Pod::Spec.new do |spec|
 
   spec.static_framework = true
   spec.dependency 'PLCrashReporter', '~> 1.12'
-  spec.dependency 'CoralogixInternal', '2.11.1'
+  spec.dependency 'CoralogixInternal', '2.11.2'
 
   spec.test_spec 'Tests' do |test|
     test.source_files = 'Tests/CoralogixRumTests/**/*.swift'

--- a/CoralogixInternal.podspec
+++ b/CoralogixInternal.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "CoralogixInternal"
-  spec.version      = "2.11.1"
+  spec.version      = "2.11.2"
   spec.summary      = "Coralogix Internal Package. This module is not for public use."
 
   spec.description  = <<-DESC

--- a/CoralogixInternal/Sources/Extention/UIViewExt.swift
+++ b/CoralogixInternal/Sources/Extention/UIViewExt.swift
@@ -94,9 +94,8 @@ public extension UIView {
         return rect.intersection(rootView.bounds)
     }
 
-    /// True when `text` matches any entry in `patterns`. Each entry is treated as a
-    /// case-insensitive regular expression, falling back to a case-insensitive substring
-    /// match when the entry is not valid regex.
+    /// Matches `text` against `patterns` as case-insensitive regex, falling back to a
+    /// case-insensitive substring check for entries that aren't valid regex.
     internal static func textMatchesAny(_ text: String, _ patterns: [String]) -> Bool {
         patterns.contains { pattern in
             guard let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive) else {
@@ -138,16 +137,11 @@ public extension UIView {
         return rects
     }
 
-    /// Collects a mask rect for any visible `UINavigationBar` whose title text matches
-    /// `maskText`.
+    /// Masks a `UINavigationBar` by its (stable) geometry when its title matches `maskText`.
     ///
-    /// During a push/pop UIKit renders the navigation-bar title with a snapshot *layer* that
-    /// has no backing `UIView`, so the text-view walk above can't redact it and the title
-    /// leaks for the frames the transition guard misses (iOS 18.5; iOS 26 composites the
-    /// title in place, so it never leaks there). The bar's own frame is stable through the
-    /// transition, and the title string is readable from `UINavigationItem` regardless of how
-    /// it is being composited, so mask the whole bar by geometry when its title matches.
-    /// Scoped to bars whose title actually matches `maskText`, so unrelated bars are untouched.
+    /// During a push/pop UIKit draws the title with a snapshot layer that has no backing
+    /// `UIView`, so the text-view walk can't redact it and the title leaks (iOS 18.5). The
+    /// title string stays readable from `UINavigationItem`, so mask by geometry instead.
     internal func collectNavigationBarTitleRects(in rootView: UIView, maskText: [String]?) -> [CGRect] {
         guard let maskText = maskText, !maskText.isEmpty else { return [] }
         var rects: [CGRect] = []
@@ -193,18 +187,11 @@ public extension UIView {
 
     // MARK: - Screenshot capture
 
-    /// Returns true when a screenshot taken right now would mask at the wrong place because
-    /// view-controller content in the active scene is mid-transition.
-    ///
-    /// Two complementary signals — a frame is unsafe if either fires:
-    /// - `transitionCoordinator != nil` catches a transition's leading edge, where the
-    ///   coordinator is set before the compositor has moved anything.
-    /// - Composited-vs-model displacement of a view-controller's view catches the trailing
-    ///   edge: the coordinator clears a frame or two before the slide finishes settling, and
-    ///   the mask-rect walk lands off the still-moving content, leaking a sliver.
-    ///
-    /// (The navigation-bar *title* leak is handled separately, by masking the bar's geometry
-    /// in `collectNavigationBarTitleRects` — its snapshot layer can't be caught here.)
+    /// True while view-controller content is mid-transition, when the mask-rect walk would
+    /// land off the moving content. `transitionCoordinator` catches the leading edge;
+    /// composited-vs-model displacement catches the trailing edge, where the coordinator
+    /// clears a frame or two before the slide settles. (The nav-bar title leak is handled
+    /// separately in `collectNavigationBarTitleRects`.)
     static func isNavigationTransitionActive() -> Bool {
         guard let scene = UIApplication.shared.connectedScenes
             .compactMap({ $0 as? UIWindowScene })
@@ -222,10 +209,9 @@ public extension UIView {
         return false
     }
 
-    /// True when a loaded view controller's view is composited away from its model position
-    /// in `window` — i.e. mid-slide. Walks only view-controller views (one layer per VC),
-    /// so ordinary in-content animations don't trip it. `viewIfLoaded` avoids forcing
-    /// `loadView` during capture.
+    /// True when a loaded VC's view is composited away from its model position (mid-slide).
+    /// Checks only VC views, so ordinary in-content animations don't trip it; `viewIfLoaded`
+    /// avoids forcing `loadView` during capture.
     private static func vcContentIsDisplaced(_ vc: UIViewController, in window: UIWindow) -> Bool {
         if let view = vc.viewIfLoaded, view.window === window, Self.isDisplaced(view, in: window) {
             return true
@@ -237,9 +223,8 @@ public extension UIView {
         return false
     }
 
-    /// True when `view`'s composited (presentation) origin diverges from its model origin in
-    /// `root` coordinates. Must run on the main thread outside a render pass, where
-    /// `presentation()` reflects the in-flight animated values.
+    /// True when `view`'s presentation-layer origin diverges from its model origin in `root`.
+    /// Call on the main thread outside a render pass, where `presentation()` is in-flight.
     private static func isDisplaced(_ view: UIView, in root: UIView, epsilon: CGFloat = 0.5) -> Bool {
         var point = CGPoint.zero
         var cur: UIView = view

--- a/CoralogixInternal/Sources/Extention/UIViewExt.swift
+++ b/CoralogixInternal/Sources/Extention/UIViewExt.swift
@@ -94,6 +94,18 @@ public extension UIView {
         return rect.intersection(rootView.bounds)
     }
 
+    /// True when `text` matches any entry in `patterns`. Each entry is treated as a
+    /// case-insensitive regular expression, falling back to a case-insensitive substring
+    /// match when the entry is not valid regex.
+    internal static func textMatchesAny(_ text: String, _ patterns: [String]) -> Bool {
+        patterns.contains { pattern in
+            guard let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive) else {
+                return text.localizedCaseInsensitiveContains(pattern)
+            }
+            return regex.firstMatch(in: text, range: NSRange(text.startIndex..., in: text)) != nil
+        }
+    }
+
     /// Collects rects for text-bearing views (UILabel, UITextField, UITextView) in `rootView`'s
     /// coordinate space. Short-circuits at FlutterView subtrees — those arrive pre-masked
     /// via the Dart bitmap provider.
@@ -106,23 +118,12 @@ public extension UIView {
             if let cls = _flutterViewClass, view.isKind(of: cls) { return }
 
             var shouldMask = false
-            let matchesAnyPattern: (String) -> Bool = { text in
-                maskText.contains { pattern in
-                    // Each entry may be a plain literal string or a regular expression.
-                    // Regex is matched case-insensitively; fall back to a case-insensitive
-                    // substring check when the pattern is not valid regex.
-                    guard let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive) else {
-                        return text.localizedCaseInsensitiveContains(pattern)
-                    }
-                    return regex.firstMatch(in: text, range: NSRange(text.startIndex..., in: text)) != nil
-                }
-            }
             if let label = view as? UILabel, let text = label.text {
-                shouldMask = matchesAnyPattern(text)
+                shouldMask = UIView.textMatchesAny(text, maskText)
             } else if let field = view as? UITextField, let text = field.text {
-                shouldMask = matchesAnyPattern(text)
+                shouldMask = UIView.textMatchesAny(text, maskText)
             } else if let tv = view as? UITextView, let text = tv.text {
-                shouldMask = matchesAnyPattern(text)
+                shouldMask = UIView.textMatchesAny(text, maskText)
             }
 
             if shouldMask {
@@ -130,6 +131,38 @@ public extension UIView {
                 if !rect.isNull && !rect.isEmpty { rects.append(rect) }
             }
 
+            for sub in view.subviews { traverse(sub) }
+        }
+
+        traverse(rootView)
+        return rects
+    }
+
+    /// Collects a mask rect for any visible `UINavigationBar` whose title text matches
+    /// `maskText`.
+    ///
+    /// During a push/pop UIKit renders the navigation-bar title with a snapshot *layer* that
+    /// has no backing `UIView`, so the text-view walk above can't redact it and the title
+    /// leaks for the frames the transition guard misses (iOS 18.5; iOS 26 composites the
+    /// title in place, so it never leaks there). The bar's own frame is stable through the
+    /// transition, and the title string is readable from `UINavigationItem` regardless of how
+    /// it is being composited, so mask the whole bar by geometry when its title matches.
+    /// Scoped to bars whose title actually matches `maskText`, so unrelated bars are untouched.
+    internal func collectNavigationBarTitleRects(in rootView: UIView, maskText: [String]?) -> [CGRect] {
+        guard let maskText = maskText, !maskText.isEmpty else { return [] }
+        var rects: [CGRect] = []
+
+        func traverse(_ view: UIView) {
+            guard !view.isHidden, view.alpha > 0 else { return }
+            if let bar = view as? UINavigationBar {
+                let titles = ([bar.topItem?.title, bar.topItem?.prompt, bar.backItem?.title]
+                    .compactMap { $0 }) + (bar.items ?? []).compactMap { $0.title }
+                if titles.contains(where: { UIView.textMatchesAny($0, maskText) }) {
+                    let rect = bar.convert(bar.bounds, to: rootView).intersection(rootView.bounds)
+                    if !rect.isNull && !rect.isEmpty { rects.append(rect) }
+                }
+                return
+            }
             for sub in view.subviews { traverse(sub) }
         }
 
@@ -160,21 +193,25 @@ public extension UIView {
 
     // MARK: - Screenshot capture
 
-    /// Returns true when a UIKit-managed transition (push, pop, modal) is in progress
-    /// for any view controller in the active scene.
+    /// Returns true when a screenshot taken right now would mask at the wrong place because
+    /// view-controller content in the active scene is mid-transition.
     ///
-    /// `UIViewController.transitionCoordinator` is non-nil exactly while UIKit is running
-    /// a transition animation and nil at rest. Inside `UIGraphicsImageRenderer`,
-    /// `layer.presentation()` always returns nil, so mask-rect walks use model-layer
-    /// positions which diverge from the composited frame during animations. Skipping the
-    /// capture and waiting for the next timer tick avoids that mismatch entirely.
+    /// Two complementary signals — a frame is unsafe if either fires:
+    /// - `transitionCoordinator != nil` catches a transition's leading edge, where the
+    ///   coordinator is set before the compositor has moved anything.
+    /// - Composited-vs-model displacement of a view-controller's view catches the trailing
+    ///   edge: the coordinator clears a frame or two before the slide finishes settling, and
+    ///   the mask-rect walk lands off the still-moving content, leaking a sliver.
+    ///
+    /// (The navigation-bar *title* leak is handled separately, by masking the bar's geometry
+    /// in `collectNavigationBarTitleRects` — its snapshot layer can't be caught here.)
     static func isNavigationTransitionActive() -> Bool {
         guard let scene = UIApplication.shared.connectedScenes
             .compactMap({ $0 as? UIWindowScene })
             .first(where: { $0.activationState == .foregroundActive }) else { return false }
         return scene.windows.contains { win in
             guard let root = win.rootViewController else { return false }
-            return Self.vcHasActiveTransition(root)
+            return Self.vcHasActiveTransition(root) || Self.vcContentIsDisplaced(root, in: win)
         }
     }
 
@@ -183,6 +220,38 @@ public extension UIView {
         for child in vc.children where vcHasActiveTransition(child) { return true }
         if let presented = vc.presentedViewController, vcHasActiveTransition(presented) { return true }
         return false
+    }
+
+    /// True when a loaded view controller's view is composited away from its model position
+    /// in `window` — i.e. mid-slide. Walks only view-controller views (one layer per VC),
+    /// so ordinary in-content animations don't trip it. `viewIfLoaded` avoids forcing
+    /// `loadView` during capture.
+    private static func vcContentIsDisplaced(_ vc: UIViewController, in window: UIWindow) -> Bool {
+        if let view = vc.viewIfLoaded, view.window === window, Self.isDisplaced(view, in: window) {
+            return true
+        }
+        for child in vc.children where vcContentIsDisplaced(child, in: window) { return true }
+        if let presented = vc.presentedViewController, vcContentIsDisplaced(presented, in: window) {
+            return true
+        }
+        return false
+    }
+
+    /// True when `view`'s composited (presentation) origin diverges from its model origin in
+    /// `root` coordinates. Must run on the main thread outside a render pass, where
+    /// `presentation()` reflects the in-flight animated values.
+    private static func isDisplaced(_ view: UIView, in root: UIView, epsilon: CGFloat = 0.5) -> Bool {
+        var point = CGPoint.zero
+        var cur: UIView = view
+        while cur !== root {
+            guard let parent = cur.superview else { break }
+            let from = cur.layer.presentation() ?? cur.layer
+            let to = parent.layer.presentation() ?? parent.layer
+            point = from.convert(point, to: to)
+            cur = parent
+        }
+        let model = view.convert(CGPoint.zero, to: root)
+        return abs(point.x - model.x) > epsilon || abs(point.y - model.y) > epsilon
     }
 
     /// Renders a composite screenshot of all visible windows with masking applied.
@@ -262,6 +331,8 @@ public extension UIView {
 
                     if let maskText = maskText, !maskText.isEmpty {
                         nativeMaskRects += collectTextViewRects(in: win, maskText: maskText)
+                            .map { $0.offsetBy(dx: origin.x, dy: origin.y) }
+                        nativeMaskRects += collectNavigationBarTitleRects(in: win, maskText: maskText)
                             .map { $0.offsetBy(dx: origin.x, dy: origin.y) }
                     }
                     if maskAllImages {

--- a/CoralogixInternal/Sources/Extention/UIViewExt.swift
+++ b/CoralogixInternal/Sources/Extention/UIViewExt.swift
@@ -137,12 +137,14 @@ public extension UIView {
         return rects
     }
 
-    /// Masks a `UINavigationBar` by its (stable) geometry when its title matches `maskText`.
+    /// Returns the whole `UINavigationBar` bounds (not the title's text frame) for each bar
+    /// whose title matches `maskText`.
     ///
     /// During a push/pop UIKit draws the title with a snapshot layer that has no backing
     /// `UIView`, so the text-view walk can't redact it and the title leaks (iOS 18.5). The
-    /// title string stays readable from `UINavigationItem`, so mask by geometry instead.
-    internal func collectNavigationBarTitleRects(in rootView: UIView, maskText: [String]?) -> [CGRect] {
+    /// title string stays readable from `UINavigationItem`, so mask the bar's whole (stable)
+    /// geometry instead of trying to locate the moving title.
+    internal func collectMatchingNavigationBarRects(in rootView: UIView, maskText: [String]?) -> [CGRect] {
         guard let maskText = maskText, !maskText.isEmpty else { return [] }
         var rects: [CGRect] = []
 
@@ -191,7 +193,7 @@ public extension UIView {
     /// land off the moving content. `transitionCoordinator` catches the leading edge;
     /// composited-vs-model displacement catches the trailing edge, where the coordinator
     /// clears a frame or two before the slide settles. (The nav-bar title leak is handled
-    /// separately in `collectNavigationBarTitleRects`.)
+    /// separately in `collectMatchingNavigationBarRects`.)
     static func isNavigationTransitionActive() -> Bool {
         guard let scene = UIApplication.shared.connectedScenes
             .compactMap({ $0 as? UIWindowScene })
@@ -317,7 +319,7 @@ public extension UIView {
                     if let maskText = maskText, !maskText.isEmpty {
                         nativeMaskRects += collectTextViewRects(in: win, maskText: maskText)
                             .map { $0.offsetBy(dx: origin.x, dy: origin.y) }
-                        nativeMaskRects += collectNavigationBarTitleRects(in: win, maskText: maskText)
+                        nativeMaskRects += collectMatchingNavigationBarRects(in: win, maskText: maskText)
                             .map { $0.offsetBy(dx: origin.x, dy: origin.y) }
                     }
                     if maskAllImages {

--- a/CoralogixInternal/Sources/Utils.swift
+++ b/CoralogixInternal/Sources/Utils.swift
@@ -16,7 +16,7 @@ public enum ImageFormat {
 }
 
 public enum Global: String {
-    case sdk = "2.11.1"
+    case sdk = "2.11.2"
     case swiftVersion = "5.9"
     case coralogixPath = "/browser/v1beta/logs"
     case sessionReplayPath = "/browser/alpha/sessionrecording"

--- a/SessionReplay.podspec
+++ b/SessionReplay.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "SessionReplay"
-  spec.version      = "2.11.1"
+  spec.version      = "2.11.2"
   spec.summary      = "Coralogix Session-Replay pod for iOS."
 
   spec.description  = <<-DESC
@@ -23,7 +23,7 @@ Pod::Spec.new do |spec|
   spec.static_framework = true
 
   spec.source_files  = 'SessionReplay/Sources/**/*.swift'
-  spec.dependency 'CoralogixInternal', '2.11.1'
+  spec.dependency 'CoralogixInternal', '2.11.2'
   
     spec.test_spec 'Tests' do |test|
         test.source_files = 'Tests/SessionReplayTests/**/*.swift'

--- a/Tests/CoralogixInternalTests/UIViewExtNavigationBarMaskingTests.swift
+++ b/Tests/CoralogixInternalTests/UIViewExtNavigationBarMaskingTests.swift
@@ -1,0 +1,62 @@
+//
+//  UIViewExtNavigationBarMaskingTests.swift
+//  CoralogixInternalTests
+//
+
+import XCTest
+import UIKit
+@testable import CoralogixInternal
+
+final class UIViewExtNavigationBarMaskingTests: XCTestCase {
+
+    // MARK: - textMatchesAny
+
+    func testTextMatchesAny_substringIsCaseInsensitive() {
+        XCTAssertTrue(UIView.textMatchesAny("My Password Field", ["password"]))
+        XCTAssertFalse(UIView.textMatchesAny("Username", ["password"]))
+    }
+
+    func testTextMatchesAny_regexWildcardMatchesAnyText() {
+        XCTAssertTrue(UIView.textMatchesAny("anything at all", [".*"]))
+    }
+
+    func testTextMatchesAny_regexPattern() {
+        XCTAssertTrue(UIView.textMatchesAny("Order #4821", ["#\\d+"]))
+        XCTAssertFalse(UIView.textMatchesAny("Order ABC", ["#\\d+"]))
+    }
+
+    // MARK: - collectNavigationBarTitleRects
+
+    func testNavigationBarTitleRects_masksBarWhenTitleMatches() {
+        let bar = UINavigationBar(frame: CGRect(x: 0, y: 0, width: 320, height: 44))
+        bar.items = [UINavigationItem(title: "Secret Screen")]
+        let root = UIView(frame: CGRect(x: 0, y: 0, width: 320, height: 480))
+        root.addSubview(bar)
+
+        let rects = UIView().collectNavigationBarTitleRects(in: root, maskText: ["Secret"])
+
+        XCTAssertEqual(rects.count, 1)
+        XCTAssertEqual(rects.first, bar.convert(bar.bounds, to: root))
+    }
+
+    func testNavigationBarTitleRects_ignoresBarWhenTitleDoesNotMatch() {
+        let bar = UINavigationBar(frame: CGRect(x: 0, y: 0, width: 320, height: 44))
+        bar.items = [UINavigationItem(title: "Home")]
+        let root = UIView(frame: CGRect(x: 0, y: 0, width: 320, height: 480))
+        root.addSubview(bar)
+
+        let rects = UIView().collectNavigationBarTitleRects(in: root, maskText: ["password"])
+
+        XCTAssertTrue(rects.isEmpty)
+    }
+
+    func testNavigationBarTitleRects_emptyWhenNoMaskText() {
+        let bar = UINavigationBar(frame: CGRect(x: 0, y: 0, width: 320, height: 44))
+        bar.items = [UINavigationItem(title: "Secret Screen")]
+        let root = UIView(frame: CGRect(x: 0, y: 0, width: 320, height: 480))
+        root.addSubview(bar)
+
+        XCTAssertTrue(UIView().collectNavigationBarTitleRects(in: root, maskText: nil).isEmpty)
+        XCTAssertTrue(UIView().collectNavigationBarTitleRects(in: root, maskText: []).isEmpty)
+    }
+}

--- a/Tests/CoralogixInternalTests/UIViewExtNavigationBarMaskingTests.swift
+++ b/Tests/CoralogixInternalTests/UIViewExtNavigationBarMaskingTests.swift
@@ -25,38 +25,38 @@ final class UIViewExtNavigationBarMaskingTests: XCTestCase {
         XCTAssertFalse(UIView.textMatchesAny("Order ABC", ["#\\d+"]))
     }
 
-    // MARK: - collectNavigationBarTitleRects
+    // MARK: - collectMatchingNavigationBarRects
 
-    func testNavigationBarTitleRects_masksBarWhenTitleMatches() {
+    func testMatchingNavigationBarRects_masksBarWhenTitleMatches() {
         let bar = UINavigationBar(frame: CGRect(x: 0, y: 0, width: 320, height: 44))
         bar.items = [UINavigationItem(title: "Secret Screen")]
         let root = UIView(frame: CGRect(x: 0, y: 0, width: 320, height: 480))
         root.addSubview(bar)
 
-        let rects = UIView().collectNavigationBarTitleRects(in: root, maskText: ["Secret"])
+        let rects = UIView().collectMatchingNavigationBarRects(in: root, maskText: ["Secret"])
 
         XCTAssertEqual(rects.count, 1)
         XCTAssertEqual(rects.first, bar.convert(bar.bounds, to: root))
     }
 
-    func testNavigationBarTitleRects_ignoresBarWhenTitleDoesNotMatch() {
+    func testMatchingNavigationBarRects_ignoresBarWhenTitleDoesNotMatch() {
         let bar = UINavigationBar(frame: CGRect(x: 0, y: 0, width: 320, height: 44))
         bar.items = [UINavigationItem(title: "Home")]
         let root = UIView(frame: CGRect(x: 0, y: 0, width: 320, height: 480))
         root.addSubview(bar)
 
-        let rects = UIView().collectNavigationBarTitleRects(in: root, maskText: ["password"])
+        let rects = UIView().collectMatchingNavigationBarRects(in: root, maskText: ["password"])
 
         XCTAssertTrue(rects.isEmpty)
     }
 
-    func testNavigationBarTitleRects_emptyWhenNoMaskText() {
+    func testMatchingNavigationBarRects_emptyWhenNoMaskText() {
         let bar = UINavigationBar(frame: CGRect(x: 0, y: 0, width: 320, height: 44))
         bar.items = [UINavigationItem(title: "Secret Screen")]
         let root = UIView(frame: CGRect(x: 0, y: 0, width: 320, height: 480))
         root.addSubview(bar)
 
-        XCTAssertTrue(UIView().collectNavigationBarTitleRects(in: root, maskText: nil).isEmpty)
-        XCTAssertTrue(UIView().collectNavigationBarTitleRects(in: root, maskText: []).isEmpty)
+        XCTAssertTrue(UIView().collectMatchingNavigationBarRects(in: root, maskText: nil).isEmpty)
+        XCTAssertTrue(UIView().collectMatchingNavigationBarRects(in: root, maskText: []).isEmpty)
     }
 }


### PR DESCRIPTION
## Summary
Fixes the Session Replay navigation-transition leak on **iOS 18.5** (CX-45948) — 60/133 `navigate_*` harness frames were rendering the unmasked nav-bar title.

Two causes, pinned via layer/pixel probing on a real iPhone 16 / iOS 18.5 sim:
1. **Nav-bar title** — during a push/pop, UIKit draws the title with a snapshot *layer* that has no backing `UIView`, so the view-based mask walk can't redact it. (iOS 26.5 draws the title in place, so it never leaked there.)
2. **Content trailing edge** — a rare ~1-frame sliver where `transitionCoordinator` clears just before a sliding view-controller view settles.

## Fix (`CoralogixInternal/.../UIViewExt.swift`, SDK-only)
- `collectNavigationBarTitleRects` — masks a `UINavigationBar` by its (stable) geometry when its `UINavigationItem` title matches `maskText`, so it doesn't depend on finding the transient snapshot.
- `vcContentIsDisplaced` / `isDisplaced` added to `isNavigationTransitionActive()` — skips capture while a VC view is composited away from its model position.
- Extracted a shared `textMatchesAny`. New helpers are `internal` (no public API change).

## Verification (`tool/run_leak_harness.sh`)
| Env | Before | After |
|---|---|---|
| iPhone 16 / iOS 18.5 | 60/133 | **0 leaks × 3 runs** |
| iPhone 17 / iOS 26.5 | 0/127 | **0/127 (no regression)** |

6 new unit tests (`UIViewExtNavigationBarMaskingTests`). Version 2.11.1 → **2.11.2** (patch, 4 files) + CHANGELOG.

## Notes
- The bar is masked **whole** when its title matches (can't locate the transient snapshot). For `maskText: [".*"]` that's every bar; for specific patterns only when the title itself matches.
- AC #2 (re-add the leak harness to CI) **descoped** — session recording is being rebuilt from scratch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)