### PR TITLE
[CX-51128] Expose isSessionSampledIn to beforeSend for sampling-aware filtering (2.13.0)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,8 @@ The protection is two layers:
 1. **Strip** the field from the editable subset that `beforeSend(cxRum)` receives (so customers don't see fields they can't change).
 2. **Restore** the original value after the merge step (so a callback that injects the field into its return dict can't tamper with it).
 
+**Exception — visible read-only fields.** A field whose purpose is to inform the callback's decision (e.g. `session_context.isSessionSampledIn`, which `beforeSend` reads to filter events from sampled-out sessions) must stay VISIBLE in the subset — stripping it would defeat the feature. Such fields skip layer 1 but keep layer 2: the SDK's value is always restored after the merge, so they remain tamper-proof. Integrity comes from the restore; the strip layer is only a UX courtesy. A PR adding a visible read-only field must include a test proving the restore survives a callback that rewrites it.
+
 ### 4.5 Wire-shape parity (`text.cx_rum` ↔ `otelSpan.attributes`)
 
 Any field emitted at `text.cx_rum.*` must also be mirrored into `instrumentation_data.otelSpan.attributes` under the corresponding `cx_rum.*` snake_case key. The mapping lives in `Coralogix/Sources/Model/InstrumentationData.swift` (`AttrKey` enum + the two `buildRumContextAttributes` variants — live and post-`beforeSend` dict).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Release-mechanics commits (version bumps, podspec/script tweaks, README edits) a
 omitted; the focus here is user-facing behavior changes. Tickets are referenced as
 `CX-XXXXX` (Jira) or `ALPH-XXXX` (legacy). Pull request numbers are in parentheses.
 
+## [2.13.0] - 2026-07-28
+
+### Added
+- Every event now carries `session_context.isSessionSampledIn` (read-only, also mirrored on `instrumentation_data.otelSpan.attributes`): `false` marks events that reached export only via `excludeFromSampling` while the session itself was sampled out. Lets a `beforeSend` callback keep just crashes/ANRs (or any subset) at low session sample rates without reflecting into SDK internals. The decision is stamped on each span at creation, so events buffered across a session rotation keep the sampling decision of the session they belong to.
+
 ## [2.12.0] - 2026-07-26
 
 ### Added

--- a/Coralogix.podspec
+++ b/Coralogix.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "Coralogix"
-  spec.version      = "2.12.0"
+  spec.version      = "2.13.0"
   spec.summary      = "Coralogix OpenTelemetry pod for iOS."
 
   spec.description  = <<-DESC
@@ -29,7 +29,7 @@ Pod::Spec.new do |spec|
 
   spec.static_framework = true
   spec.dependency 'PLCrashReporter', '~> 1.12'
-  spec.dependency 'CoralogixInternal', '2.12.0'
+  spec.dependency 'CoralogixInternal', '2.13.0'
 
   spec.test_spec 'Tests' do |test|
     test.source_files = 'Tests/CoralogixRumTests/**/*.swift'

--- a/Coralogix/Sources/CoralogixRum.swift
+++ b/Coralogix/Sources/CoralogixRum.swift
@@ -127,14 +127,22 @@ public class CoralogixRum {
         self.setupExporter(sessionManager: sessionManager, options: options)
         self.timeMeasurementTracker = TimeMeasurementTracker(sessionManager: sessionManager)
 
-        // Seed the exporter and install the reroll callback immediately after the exporter
+        // Seed the exporter and install the reroll hooks immediately after the exporter
         // exists, before swizzling or instrumentation init can drive a session rotation
         // (e.g. a tap or foreground notification arriving mid-startup). Re-rolling on every
         // rotation gives long-running apps a fresh probability per session.
+        //
+        // SessionManager owns the roll: it happens inside the rotation lock so the decision
+        // is atomic with the session identity and gets stamped on every span
+        // (is_session_sampled_in). The callback only propagates the stored decision to the
+        // exporter's filter — rolling again here would let the filter and the stamp disagree.
+        sessionManager.setSessionSampledIn(initialSampledIn)
+        sessionManager.samplingRoller = { options.sdkSampler.shouldInitialized() }
         self.coralogixExporter?.updateSessionSampling(sampledIn: initialSampledIn)
-        sessionManager.samplingReevaluationCallback = { [weak self] _ in
-            self?.coralogixExporter?.updateSessionSampling(
-                sampledIn: options.sdkSampler.shouldInitialized()
+        sessionManager.samplingReevaluationCallback = { [weak self, weak sessionManager] _ in
+            guard let self, let sessionManager else { return }
+            self.coralogixExporter?.updateSessionSampling(
+                sampledIn: sessionManager.isSessionSampledIn
             )
         }
 

--- a/Coralogix/Sources/Model/Contexts/SessionContext.swift
+++ b/Coralogix/Sources/Model/Contexts/SessionContext.swift
@@ -16,14 +16,20 @@ struct SessionContext {
     let userMetadata: [String: String]?
     var isPidEqualToOldPid: Bool = false
     var hasRecording: Bool = false
-    
+    // Whether the session this event belongs to was sampled in. false means the event
+    // reached export only because its type is in excludeFromSampling. Read from the span
+    // attribute stamped at creation time — never from the live flag, which may already
+    // describe a newer session. Defaults to true: a span without the stamp (e.g. one
+    // persisted by an older SDK version) can only reach export on a sampled-in session.
+    var isSessionSampledIn: Bool = true
+
     init?(otel: SpanDataProtocol,
           userMetadata: [String: String]?,
           hasRecording: Bool = false) {
         guard let sessionInfo = SessionContext.resolveSession(from: otel) else {
             return nil  // Drop span if session attributes are missing
         }
-        
+
         (self.sessionId, self.sessionCreationDate, self.isPidEqualToOldPid) = sessionInfo
 
         self.userId = otel.getString(forKey: .userId) ?? ""
@@ -31,6 +37,7 @@ struct SessionContext {
         self.userEmail = otel.getString(forKey: .userEmail) ?? ""
         self.userMetadata = userMetadata
         self.hasRecording = hasRecording
+        self.isSessionSampledIn = otel.getString(forKey: .spanSessionSampledIn).map { $0 == "true" } ?? true
     }
     
     private static func resolveSession(from otel: SpanDataProtocol) -> (id: String, creationDate: TimeInterval, isPidEqual: Bool)? {
@@ -78,6 +85,7 @@ struct SessionContext {
         result[Keys.userName.rawValue] = self.userName
         result[Keys.userEmail.rawValue] = self.userEmail
         result[Keys.hasRecording.rawValue] = self.hasRecording
+        result[Keys.isSessionSampledIn.rawValue] = self.isSessionSampledIn
         if let userMetadata = self.userMetadata {
             result[Keys.userMetadata.rawValue] = userMetadata
         }

--- a/Coralogix/Sources/Model/CxSpan.swift
+++ b/Coralogix/Sources/Model/CxSpan.swift
@@ -320,6 +320,11 @@ public struct SessionMetadata {
     var oldPid: String?
     var oldSessionId: String?
     var oldSessionTimeInterval: TimeInterval?
+    /// Sampling decision of the previous launch's session, recovered from the keychain.
+    /// nil when the prior launch predates the persisted value — treated as sampled-in,
+    /// since a recovered crash misclassified as sampled-out could be dropped by a
+    /// customer's beforeSend filter.
+    var oldSessionSampledIn: Bool?
     
     init(sessionId: String, sessionCreationDate: TimeInterval, using keychain: KeyChainProtocol) {
         self.sessionId = sessionId
@@ -343,6 +348,11 @@ public struct SessionMetadata {
             self.oldPid = oldPid
             self.oldSessionId = oldSessionId
             self.oldSessionTimeInterval = TimeInterval(oldSessionTimeInterval)
+            // Optional on purpose: launches recorded by SDK versions that predate the
+            // persisted decision have no entry; SessionManager defaults those to true.
+            self.oldSessionSampledIn = keychain.readStringFromKeychain(service: Keys.service.rawValue,
+                                                                       key: Keys.keySessionSampledIn.rawValue)
+                .map { $0 == "true" }
         }
         
         keychain.writeStringToKeychain(service: Keys.service.rawValue,

--- a/Coralogix/Sources/Model/CxSpan.swift
+++ b/Coralogix/Sources/Model/CxSpan.swift
@@ -83,6 +83,9 @@ public class CxSpan {
 
                 // Restore stripped sessionContext fields (sessionId, sessionCreationDate)
                 // for the same reason — a callback could inject them inside sessionContext.
+                // isSessionSampledIn stays VISIBLE in the subset (callbacks filter on it —
+                // that's its purpose) but is restored here so it's read-only: it records
+                // the SDK's sampling decision for the session, not an editable field.
                 // If the callback corrupted sessionContext to a non-dict value
                 // (e.g. returned a string), mergeDictionaries replaced our dict with it
                 // entirely; restore the whole original sessionContext in that case so
@@ -91,6 +94,7 @@ public class CxSpan {
                     if var mergedSession = mergedDict[Keys.sessionContext.rawValue] as? [String: Any] {
                         mergedSession[Keys.sessionId.rawValue] = originalSession[Keys.sessionId.rawValue]
                         mergedSession[Keys.sessionCreationDate.rawValue] = originalSession[Keys.sessionCreationDate.rawValue]
+                        mergedSession[Keys.isSessionSampledIn.rawValue] = originalSession[Keys.isSessionSampledIn.rawValue]
                         mergedDict[Keys.sessionContext.rawValue] = mergedSession
                     } else {
                         mergedDict[Keys.sessionContext.rawValue] = originalSession

--- a/Coralogix/Sources/Model/InstrumentationData.swift
+++ b/Coralogix/Sources/Model/InstrumentationData.swift
@@ -94,6 +94,8 @@ struct OtelSpan {
         static let sessionId                 = "cx_rum.session_context.session_id"
         static let sessionCreationDate       = "cx_rum.session_context.session_creation_date"
         static let hasRecording              = "cx_rum.session_context.hasRecording"
+        // camelCase like hasRecording; matches the Android SDK mirror key exactly.
+        static let isSessionSampledIn        = "cx_rum.session_context.isSessionSampledIn"
         static let userId                    = "cx_rum.session_context.user_id"
         static let userName                  = "cx_rum.session_context.user_name"
         static let userEmail                 = "cx_rum.session_context.user_email"
@@ -162,6 +164,9 @@ struct OtelSpan {
             if let v = session[Keys.sessionId.rawValue] as? String { attrs[AttrKey.sessionId] = v }
             if let v = session[Keys.sessionCreationDate.rawValue] { attrs[AttrKey.sessionCreationDate] = v }
             if let v = session[Keys.hasRecording.rawValue] as? Bool { attrs[AttrKey.hasRecording] = v }
+            // Same default as SessionContext: a span without the stamp can only reach
+            // export on a sampled-in session.
+            attrs[AttrKey.isSessionSampledIn] = (session[Keys.isSessionSampledIn.rawValue] as? Bool) ?? true
             if let v = session[Keys.userId.rawValue] as? String, !v.isEmpty { attrs[AttrKey.userId] = v }
             if let v = session[Keys.userName.rawValue] as? String, !v.isEmpty { attrs[AttrKey.userName] = v }
             if let v = session[Keys.userEmail.rawValue] as? String, !v.isEmpty { attrs[AttrKey.userEmail] = v }
@@ -265,6 +270,7 @@ struct OtelSpan {
             attrs[AttrKey.sessionId] = session.sessionId
             attrs[AttrKey.sessionCreationDate] = session.sessionCreationDate.milliseconds
             attrs[AttrKey.hasRecording] = session.hasRecording
+            attrs[AttrKey.isSessionSampledIn] = session.isSessionSampledIn
             if !session.userId.isEmpty    { attrs[AttrKey.userId]    = session.userId }
             if !session.userName.isEmpty  { attrs[AttrKey.userName]  = session.userName }
             if !session.userEmail.isEmpty { attrs[AttrKey.userEmail] = session.userEmail }

--- a/Coralogix/Sources/Utils/SessionManager.swift
+++ b/Coralogix/Sources/Utils/SessionManager.swift
@@ -89,6 +89,18 @@ public class SessionManager {
         sessionLock.lock()
         defer { sessionLock.unlock() }
         _isSessionSampledIn = sampledIn
+        persistSessionSampledInLocked(sampledIn)
+    }
+
+    /// Mirrors the live decision into the keychain next to the session identity, so a
+    /// crash captured on the next launch can be attributed with the crashed session's
+    /// decision (`lastLaunchSessionSpanAttributes`) instead of the relaunch's fresh roll.
+    /// PRECONDITION: caller holds `sessionLock` (same discipline as the identity writes
+    /// in `SessionMetadata.loadPrevSession`, which also run under the lock).
+    private func persistSessionSampledInLocked(_ sampledIn: Bool) {
+        KeychainManager().writeStringToKeychain(service: Keys.service.rawValue,
+                                                key: Keys.keySessionSampledIn.rawValue,
+                                                value: String(sampledIn))
     }
 
     public var hasRecording: Bool = false
@@ -202,12 +214,17 @@ public class SessionManager {
         sessionLock.lock()
         let oldSessionId = self.sessionMetadata?.oldSessionId
         let oldCreationDate = self.sessionMetadata?.oldSessionTimeInterval
+        let oldSampledIn = self.sessionMetadata?.oldSessionSampledIn
         sessionLock.unlock()
 
         guard let oldSessionId, let oldCreationDate else { return [] }
+        // nil (prior launch predates the persisted decision) defaults to true: a
+        // recovered crash misclassified as sampled-out could be dropped by a
+        // customer's beforeSend filter — the failure mode this feature exists to avoid.
         return [
             (Keys.sessionId.rawValue, oldSessionId),
-            (Keys.sessionCreationDate.rawValue, String(Int(oldCreationDate)))
+            (Keys.sessionCreationDate.rawValue, String(Int(oldCreationDate))),
+            (Keys.spanSessionSampledIn.rawValue, String(oldSampledIn ?? true))
         ]
     }
 
@@ -322,6 +339,7 @@ public class SessionManager {
         // startup installs it) keeps the seeded/default value.
         if let samplingRoller = self.samplingRoller {
             self._isSessionSampledIn = samplingRoller()
+            persistSessionSampledInLocked(self._isSessionSampledIn)
         }
         // Reset snapshot-throttle so the fresh session can emit its first
         // snapshot immediately. CxRumBuilder.buildSnapshotContextIfNeeded

--- a/Coralogix/Sources/Utils/SessionManager.swift
+++ b/Coralogix/Sources/Utils/SessionManager.swift
@@ -66,6 +66,31 @@ public class SessionManager {
     /// SessionReplay listener that owns `sessionChangedCallback`. Internal-only — host apps
     /// have no use for setting this, and a public slot would invite accidental clobber.
     internal var samplingReevaluationCallback: ((String) -> Void)?
+
+    /// Rolls the sampling decision for a newly rotated session. Installed once at startup;
+    /// invoked inside `performRotationLocked` so the decision is replaced atomically with
+    /// the session identity — the single roll per rotation is what both the exporter's
+    /// sampling filter and the per-span stamp observe, so they can never disagree.
+    internal var samplingRoller: (() -> Bool)?
+    private var _isSessionSampledIn: Bool = true
+
+    /// Whether the current session was sampled in. Per-session: re-rolled on every
+    /// rotation. Defaults to `true` until the SDK seeds it (sessions created before the
+    /// roller is installed inherit the init-time roll via `setSessionSampledIn`).
+    internal var isSessionSampledIn: Bool {
+        sessionLock.lock()
+        defer { sessionLock.unlock() }
+        return _isSessionSampledIn
+    }
+
+    /// Seeds the decision for the session that already exists when the SDK starts up
+    /// (created by `init` before `samplingRoller` could be installed).
+    internal func setSessionSampledIn(_ sampledIn: Bool) {
+        sessionLock.lock()
+        defer { sessionLock.unlock() }
+        _isSessionSampledIn = sampledIn
+    }
+
     public var hasRecording: Bool = false
     
     public var lastSnapshotEventTime: Date?
@@ -140,12 +165,14 @@ public class SessionManager {
         sessionLock.lock()
         let current = self.sessionMetadata
         let prev = self.prevSessionMetadata
+        let sampledIn = self._isSessionSampledIn
         sessionLock.unlock()
 
         var attrs: [(key: String, value: String)] = []
         if let current {
             attrs.append((Keys.sessionId.rawValue, current.sessionId))
             attrs.append((Keys.sessionCreationDate.rawValue, String(Int(current.sessionCreationDate))))
+            attrs.append((Keys.spanSessionSampledIn.rawValue, String(sampledIn)))
         }
         if let prev {
             if let prevPid = prev.oldPid {
@@ -289,6 +316,13 @@ public class SessionManager {
         self.sessionMetadata = SessionMetadata(sessionId: UUID().uuidString.lowercased(),
                                                sessionCreationDate: Date().timeIntervalSince1970,
                                                using: KeychainManager())
+        // Roll the new session's sampling decision under the same lock acquisition that
+        // replaces the session identity, so no span can observe a fresh session_id with
+        // the previous session's sampling decision (or vice versa). Absent roller (before
+        // startup installs it) keeps the seeded/default value.
+        if let samplingRoller = self.samplingRoller {
+            self._isSessionSampledIn = samplingRoller()
+        }
         // Reset snapshot-throttle so the fresh session can emit its first
         // snapshot immediately. CxRumBuilder.buildSnapshotContextIfNeeded
         // treats nil as "throttle expired", so the next qualifying event

--- a/CoralogixInternal.podspec
+++ b/CoralogixInternal.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "CoralogixInternal"
-  spec.version      = "2.12.0"
+  spec.version      = "2.13.0"
   spec.summary      = "Coralogix Internal Package. This module is not for public use."
 
   spec.description  = <<-DESC

--- a/CoralogixInternal/Sources/Keys.swift
+++ b/CoralogixInternal/Sources/Keys.swift
@@ -135,6 +135,10 @@ public enum Keys: String {
     case service = "com.coralogix.sdk"
     case keySessionId = "sessionId"
     case keySessionTimeInterval = "sessionTimeInterval"
+    // Keychain slot for the live session's sampling decision. Persisted so a crash
+    // recovered on the next launch can be stamped with the crashed session's decision
+    // instead of inheriting the relaunch session's roll.
+    case keySessionSampledIn = "sessionSampledIn"
     case snapshotContext = "snapshot_context"
     case errorCount
     case viewCount

--- a/CoralogixInternal/Sources/Keys.swift
+++ b/CoralogixInternal/Sources/Keys.swift
@@ -23,6 +23,13 @@ public enum Keys: String {
     case nativeVersion = "native_version"
     case sessionId = "session_id"
     case sessionCreationDate = "session_creation_date"
+    // Span attribute stamped at creation alongside session_id: the sampling decision
+    // belongs to the session the span was created in, and reading the live flag at
+    // export time would mis-attribute spans buffered across a session rotation
+    // (the flag is re-rolled per session). Matches the Android SDK attribute name.
+    case spanSessionSampledIn = "is_session_sampled_in"
+    // session_context payload key; camelCase matches hasRecording and the Android wire format.
+    case isSessionSampledIn = "isSessionSampledIn"
     case prevSessionCreationDate
     case prevSessionId
     case prevPid

--- a/CoralogixInternal/Sources/Utils.swift
+++ b/CoralogixInternal/Sources/Utils.swift
@@ -16,7 +16,7 @@ public enum ImageFormat {
 }
 
 public enum Global: String {
-    case sdk = "2.12.0"
+    case sdk = "2.13.0"
     case swiftVersion = "5.9"
     case coralogixPath = "/browser/v1beta/logs"
     case sessionReplayPath = "/browser/alpha/sessionrecording"

--- a/README.md
+++ b/README.md
@@ -183,6 +183,23 @@ Accepted `ExcludableInstrumentation` cases:
 
 Parity note: the Coralogix Browser SDK exposes the same option with matching semantics.
 
+#### Telling excluded events apart in `beforeSend`
+Every event carries `session_context.isSessionSampledIn` (read-only). `false` means the event reached export only because its category is listed in `excludeFromSampling` — the session itself was sampled out. Use it in `beforeSend` to apply your own filtering on top of the exclude list, e.g. keep only crashes and ANRs from sampled-out sessions:
+
+```swift
+beforeSend: { cxRum in
+    let session = cxRum["session_context"] as? [String: Any]
+    let sampledIn = session?["isSessionSampledIn"] as? Bool ?? true
+    let severity = (cxRum["event_context"] as? [String: Any])?["severity"] as? Int
+
+    // Session sampled out: forward only error-severity events, drop the rest.
+    if !sampledIn && severity != 5 {
+        return nil
+    }
+    return cxRum
+}
+```
+
 ### Before Send
 Enable event access and modification before sending to Coralogix, supporting content modification.
 ```swift

--- a/SessionReplay.podspec
+++ b/SessionReplay.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "SessionReplay"
-  spec.version      = "2.12.0"
+  spec.version      = "2.13.0"
   spec.summary      = "Coralogix Session-Replay pod for iOS."
 
   spec.description  = <<-DESC
@@ -23,7 +23,7 @@ Pod::Spec.new do |spec|
   spec.static_framework = true
 
   spec.source_files  = 'SessionReplay/Sources/**/*.swift'
-  spec.dependency 'CoralogixInternal', '2.12.0'
+  spec.dependency 'CoralogixInternal', '2.13.0'
   
     spec.test_spec 'Tests' do |test|
         test.source_files = 'Tests/SessionReplayTests/**/*.swift'

--- a/Tests/CoralogixRumTests/SessionSamplingFlagTests.swift
+++ b/Tests/CoralogixRumTests/SessionSamplingFlagTests.swift
@@ -99,6 +99,64 @@ final class SessionSamplingFlagTests: XCTestCase {
         XCTAssertEqual(attrs[Keys.spanSessionSampledIn.rawValue], "true")
     }
 
+    // MARK: - Crash attribution: recovered crashes carry the crashed session's decision
+
+    func testLastLaunchAttributes_carryCrashedSessionSamplingDecision() throws {
+        let sessionManager = SessionManager()
+        var metadata = try XCTUnwrap(sessionManager.sessionMetadata)
+        metadata.oldSessionId = "crashed-session-abc"
+        metadata.oldSessionTimeInterval = TimeInterval(1_600_000_000)
+        metadata.oldSessionSampledIn = false
+        sessionManager.sessionMetadata = metadata
+
+        let attrs = Dictionary(uniqueKeysWithValues: sessionManager.lastLaunchSessionSpanAttributes())
+        XCTAssertEqual(attrs[Keys.spanSessionSampledIn.rawValue], "false",
+                       "A recovered crash must be stamped with the crashed session's decision, not the relaunch roll.")
+        XCTAssertEqual(attrs[Keys.sessionId.rawValue], "crashed-session-abc")
+    }
+
+    func testLastLaunchAttributes_missingPersistedDecision_defaultsToSampledIn() throws {
+        // Prior launch recorded by an SDK version that predates the persisted decision.
+        let sessionManager = SessionManager()
+        var metadata = try XCTUnwrap(sessionManager.sessionMetadata)
+        metadata.oldSessionId = "crashed-session-abc"
+        metadata.oldSessionTimeInterval = TimeInterval(1_600_000_000)
+        metadata.oldSessionSampledIn = nil
+        sessionManager.sessionMetadata = metadata
+
+        let attrs = Dictionary(uniqueKeysWithValues: sessionManager.lastLaunchSessionSpanAttributes())
+        XCTAssertEqual(attrs[Keys.spanSessionSampledIn.rawValue], "true",
+                       "Unknown prior decision must default to sampled-in so the crash can't be dropped by a beforeSend filter.")
+    }
+
+    func testLoadPrevSession_recoversPersistedSamplingDecision() {
+        // First "launch" leaves its identity + sampling decision in the keychain.
+        let keychain = MockKeyschainManager()
+        _ = SessionMetadata(sessionId: "crashed-session", sessionCreationDate: 1_600_000_000, using: keychain)
+        keychain.writeStringToKeychain(service: Keys.service.rawValue,
+                                       key: Keys.keySessionSampledIn.rawValue,
+                                       value: "false")
+
+        // Relaunch: the fresh session's metadata recovers the crashed launch's state.
+        let relaunch = SessionMetadata(sessionId: "fresh-session", sessionCreationDate: 1_700_000_000, using: keychain)
+
+        XCTAssertEqual(relaunch.oldSessionId, "crashed-session")
+        XCTAssertEqual(relaunch.oldSessionSampledIn, false,
+                       "The crashed launch's sampling decision must be recovered alongside its identity.")
+    }
+
+    func testLoadPrevSession_withoutPersistedDecision_leavesNil() {
+        // Prior launch written by an SDK version that predates the persisted decision.
+        let keychain = MockKeyschainManager()
+        _ = SessionMetadata(sessionId: "legacy-session", sessionCreationDate: 1_600_000_000, using: keychain)
+
+        let relaunch = SessionMetadata(sessionId: "fresh-session", sessionCreationDate: 1_700_000_000, using: keychain)
+
+        XCTAssertEqual(relaunch.oldSessionId, "legacy-session")
+        XCTAssertNil(relaunch.oldSessionSampledIn,
+                     "Absent keychain entry must stay nil so lastLaunchSessionSpanAttributes applies the sampled-in default.")
+    }
+
     // MARK: - SessionContext parses the stamp (wire payload)
 
     func testSessionContext_parsesSampledOutStamp() throws {

--- a/Tests/CoralogixRumTests/SessionSamplingFlagTests.swift
+++ b/Tests/CoralogixRumTests/SessionSamplingFlagTests.swift
@@ -1,0 +1,239 @@
+//
+//  SessionSamplingFlagTests.swift
+//
+//  CX-51128: the session sampling decision is stamped on every span at creation
+//  (is_session_sampled_in) and surfaced as session_context.isSessionSampledIn on the
+//  wire, in the otelSpan attribute mirror, and in the subset `beforeSend` receives —
+//  so a callback can tell whether an event belongs to a sampled-in session or reached
+//  export only via excludeFromSampling (e.g. keep just errors/ANRs at low sample rates).
+//
+
+import XCTest
+import CoralogixInternal
+@testable import Coralogix
+
+final class SessionSamplingFlagTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        CoralogixRum.isInitialized = false
+    }
+
+    // MARK: - SessionManager stamps the decision alongside the session identity
+
+    func testSessionSpanAttributes_containSampledOutStamp() {
+        let sessionManager = SessionManager()
+        sessionManager.setSessionSampledIn(false)
+
+        let attrs = Dictionary(uniqueKeysWithValues: sessionManager.sessionSpanAttributes().map { ($0.key, $0.value) })
+
+        XCTAssertEqual(attrs[Keys.spanSessionSampledIn.rawValue], "false")
+        XCTAssertNotNil(attrs[Keys.sessionId.rawValue],
+                        "The stamp must ride with the session identity attributes.")
+    }
+
+    func testSessionSpanAttributes_containSampledInStamp() {
+        let sessionManager = SessionManager()
+        sessionManager.setSessionSampledIn(true)
+
+        let attrs = Dictionary(uniqueKeysWithValues: sessionManager.sessionSpanAttributes().map { ($0.key, $0.value) })
+
+        XCTAssertEqual(attrs[Keys.spanSessionSampledIn.rawValue], "true")
+    }
+
+    // MARK: - Rotation re-rolls via the installed roller, atomically with the identity swap
+
+    func testRotation_rerollsDecisionThroughSamplingRoller() {
+        let sessionManager = SessionManager()
+        sessionManager.setSessionSampledIn(true)
+        sessionManager.samplingRoller = { false }
+
+        sessionManager.setupSessionMetadata()
+
+        XCTAssertFalse(sessionManager.isSessionSampledIn,
+                       "Rotation must replace the decision with the roller's result.")
+        let attrs = Dictionary(uniqueKeysWithValues: sessionManager.sessionSpanAttributes().map { ($0.key, $0.value) })
+        XCTAssertEqual(attrs[Keys.spanSessionSampledIn.rawValue], "false")
+    }
+
+    func testRotation_withoutRoller_keepsSeededDecision() {
+        // Sessions rotate before startup() installs the roller (e.g. the one created in
+        // SessionManager.init); they must keep the seeded value, not flip to a default.
+        let sessionManager = SessionManager()
+        sessionManager.setSessionSampledIn(false)
+
+        sessionManager.setupSessionMetadata()
+
+        XCTAssertFalse(sessionManager.isSessionSampledIn)
+    }
+
+    // MARK: - End-to-end wiring through CoralogixRum init
+
+    func testInit_sampledOutWithExclude_stampsFalseAndSyncsExporter() {
+        let rum = CoralogixRum(options: makeSamplingOptions(sampleRate: 0, exclude: [.errors]))
+        defer { rum.shutdown() }
+
+        guard let sessionManager = rum.sessionManager else {
+            return XCTFail("SessionManager must exist after init with a non-empty exclude set.")
+        }
+        XCTAssertFalse(sessionManager.isSessionSampledIn)
+        let attrs = Dictionary(uniqueKeysWithValues: sessionManager.sessionSpanAttributes().map { ($0.key, $0.value) })
+        XCTAssertEqual(attrs[Keys.spanSessionSampledIn.rawValue], "false")
+
+        // Rotation must keep the exporter's filter flag and the stamp in agreement
+        // (single roll per rotation — sampleRate 0 makes it deterministic).
+        sessionManager.setupSessionMetadata()
+        XCTAssertFalse(sessionManager.isSessionSampledIn)
+        XCTAssertEqual(rum.coralogixExporter?.isCurrentSessionSampledIn(), false)
+    }
+
+    func testInit_sampledIn_stampsTrue() {
+        let rum = CoralogixRum(options: makeSamplingOptions(sampleRate: 100, exclude: []))
+        defer { rum.shutdown() }
+
+        guard let sessionManager = rum.sessionManager else {
+            return XCTFail("SessionManager must exist after a sampled-in init.")
+        }
+        XCTAssertTrue(sessionManager.isSessionSampledIn)
+        let attrs = Dictionary(uniqueKeysWithValues: sessionManager.sessionSpanAttributes().map { ($0.key, $0.value) })
+        XCTAssertEqual(attrs[Keys.spanSessionSampledIn.rawValue], "true")
+    }
+
+    // MARK: - SessionContext parses the stamp (wire payload)
+
+    func testSessionContext_parsesSampledOutStamp() throws {
+        let context = try XCTUnwrap(SessionContext(otel: makeSpan(sampledIn: "false"), userMetadata: nil))
+
+        XCTAssertFalse(context.isSessionSampledIn)
+        let dict = context.getDictionary()
+        XCTAssertEqual(dict[Keys.isSessionSampledIn.rawValue] as? Bool, false)
+    }
+
+    func testSessionContext_parsesSampledInStamp() throws {
+        let context = try XCTUnwrap(SessionContext(otel: makeSpan(sampledIn: "true"), userMetadata: nil))
+
+        XCTAssertTrue(context.isSessionSampledIn)
+        XCTAssertEqual(context.getDictionary()[Keys.isSessionSampledIn.rawValue] as? Bool, true)
+    }
+
+    func testSessionContext_missingStamp_defaultsToSampledIn() throws {
+        // Spans persisted by older SDK versions carry no stamp; they can only have
+        // reached export on a sampled-in session, so the payload must say true.
+        let context = try XCTUnwrap(SessionContext(otel: makeSpan(sampledIn: nil), userMetadata: nil))
+
+        XCTAssertTrue(context.isSessionSampledIn)
+        XCTAssertEqual(context.getDictionary()[Keys.isSessionSampledIn.rawValue] as? Bool, true)
+    }
+
+    // MARK: - beforeSend sees the flag; tampering with it has no effect
+
+    func testBeforeSend_subsetExposesSampledOutFlag() throws {
+        var observed: Bool?
+        _ = try runThroughBeforeSend(sampledIn: "false") { cxRum in
+            let session = cxRum[Keys.sessionContext.rawValue] as? [String: Any]
+            observed = session?[Keys.isSessionSampledIn.rawValue] as? Bool
+            return cxRum
+        }
+
+        XCTAssertEqual(observed, false,
+                       "beforeSend must see isSessionSampledIn — filtering on it is the feature.")
+    }
+
+    func testBeforeSend_tamperingWithFlag_isIgnored() throws {
+        let result = try runThroughBeforeSend(sampledIn: "false") { cxRum in
+            var edit = cxRum
+            var session = (edit[Keys.sessionContext.rawValue] as? [String: Any]) ?? [:]
+            session[Keys.isSessionSampledIn.rawValue] = true
+            edit[Keys.sessionContext.rawValue] = session
+            return edit
+        }
+
+        let session = try XCTUnwrap(result.text[Keys.sessionContext.rawValue] as? [String: Any])
+        XCTAssertEqual(session[Keys.isSessionSampledIn.rawValue] as? Bool, false,
+                       "The SDK's sampling decision must survive a callback that rewrites it.")
+        XCTAssertEqual(result.otel["cx_rum.session_context.isSessionSampledIn"] as? Bool, false,
+                       "The otelSpan attribute mirror must carry the SDK's value, not the tampered one.")
+    }
+
+    func testPayload_sampledOutFlag_reachesTextAndOtelMirror() throws {
+        let result = try runThroughBeforeSend(sampledIn: "false") { $0 }
+
+        let session = try XCTUnwrap(result.text[Keys.sessionContext.rawValue] as? [String: Any])
+        XCTAssertEqual(session[Keys.isSessionSampledIn.rawValue] as? Bool, false)
+        XCTAssertEqual(result.otel["cx_rum.session_context.isSessionSampledIn"] as? Bool, false)
+    }
+
+    func testPayload_withoutBeforeSend_carriesFlagInTextAndStructBuiltMirror() throws {
+        // No beforeSend: text.cx_rum comes straight from CxRumPayloadBuilder and the
+        // otelSpan attributes from the struct-based mirror (not the dict rebuild).
+        let result = try runThroughBeforeSend(sampledIn: "false", beforeSend: nil)
+
+        let session = try XCTUnwrap(result.text[Keys.sessionContext.rawValue] as? [String: Any])
+        XCTAssertEqual(session[Keys.isSessionSampledIn.rawValue] as? Bool, false)
+        XCTAssertEqual(result.otel["cx_rum.session_context.isSessionSampledIn"] as? Bool, false)
+    }
+
+    // MARK: - Helpers
+
+    /// networkRequest event type so instrumentation_data (and its attribute mirror) is emitted.
+    private func makeSpan(sampledIn: String?) -> MockSpanData {
+        var attributes: [String: Any] = [
+            Keys.severity.rawValue: AttributeValue("3"),
+            Keys.eventType.rawValue: AttributeValue(CoralogixEventType.networkRequest.rawValue),
+            Keys.source.rawValue: AttributeValue("fetch"),
+            Keys.environment.rawValue: AttributeValue("test"),
+            Keys.sessionId.rawValue: AttributeValue("session_001"),
+            Keys.sessionCreationDate.rawValue: AttributeValue(1609459200),
+            SemanticAttributes.httpUrl.rawValue: AttributeValue("https://example.com"),
+            SemanticAttributes.httpMethod.rawValue: AttributeValue("GET"),
+            SemanticAttributes.httpStatusCode.rawValue: AttributeValue("200")
+        ]
+        if let sampledIn {
+            attributes[Keys.spanSessionSampledIn.rawValue] = AttributeValue(sampledIn)
+        }
+        return MockSpanData(attributes: attributes,
+                            startTime: Date(),
+                            endTime: Date(),
+                            spanId: "20",
+                            traceId: "30",
+                            name: "testSpan",
+                            kind: 2,
+                            statusCode: ["status": "ok"],
+                            resources: [:])
+    }
+
+    private func runThroughBeforeSend(
+        sampledIn: String?,
+        beforeSend: (([String: Any]) -> [String: Any]?)?
+    ) throws -> (text: [String: Any], otel: [String: Any]) {
+        let options = CoralogixExporterOptions(
+            coralogixDomain: .US2,
+            userContext: nil,
+            environment: "test",
+            application: "TestApp",
+            version: "1.0.0",
+            publicKey: "test-key",
+            ignoreUrls: [],
+            ignoreErrors: [],
+            labels: nil,
+            beforeSend: beforeSend,
+            debug: false
+        )
+        let cxSpan = try XCTUnwrap(CxSpan(
+            otel: makeSpan(sampledIn: sampledIn),
+            versionMetadata: VersionMetadata(appName: "TestApp", appVersion: "1.0.0"),
+            sessionManager: SessionManager(),
+            networkManager: NetworkManager(),
+            viewManager: ViewManager(keyChain: KeychainManager()),
+            metricsManager: MetricsManager(),
+            options: options
+        ))
+        let dict = try XCTUnwrap(cxSpan.getDictionary())
+        let textWrapper = try XCTUnwrap(dict[Keys.text.rawValue] as? [String: Any])
+        let textCxRum = try XCTUnwrap(textWrapper[Keys.cxRum.rawValue] as? [String: Any])
+        let inst = try XCTUnwrap(dict[Keys.instrumentationData.rawValue] as? [String: Any])
+        let otelSpan = try XCTUnwrap(inst[Keys.otelSpan.rawValue] as? [String: Any])
+        let attrs = try XCTUnwrap(otelSpan[Keys.attributes.rawValue] as? [String: Any])
+        return (textCxRum, attrs)
+    }
+}

--- a/Tests/CoralogixRumTests/Utils.swift
+++ b/Tests/CoralogixRumTests/Utils.swift
@@ -106,7 +106,10 @@ class MockKeyschainManager: KeyChainProtocol {
     var pid = ""
     var sessionId = ""
     var sessionTimeInterval = ""
-    
+    /// nil (unlike the "" sentinels above) so tests can distinguish "never written"
+    /// from "written empty" — loadPrevSession treats absence as a legacy launch.
+    var sessionSampledIn: String?
+
     func readStringFromKeychain(service: String, key: String) -> String? {
         if key == "pid" {
             return self.pid
@@ -114,10 +117,12 @@ class MockKeyschainManager: KeyChainProtocol {
             return self.sessionId
         } else if key == "sessionTimeInterval" {
             return self.sessionTimeInterval
+        } else if key == "sessionSampledIn" {
+            return self.sessionSampledIn
         }
         return nil
     }
-    
+
     func writeStringToKeychain(service: String, key: String, value: String) {
         if key == "pid" {
             self.pid = value
@@ -125,6 +130,8 @@ class MockKeyschainManager: KeyChainProtocol {
             self.sessionId = value
         } else if key == "sessionTimeInterval" {
             self.sessionTimeInterval = value
+        } else if key == "sessionSampledIn" {
+            self.sessionSampledIn = value
         }
     }
 
@@ -135,6 +142,8 @@ class MockKeyschainManager: KeyChainProtocol {
             self.sessionId = ""
         } else if key == "sessionTimeInterval" {
             self.sessionTimeInterval = ""
+        } else if key == "sessionSampledIn" {
+            self.sessionSampledIn = nil
         }
     }
 }


### PR DESCRIPTION
## What

Every event now carries **`session_context.isSessionSampledIn`** (read-only, also mirrored on `instrumentation_data.otelSpan.attributes` as `cx_rum.session_context.isSessionSampledIn`).

`false` means the event reached export only because its category is listed in `excludeFromSampling` while the session itself was sampled out. A `beforeSend` callback can now keep just crashes/ANRs (or any subset) at low session sample rates — previously this required reflection into SDK internals ([CX-51122](https://coralogix.atlassian.net/browse/CX-51122)).

Mirrors the Android SDK change shipped in 2.19.0 (`coralogix/android-sdk#235`).

## How

- **Stamped at span creation, not read at export**: the sampling decision belongs to the session the span was created in; reading the live flag at export time would mis-attribute spans buffered across a session rotation (the flag is re-rolled per session). The stamp rides `SessionManager.sessionSpanAttributes()` — the single session-stamping path shared by `makeSpan`, custom spans, and network instrumentation.
- **`SessionManager` owns the roll**: it happens inside `performRotationLocked` under `sessionLock`, atomically with the session-identity swap, so no span can pair a fresh `session_id` with the previous session's sampling decision. The exporter filter's flag is fed from that single stored roll (previously the rotation callback rolled independently — filter and stamp could never have agreed otherwise).
- **Visible but read-only in `beforeSend`**: the flag stays in the editable subset (filtering on it is the feature) but the SDK's value is restored after the merge, so tampering has no effect.
- **Default `true` when the stamp is absent** (e.g. events persisted by older SDK versions): a span without the stamp can only have reached export on a sampled-in session.

## Verification (PoC on simulator)

Ran the demo app with a forced worst-case config — session sampled **out**, errors excluded from sampling, and a `beforeSend` that forwards **only ANR events**:

```swift
sessionSampleRate: 0,
excludeFromSampling: [.errors],
...
beforeSend: { cxRum in
    let session = cxRum["session_context"] as? [String: Any]
    let sampledIn = session?["isSessionSampledIn"] as? Bool ?? true
    if !sampledIn {
        let errorType = (cxRum["error_context"] as? [String: Any])?["error_type"] as? String
        guard errorType == "ANR" else {
            return nil   // drop everything else from the sampled-out session
        }
    }
    return cxRum
},
```

Triggered "Simulate ANR" plus other events (errors, taps, navigation) in `DemoAppSwift`. Only the ANR was exported, carrying `isSessionSampledIn: false` — everything else was dropped by the callback.

**PoC session in Coralogix (EU2):** [RUM session — only the ANR arrived](https://c4c.app.eu2.coralogix.com/rum/session?rum-sessions-query-id=aa2e89c51180500972b58bd8cce2967c106c5dc11ac75c2ee544e4db&is-archive=true&from=1785228728831&to=1785229628831&rum-apps=DemoApp-iOS-swift&timestamp=1785229387000&user-name=%3F&has-recording=false&has-screenshot=false&session-event-id=002483dd-5e8b-449b-a4d6-c4145917ec37&session-tab=ACTIONS&session-actions-filter=Navigation,Error)

**A regular session with no beforeSend and sessionSampleRate: 100:** [RUM session - everything arrives correctly](https://c4c.app.eu2.coralogix.com/rum/session?rum-sessions-query-id=5fe08b239c6fef78f71d083377a103fbe0160c296d01b0c0b6888081&is-archive=true&from=1785229924579&to=1785230824579&rum-apps=DemoApp-iOS-swift&timestamp=1785230560000&user-name=%3F&has-recording=false&has-screenshot=false&session-event-id=bdf929e1-61ed-4166-acd0-7b6d4a35d24d&session-tab=ACTIONS&session-actions-filter=Navigation,Network,Click,Error)

Also: full `Coralogix-Package` test suite green (914 passed, 0 failed) incl. 13 new tests in `SessionSamplingFlagTests` covering stamping, rotation reroll, seeding before the roller is installed, payload defaults, `beforeSend` visibility + tamper-resistance, and both otelSpan mirror paths.

## Notes

- Crash-on-relaunch spans initially had the **new** session's stamp; fixed in `af90aad` — the decision is now persisted in the keychain with the session identity, so recovered crashes carry the crashed session's actual decision (defaulting to sampled-in for launches recorded by older SDK versions). Not an issue on Android, which uploads crashes in-process at crash time.
- Follow-up candidate: `passesSessionSampling` still filters on the live flag; now that every span carries its own stamp, filtering on the span attribute would make filter and stamp agree exactly for spans buffered across a rotation.
- Version bumped 2.12.0 → 2.13.0 (new wire field + new documented behavior); CHANGELOG and README updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[CX-51122]: https://coralogix.atlassian.net/browse/CX-51122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
