### PR TITLE
feat: labels on hybrid reportError overloads (2.13.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Release-mechanics commits (version bumps, podspec/script tweaks, README edits) a
 omitted; the focus here is user-facing behavior changes. Tickets are referenced as
 `CX-XXXXX` (Jira) or `ALPH-XXXX` (legacy). Pull request numbers are in parentheses.
 
+## [2.12.1] - 2026-07-28
+
+### Added
+- The hybrid `reportError(message:stackTrace:…)` (React Native) and `reportError(message:obfuscatedStackTrace:…)` (Flutter) overloads now accept an optional `labels` dictionary, so a handled error reported through a hybrid bridge can carry per-event labels in the same call — bringing them in line with the native `error:` / `NSError` / `exception:` overloads. Labels are also preserved for crash events recovered on the next launch.
+
 ## [2.12.0] - 2026-07-26
 
 ### Added

--- a/Coralogix.podspec
+++ b/Coralogix.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "Coralogix"
-  spec.version      = "2.12.0"
+  spec.version      = "2.12.1"
   spec.summary      = "Coralogix OpenTelemetry pod for iOS."
 
   spec.description  = <<-DESC
@@ -29,7 +29,7 @@ Pod::Spec.new do |spec|
 
   spec.static_framework = true
   spec.dependency 'PLCrashReporter', '~> 1.12'
-  spec.dependency 'CoralogixInternal', '2.12.0'
+  spec.dependency 'CoralogixInternal', '2.12.1'
 
   spec.test_spec 'Tests' do |test|
     test.source_files = 'Tests/CoralogixRumTests/**/*.swift'

--- a/Coralogix/Sources/CoralogixRum.swift
+++ b/Coralogix/Sources/CoralogixRum.swift
@@ -302,7 +302,8 @@ public class CoralogixRum {
                             arch: String? = nil,
                             buildId: String? = nil,
                             stackTraceType: String? = nil,
-                            customAttributes: [String: Any]? = nil) {
+                            customAttributes: [String: Any]? = nil,
+                            labels: [String: Any]? = nil) {
         guard CoralogixRum.isInitialized else { return }
         self.reportErrorWith(message: message,
                              stackTrace: stackTrace,
@@ -311,7 +312,8 @@ public class CoralogixRum {
                              arch: arch,
                              buildId: buildId,
                              stackTraceType: stackTraceType,
-                             customAttributes: customAttributes)
+                             customAttributes: customAttributes,
+                             labels: labels)
     }
 
     /// Reports a Dart obfuscated error from Flutter.
@@ -331,14 +333,16 @@ public class CoralogixRum {
                             arch: String? = nil,
                             buildId: String? = nil,
                             stackTraceType: String? = Keys.obfuscated.rawValue,
-                            customAttributes: [String: Any]? = nil) {
+                            customAttributes: [String: Any]? = nil,
+                            labels: [String: Any]? = nil) {
         guard CoralogixRum.isInitialized else { return }
         self.reportErrorWith(message: message,
                              obfuscatedStackTrace: obfuscatedStackTrace,
                              arch: arch,
                              buildId: buildId,
                              stackTraceType: stackTraceType,
-                             customAttributes: customAttributes)
+                             customAttributes: customAttributes,
+                             labels: labels)
     }
     
     public func reportMobileVitalsMeasurement(type: String, metrics: [HybridMetric]) {

--- a/Coralogix/Sources/Instrumentation/ErrorInstrumentation.swift
+++ b/Coralogix/Sources/Instrumentation/ErrorInstrumentation.swift
@@ -82,7 +82,8 @@ extension CoralogixRum {
                          arch: String?,
                          buildId: String?,
                          stackTraceType: String?,
-                         customAttributes: [String: Any]? = nil) {
+                         customAttributes: [String: Any]? = nil,
+                         labels: [String: Any]? = nil) {
         let frames: [[String: Any]] = obfuscatedStackTrace.map { [Keys.virt.rawValue: $0] }
         let stackTraceJson = Helper.convertArrayToJsonString(array: frames)
         reportErrorInternal(message: message,
@@ -90,7 +91,8 @@ extension CoralogixRum {
                             arch: arch,
                             buildId: buildId,
                             stackTraceType: stackTraceType,
-                            customAttributes: customAttributes)
+                            customAttributes: customAttributes,
+                            labels: labels)
     }
 
     // MARK: - Used By React Native
@@ -101,7 +103,8 @@ extension CoralogixRum {
                          arch: String? = nil,
                          buildId: String? = nil,
                          stackTraceType: String? = nil,
-                         customAttributes: [String: Any]? = nil) {
+                         customAttributes: [String: Any]? = nil,
+                         labels: [String: Any]? = nil) {
         let stackTraceJson = Helper.convertArrayToJsonString(array: stackTrace)
         reportErrorInternal(message: message,
                             stackTraceJson: stackTraceJson,
@@ -110,7 +113,8 @@ extension CoralogixRum {
                             arch: arch,
                             buildId: buildId,
                             stackTraceType: stackTraceType,
-                            customAttributes: customAttributes)
+                            customAttributes: customAttributes,
+                            labels: labels)
     }
 
     private func reportErrorInternal(message: String,
@@ -120,7 +124,8 @@ extension CoralogixRum {
                                      arch: String? = nil,
                                      buildId: String? = nil,
                                      stackTraceType: String? = nil,
-                                     customAttributes: [String: Any]? = nil) {
+                                     customAttributes: [String: Any]? = nil,
+                                     labels: [String: Any]? = nil) {
         guard isErrorsEnabled else { return }
         var persistedEventId: String?
         if isCrash {
@@ -133,7 +138,8 @@ extension CoralogixRum {
                                                       arch: arch,
                                                       buildId: buildId,
                                                       stackTraceType: stackTraceType,
-                                                      customAttributes: customAttributes)
+                                                      customAttributes: customAttributes,
+                                                      labels: labels)
         }
         self.writeError(
             domain: "",
@@ -145,6 +151,7 @@ extension CoralogixRum {
             buildId: buildId,
             stackTraceType: stackTraceType,
             customAttributes: customAttributes,
+            labels: labels,
             crashEventId: persistedEventId
         )
         if isCrash {
@@ -167,7 +174,8 @@ extension CoralogixRum {
                                    arch: String?,
                                    buildId: String?,
                                    stackTraceType: String?,
-                                   customAttributes: [String: Any]?) -> String {
+                                   customAttributes: [String: Any]?,
+                                   labels: [String: Any]?) -> String {
         var event: [String: Any] = [
             Keys.errorMessage.rawValue: message,
             Keys.crashTimestamp.rawValue: String(Date().timeIntervalSince1970.milliseconds)
@@ -182,6 +190,9 @@ extension CoralogixRum {
         // write and silently drop the crash backup.
         if let json = Helper.jsonAttributeString(dict: customAttributes) {
             event[Keys.data.rawValue] = json
+        }
+        if let json = Helper.jsonAttributeString(dict: labels) {
+            event[Keys.customLabels.rawValue] = json
         }
         return crashEventStore.append(event)
     }
@@ -206,6 +217,8 @@ extension CoralogixRum {
                 buildId: event[Keys.buildId.rawValue] as? String,
                 stackTraceType: event[Keys.stackTraceType.rawValue] as? String,
                 customAttributes: (event[Keys.data.rawValue] as? String)
+                    .flatMap { Helper.convertJsonStringToDict(jsonString: $0) },
+                labels: (event[Keys.customLabels.rawValue] as? String)
                     .flatMap { Helper.convertJsonStringToDict(jsonString: $0) },
                 crashTimestamp: event[Keys.crashTimestamp.rawValue] as? String,
                 crashEventId: event[CrashEventStore.eventIdKey] as? String

--- a/CoralogixInternal.podspec
+++ b/CoralogixInternal.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "CoralogixInternal"
-  spec.version      = "2.12.0"
+  spec.version      = "2.12.1"
   spec.summary      = "Coralogix Internal Package. This module is not for public use."
 
   spec.description  = <<-DESC

--- a/CoralogixInternal/Sources/Utils.swift
+++ b/CoralogixInternal/Sources/Utils.swift
@@ -16,7 +16,7 @@ public enum ImageFormat {
 }
 
 public enum Global: String {
-    case sdk = "2.12.0"
+    case sdk = "2.12.1"
     case swiftVersion = "5.9"
     case coralogixPath = "/browser/v1beta/logs"
     case sessionReplayPath = "/browser/alpha/sessionrecording"

--- a/SessionReplay.podspec
+++ b/SessionReplay.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "SessionReplay"
-  spec.version      = "2.12.0"
+  spec.version      = "2.12.1"
   spec.summary      = "Coralogix Session-Replay pod for iOS."
 
   spec.description  = <<-DESC
@@ -23,7 +23,7 @@ Pod::Spec.new do |spec|
   spec.static_framework = true
 
   spec.source_files  = 'SessionReplay/Sources/**/*.swift'
-  spec.dependency 'CoralogixInternal', '2.12.0'
+  spec.dependency 'CoralogixInternal', '2.12.1'
   
     spec.test_spec 'Tests' do |test|
         test.source_files = 'Tests/SessionReplayTests/**/*.swift'

--- a/Tests/CoralogixRumTests/CrashDeliveryTests.swift
+++ b/Tests/CoralogixRumTests/CrashDeliveryTests.swift
@@ -310,6 +310,29 @@ final class CrashDeliveryTests: XCTestCase {
         XCTAssertEqual(persisted.first?[Keys.errorMessage.rawValue] as? String, "fatal-with-date-attr")
     }
 
+    func test_reportCrash_persistsLabelsForReEmit() throws {
+        coralogixRum = CoralogixRum(options: makeSamplingOptions(sampleRate: 100, exclude: []))
+        let uploader = StubUploader()
+        uploader.result = .failure
+        coralogixRum.coralogixExporter?.spanUploader = uploader
+        let store = makeTempStore()
+        coralogixRum.crashEventStore = store
+
+        coralogixRum.reportError(message: "fatal-with-labels",
+                                 stackTrace: [],
+                                 errorType: "Error",
+                                 isCrash: true,
+                                 customAttributes: ["order_id": "A-1001"],
+                                 labels: ["team": "payments"])
+
+        // Labels must be persisted alongside the crash so the re-emit on the next
+        // launch carries them — the same durability guarantee as customAttributes.
+        let event = try XCTUnwrap(store.loadAll().first)
+        let labelsJson = try XCTUnwrap(event[Keys.customLabels.rawValue] as? String)
+        let labels = try XCTUnwrap(Helper.convertJsonStringToDict(jsonString: labelsJson))
+        XCTAssertEqual(labels["team"] as? String, "payments")
+    }
+
     func test_reportCrash_persistsToDisk_evenWhenUploadFails() {
         coralogixRum = CoralogixRum(options: makeSamplingOptions(sampleRate: 100, exclude: []))
         let uploader = StubUploader()

--- a/Tests/CoralogixRumTests/ReportErrorDataLabelsTests.swift
+++ b/Tests/CoralogixRumTests/ReportErrorDataLabelsTests.swift
@@ -122,4 +122,43 @@ final class ReportErrorDataLabelsTests: XCTestCase {
         let labels = try XCTUnwrap(result.cxRum[Keys.labels.rawValue] as? [String: Any])
         XCTAssertEqual(labels["severity_tag"] as? String, "high")
     }
+
+    // MARK: - Hybrid stack-trace paths (React Native / Flutter) carry data + labels
+
+    func test_reportError_stackTrace_customAttributesUnderErrorCustomData_andLabels() throws {
+        let result = try reportAndCaptureErrorEvent(expectedMessage: "rn boom") { rum in
+            rum.reportError(
+                message: "rn boom",
+                stackTrace: [["functionName": "doThing", "fileName": "index.js", "lineNumber": 42]],
+                errorType: "Error",
+                customAttributes: ["order_id": "A-1001"],
+                labels: ["team": "payments"]
+            )
+        }
+        let data = try XCTUnwrap(result.errorContext[Keys.errorCustomData.rawValue] as? [String: Any],
+                                 "hybrid stackTrace customAttributes must ship under error_custom_data")
+        XCTAssertEqual(data["order_id"] as? String, "A-1001")
+        let labels = try XCTUnwrap(result.cxRum[Keys.labels.rawValue] as? [String: Any],
+                                   "hybrid stackTrace labels must merge into cx_rum.labels")
+        XCTAssertEqual(labels["team"] as? String, "payments")
+    }
+
+    func test_reportError_obfuscatedStackTrace_customAttributesUnderErrorCustomData_andLabels() throws {
+        let result = try reportAndCaptureErrorEvent(expectedMessage: "flutter boom") { rum in
+            rum.reportError(
+                message: "flutter boom",
+                obfuscatedStackTrace: ["0x00000000003da15f"],
+                arch: "arm64",
+                buildId: "abc123",
+                customAttributes: ["screen": "cart"],
+                labels: ["severity_tag": "high"]
+            )
+        }
+        let data = try XCTUnwrap(result.errorContext[Keys.errorCustomData.rawValue] as? [String: Any],
+                                 "hybrid obfuscated customAttributes must ship under error_custom_data")
+        XCTAssertEqual(data["screen"] as? String, "cart")
+        let labels = try XCTUnwrap(result.cxRum[Keys.labels.rawValue] as? [String: Any],
+                                   "hybrid obfuscated labels must merge into cx_rum.labels")
+        XCTAssertEqual(labels["severity_tag"] as? String, "high")
+    }
 }


### PR DESCRIPTION
## What

Adds an optional `labels:` dictionary to the two hybrid `reportError` overloads used by the React Native and Flutter bridges:

- `reportError(message:stackTrace:errorType:isCrash:…customAttributes:labels:)` (React Native)
- `reportError(message:obfuscatedStackTrace:…customAttributes:labels:)` (Flutter)

`labels` is threaded symmetrically with the existing `customAttributes` through `reportErrorWith` → `reportErrorInternal` → `writeError` (→ `Keys.customLabels`), **and** through the crash-persist (`persistCrashEvent`) and next-launch re-emit (`resendPendingStoredCrashEvents`) paths, so labels on a fatal hybrid error survive process death.

This brings the hybrid overloads in line with the native `error:` / `NSError` / `exception:` overloads that already accept `data` + `labels` (2.12.0). `customAttributes` on these overloads already ships under `error_custom_data`, so no change was needed there.

## Why

Native enabler for the hybrid `reportError` data & labels work:
- **CX-51259** (React Native) — needs `labels` on the `stackTrace` overload.
- **CX-51261** (Flutter) — needs `labels` on the `obfuscatedStackTrace` overload.

The 2.12.0 release added `data`/`labels` only to the native (non-stack-trace) overloads; the hybrid overloads were missed, which blocked both plugins from forwarding labels. This closes that gap.

## Compatibility

Purely additive — the new parameter defaults to `nil`, so it's source- and binary-compatible. No behavior change for existing callers. Patch bump **2.12.0 → 2.12.1**.

## Tests

- `ReportErrorDataLabelsTests` — two new tests assert both hybrid overloads land `customAttributes` under `error_custom_data` and `labels` under `cx_rum.labels`.
- `CrashDeliveryTests` — new test asserts a fatal error's `labels` are persisted for next-launch re-emit.
- Full `CoralogixRumTests` suite: **778 passing, 0 failures** (iPhone 17 simulator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)