### PR TITLE
fix(CX-51747): session sampling drops buffered spans on rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ omitted; the focus here is user-facing behavior changes. Tickets are referenced 
 ## [2.13.2] - 2026-07-30
 
 ### Fixed
-- Per-session sampling no longer drops events that were buffered across a session rotation. The keep/drop decision at export now uses the sampling decision stamped on each event when it was created, instead of the current session's live decision — so an event from a sampled-in session is not lost when the session rotates to a sampled-out one (with `sessionSampleRate < 100` and `excludeFromSampling` set) before the event is sent.
+- Fixed events being dropped during a session change when per-session sampling is in use.
 
 ## [2.13.1] - 2026-07-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Release-mechanics commits (version bumps, podspec/script tweaks, README edits) a
 omitted; the focus here is user-facing behavior changes. Tickets are referenced as
 `CX-XXXXX` (Jira) or `ALPH-XXXX` (legacy). Pull request numbers are in parentheses.
 
+## [2.13.2] - 2026-07-30
+
+### Fixed
+- Per-session sampling no longer drops events that were buffered across a session rotation. The keep/drop decision at export now uses the sampling decision stamped on each event when it was created, instead of the current session's live decision — so an event from a sampled-in session is not lost when the session rotates to a sampled-out one (with `sessionSampleRate < 100` and `excludeFromSampling` set) before the event is sent.
+
 ## [2.13.1] - 2026-07-28
 
 ### Added

--- a/Coralogix.podspec
+++ b/Coralogix.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "Coralogix"
-  spec.version      = "2.13.1"
+  spec.version      = "2.13.2"
   spec.summary      = "Coralogix OpenTelemetry pod for iOS."
 
   spec.description  = <<-DESC
@@ -29,7 +29,7 @@ Pod::Spec.new do |spec|
 
   spec.static_framework = true
   spec.dependency 'PLCrashReporter', '~> 1.12'
-  spec.dependency 'CoralogixInternal', '2.13.1'
+  spec.dependency 'CoralogixInternal', '2.13.2'
 
   spec.test_spec 'Tests' do |test|
     test.source_files = 'Tests/CoralogixRumTests/**/*.swift'

--- a/Coralogix/Sources/Exporter/CoralogixExporter.swift
+++ b/Coralogix/Sources/Exporter/CoralogixExporter.swift
@@ -360,12 +360,19 @@ public class CoralogixExporter: SpanExporter {
     }
 
     /// Returns `true` if the span should proceed past the per-session sampling filter.
-    /// When the session is sampled in, every span passes. When sampled out, only spans whose
-    /// `event_type` attribute matches an opt-in entry in `options.excludeFromSampling` pass.
-    /// Spans missing an `event_type` attribute are dropped on sampled-out sessions.
+    /// When the span's own `is_session_sampled_in` stamp is true, every span passes. When it is
+    /// false, only spans whose `event_type` attribute matches an opt-in entry in
+    /// `options.excludeFromSampling` pass. Spans missing an `event_type` attribute are dropped
+    /// when stamped sampled-out.
     /// Internal (rather than private per the ticket) so unit tests can exercise it directly.
     internal func passesSessionSampling(_ span: SpanDataProtocol) -> Bool {
-        if isCurrentSessionSampledIn() { return true }
+        // The sampling decision belongs to the session the span was created in, not the live one.
+        // Read the per-span stamp SessionManager burns at creation rather than the live
+        // `currentSessionSampledIn` flag: a span created in a sampled-in session but exported
+        // after a rotation to a sampled-out session must still be kept. A missing stamp (older
+        // spans) defaults to sampled-in so nothing is dropped by omission.
+        let sampledIn = attributeStringValue(forKey: Keys.spanSessionSampledIn.rawValue, span: span).map { $0 == "true" } ?? true
+        if sampledIn { return true }
 
         guard let eventType = attributeStringValue(forKey: Keys.eventType.rawValue, span: span) else {
             return false

--- a/CoralogixInternal.podspec
+++ b/CoralogixInternal.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "CoralogixInternal"
-  spec.version      = "2.13.1"
+  spec.version      = "2.13.2"
   spec.summary      = "Coralogix Internal Package. This module is not for public use."
 
   spec.description  = <<-DESC

--- a/CoralogixInternal/Sources/Utils.swift
+++ b/CoralogixInternal/Sources/Utils.swift
@@ -16,7 +16,7 @@ public enum ImageFormat {
 }
 
 public enum Global: String {
-    case sdk = "2.13.1"
+    case sdk = "2.13.2"
     case swiftVersion = "5.9"
     case coralogixPath = "/browser/v1beta/logs"
     case sessionReplayPath = "/browser/alpha/sessionrecording"

--- a/SessionReplay.podspec
+++ b/SessionReplay.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "SessionReplay"
-  spec.version      = "2.13.1"
+  spec.version      = "2.13.2"
   spec.summary      = "Coralogix Session-Replay pod for iOS."
 
   spec.description  = <<-DESC
@@ -23,7 +23,7 @@ Pod::Spec.new do |spec|
   spec.static_framework = true
 
   spec.source_files  = 'SessionReplay/Sources/**/*.swift'
-  spec.dependency 'CoralogixInternal', '2.13.1'
+  spec.dependency 'CoralogixInternal', '2.13.2'
   
     spec.test_spec 'Tests' do |test|
         test.source_files = 'Tests/SessionReplayTests/**/*.swift'

--- a/Tests/CoralogixRumTests/HybridAPITests.swift
+++ b/Tests/CoralogixRumTests/HybridAPITests.swift
@@ -438,8 +438,8 @@ final class HybridAPITests: XCTestCase {
         exporter.spanUploader = SamplingMockSpanUploader()
 
         _ = exporter.export(spans: [
-            makeSamplingSpan(eventType: .log),
-            makeSamplingSpan(eventType: .networkRequest)
+            makeSamplingSpan(eventType: .log, sampledIn: false),
+            makeSamplingSpan(eventType: .networkRequest, sampledIn: false)
         ], explicitTimeout: nil)
 
         XCTAssertEqual(capture.eventTypes, ["log"],

--- a/Tests/CoralogixRumTests/LogSamplingDecouplingTests.swift
+++ b/Tests/CoralogixRumTests/LogSamplingDecouplingTests.swift
@@ -53,9 +53,9 @@ final class LogSamplingDecouplingTests: XCTestCase {
         exporter.spanUploader = SamplingMockSpanUploader()
 
         _ = exporter.export(spans: [
-            makeSamplingSpan(eventType: .log),
-            makeSamplingSpan(eventType: .error),
-            makeSamplingSpan(eventType: .networkRequest)
+            makeSamplingSpan(eventType: .log, sampledIn: false),
+            makeSamplingSpan(eventType: .error, sampledIn: false),
+            makeSamplingSpan(eventType: .networkRequest, sampledIn: false)
         ], explicitTimeout: nil)
 
         XCTAssertEqual(capture.eventTypes, ["log"],
@@ -140,10 +140,10 @@ final class LogSamplingDecouplingTests: XCTestCase {
         exporter.spanUploader = SamplingMockSpanUploader()
 
         _ = exporter.export(spans: [
-            makeSamplingSpan(eventType: .log),
-            makeSamplingSpan(eventType: .error),
-            makeSamplingSpan(eventType: .networkRequest),
-            makeSamplingSpan(eventType: .mobileVitals)
+            makeSamplingSpan(eventType: .log, sampledIn: false),
+            makeSamplingSpan(eventType: .error, sampledIn: false),
+            makeSamplingSpan(eventType: .networkRequest, sampledIn: false),
+            makeSamplingSpan(eventType: .mobileVitals, sampledIn: false)
         ], explicitTimeout: nil)
 
         XCTAssertEqual(Set(capture.eventTypes), Set(["log", "error"]),
@@ -179,7 +179,7 @@ final class LogSamplingDecouplingTests: XCTestCase {
         // not across calls, so the duplicate spanId here is harmless.
         group.enter()
         DispatchQueue.global(qos: .userInitiated).async {
-            let span = makeSamplingSpan(eventType: .log)
+            let span = makeSamplingSpan(eventType: .log, sampledIn: false)
             for _ in 0..<iterations {
                 _ = exporter.export(spans: [span], explicitTimeout: nil)
             }

--- a/Tests/CoralogixRumTests/LogSamplingDecouplingTests.swift
+++ b/Tests/CoralogixRumTests/LogSamplingDecouplingTests.swift
@@ -150,6 +150,30 @@ final class LogSamplingDecouplingTests: XCTestCase {
                        "Sampled-out + exclude=[.logs, .errors] must let exactly those two categories through.")
     }
 
+    // MARK: - Reverse rotation: live sampled-in must not over-include a stale sampled-out span
+
+    func testReverseRotation_liveSampledIn_staleSampledOutSpanDropped() throws {
+        // Mirror of the rotation guard: the live session is sampled IN, but the batch still carries
+        // a stale non-excluded span stamped sampled-OUT (created before a rotation into this session).
+        // It must be dropped from its own stamp, not over-included because the live session is sampled in.
+        let capture = EventTypeCapture()
+        let rum = CoralogixRum(options: makeSamplingOptions(sampleRate: 100,
+                                                            exclude: [],
+                                                            tracesExporter: capture.tracesExporterCallback()))
+        defer { rum.shutdown() }
+
+        let exporter = try requireExporter(rum)
+        exporter.spanUploader = SamplingMockSpanUploader()
+
+        _ = exporter.export(spans: [
+            makeSamplingSpan(eventType: .networkRequest, sampledIn: false), // stale, sampled-out
+            makeSamplingSpan(eventType: .error, sampledIn: true)            // current, sampled-in
+        ], explicitTimeout: nil)
+
+        XCTAssertEqual(capture.eventTypes, ["error"],
+                       "Live session sampled-in must not over-include a stale sampled-out span; only the sampled-in span survives.")
+    }
+
     // MARK: - Case 6: thread-safety smoke — rotate on one queue while exporting on another
 
     func testCase6_sessionRotation_concurrentWithExport_threadSafetySmoke() throws {

--- a/Tests/CoralogixRumTests/SamplingTestHelpers.swift
+++ b/Tests/CoralogixRumTests/SamplingTestHelpers.swift
@@ -105,9 +105,14 @@ func makeSamplingOptions(sampleRate: Int,
 /// Builds a `SpanData` that survives the encoding pipeline (`CxRumBuilder.build()` requires
 /// session attributes) and carries the `event_type` under test. No `httpUrl`, no
 /// `errorMessage`, so the URL and error filters in `export()` are no-ops.
-func makeSamplingSpan(eventType: CoralogixEventType) -> SpanData {
+///
+/// Carries the per-span `is_session_sampled_in` stamp SessionManager burns at creation, since
+/// the export sampling filter reads that stamp (not the exporter's live flag). Defaults to
+/// `sampledIn: true` — the sampled-in / filter-no-op case; sampled-out sessions pass `false`.
+func makeSamplingSpan(eventType: CoralogixEventType, sampledIn: Bool = true) -> SpanData {
     let attributes: [String: AttributeValue] = [
         Keys.eventType.rawValue: AttributeValue(eventType.rawValue),
+        Keys.spanSessionSampledIn.rawValue: AttributeValue(sampledIn ? "true" : "false"),
         Keys.severity.rawValue: AttributeValue("3"),
         Keys.source.rawValue: AttributeValue("console"),
         Keys.environment.rawValue: AttributeValue("test"),

--- a/Tests/CoralogixRumTests/SessionSamplingFilterTests.swift
+++ b/Tests/CoralogixRumTests/SessionSamplingFilterTests.swift
@@ -1,12 +1,14 @@
 //
 //  SessionSamplingFilterTests.swift
 //
-//  Verifies the per-span sampling filter at the top of CoralogixExporter.export():
-//    - Sampled in: every span passes regardless of event_type.
-//    - Sampled out: only spans whose event_type is in options.excludeFromSampling pass.
-//    - Sampled out + missing event_type: dropped (failsafe).
-//    - Sampled out + empty excludes: nothing passes (production-unreachable but invariant
-//      holds when the flag is flipped manually, e.g. on a rotation that happens to roll out).
+//  Verifies the per-span sampling filter at the top of CoralogixExporter.export(). The
+//  decision is driven by each span's own `is_session_sampled_in` stamp (burned at creation),
+//  NOT the exporter's live flag — so a span keeps the decision of the session it was born in
+//  even after a rotation flips the live flag:
+//    - Stamped sampled-in: every span passes regardless of event_type.
+//    - Stamped sampled-out: only spans whose event_type is in options.excludeFromSampling pass.
+//    - Stamped sampled-out + missing event_type: dropped (failsafe).
+//    - Stamped sampled-out + empty excludes: nothing passes.
 //
 
 import XCTest
@@ -25,11 +27,11 @@ final class SessionSamplingFilterTests: XCTestCase {
     func testPassesSessionSampling_sampledIn_passesEverySpan() {
         let exporter = makeExporter(sampleRate: 100, exclude: [])
 
-        XCTAssertTrue(exporter.passesSessionSampling(span(eventType: "log")))
-        XCTAssertTrue(exporter.passesSessionSampling(span(eventType: "network-request")))
-        XCTAssertTrue(exporter.passesSessionSampling(span(eventType: "error")))
-        XCTAssertTrue(exporter.passesSessionSampling(span(eventType: nil)),
-                      "Sampled-in must pass even spans missing event_type — only sampled-out enforces it.")
+        XCTAssertTrue(exporter.passesSessionSampling(span(eventType: "log", sampledIn: true)))
+        XCTAssertTrue(exporter.passesSessionSampling(span(eventType: "network-request", sampledIn: true)))
+        XCTAssertTrue(exporter.passesSessionSampling(span(eventType: "error", sampledIn: true)))
+        XCTAssertTrue(exporter.passesSessionSampling(span(eventType: nil, sampledIn: true)),
+                      "A sampled-in stamp must pass even spans missing event_type — only sampled-out enforces it.")
     }
 
     // MARK: - Sampled out + non-empty excludes
@@ -84,11 +86,10 @@ final class SessionSamplingFilterTests: XCTestCase {
     // MARK: - Sampled out + empty excludes (manually flipped)
 
     func testPassesSessionSampling_sampledOutEmptyExcludes_dropsEverything() {
-        // sampleRate=100 + exclude=[] inits with sampledIn=true; manually flip to false to
-        // exercise the "empty excludes + sampled out" invariant. (Production cannot reach this
-        // pair because init would short-circuit, but the filter must still hold.)
+        // Sampled-out stamp with no opt-ins: every span drops, whatever its event_type.
+        // (Production cannot reach a sampled-out session with empty excludes because init
+        // short-circuits, but the filter must still hold.)
         let exporter = makeExporter(sampleRate: 100, exclude: [])
-        exporter.updateSessionSampling(sampledIn: false)
 
         XCTAssertFalse(exporter.passesSessionSampling(span(eventType: "error")))
         XCTAssertFalse(exporter.passesSessionSampling(span(eventType: "log")))
@@ -99,13 +100,38 @@ final class SessionSamplingFilterTests: XCTestCase {
 
     func testPassesSessionSampling_sampledOut_eventTypeAsRawString_stillMatches() {
         // Belt-and-suspenders: the extraction helper supports both AttributeValue and raw String
-        // attribute encodings. Default span() uses AttributeValue; build one with a raw String
-        // to confirm the fallback branch.
+        // attribute encodings. Build both the stamp and the event_type as raw Strings to confirm
+        // the fallback branch on each — the sampled-out stamp forces the event_type match to run.
         let exporter = makeExporter(sampleRate: 0, exclude: [.logs])
-        let mock = MockSpanData(attributes: [Keys.eventType.rawValue: "log"],
+        let mock = MockSpanData(attributes: [Keys.spanSessionSampledIn.rawValue: "false",
+                                             Keys.eventType.rawValue: "log"],
                                 statusCode: nil, resources: nil)
 
         XCTAssertTrue(exporter.passesSessionSampling(mock))
+    }
+
+    // MARK: - Stamp drives the decision, not the exporter's live flag
+
+    func testPassesSessionSampling_stampSampledIn_survivesRotationToSampledOut() {
+        // Data-loss regression: a span created in a sampled-in session and exported only after a
+        // rotation flipped the live flag to sampled-out must still be kept. The decision rides on
+        // the span's own stamp, not the current session's flag.
+        let exporter = makeExporter(sampleRate: 100, exclude: [])
+        exporter.updateSessionSampling(sampledIn: false) // simulate a rotation to a sampled-out session
+
+        XCTAssertTrue(exporter.passesSessionSampling(span(eventType: "network-request", sampledIn: true)),
+                      "A span stamped sampled-in must not be dropped because the live session rotated out.")
+    }
+
+    func testPassesSessionSampling_stampSampledOut_droppedEvenWhenLiveFlagSampledIn() {
+        // Mirror image: a span stamped sampled-out with a non-excluded event_type must still be
+        // dropped while the live session is sampled in — proving the filter reads the stamp and
+        // isn't simply always-true.
+        let exporter = makeExporter(sampleRate: 0, exclude: [.errors])
+        exporter.updateSessionSampling(sampledIn: true) // live session is sampled in
+
+        XCTAssertFalse(exporter.passesSessionSampling(span(eventType: "network-request", sampledIn: false)),
+                       "A span stamped sampled-out with a non-excluded event_type must drop regardless of the live flag.")
     }
 
     // MARK: - Helpers
@@ -142,8 +168,13 @@ final class SessionSamplingFilterTests: XCTestCase {
         return exporter
     }
 
-    private func span(eventType: String?) -> MockSpanData {
-        var attrs: [String: Any] = [:]
+    /// Builds a span carrying the per-span sampling stamp the filter now reads. Defaults to
+    /// `sampledIn: false` since most cases here exercise the sampled-out branch; the sampled-in
+    /// case passes `true` explicitly.
+    private func span(eventType: String?, sampledIn: Bool = false) -> MockSpanData {
+        var attrs: [String: Any] = [
+            Keys.spanSessionSampledIn.rawValue: AttributeValue(sampledIn ? "true" : "false")
+        ]
         if let eventType = eventType {
             attrs[Keys.eventType.rawValue] = AttributeValue(eventType)
         }


### PR DESCRIPTION
## Bug (CX-51747)
The per-session sampling **drop at export** read the *live* current-session flag instead of the `is_session_sampled_in` value **stamped on each span at creation**. A span created in a sampled-in session but exported after a rotation to a sampled-out session (`sessionSampleRate < 100` with `excludeFromSampling` set) was **wrongly dropped** — data loss. Regression from the `isSessionSampledIn` feature (2.13.0).

## Fix
`CoralogixExporter.passesSessionSampling` now reads the per-span `Keys.spanSessionSampledIn` stamp (default `true` when absent) instead of `isCurrentSessionSampledIn()`, so each span keeps the sampling decision of the session it belongs to — buffered spans survive a rotation correctly.

The live `updateSessionSampling` / `currentSessionSampledIn` / `samplingReevaluationCallback` machinery is now unused by the drop decision; left in place for a small follow-up cleanup (kept this fix minimal).

## Tests
- New regression tests: a stamped-sampled-in span survives a rotation to sampled-out (the data-loss guard, fails on the old code); a stamped-sampled-out span still drops under a live sampled-in session.
- Existing sampled-out tests re-stamp their setup spans to match production (`SessionManager` stamps every span); assertions unchanged.
- Full `CoralogixRumTests` suite: **797 pass**.

Patch bump **2.13.1 → 2.13.2**. No public API change. Android counterpart: CX-51748.

🤖 Generated with [Claude Code](https://claude.com/claude-code)