### PR TITLE
CX-52295 fix: inherit masking and suppress tap markers over masked regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ Release-mechanics commits (version bumps, podspec/script tweaks, README edits) a
 omitted; the focus here is user-facing behavior changes. Tickets are referenced as
 `CX-XXXXX` (Jira) or `ALPH-XXXX` (legacy). Pull request numbers are in parentheses.
 
+## [2.13.3] - 2026-08-05
+
+### Fixed
+- Masking now applies to everything inside a masked view, not just the view it was set on. Masking a container is enough to cover its contents, including individually tappable subviews.
+- Tapping inside a masked area no longer draws a tap marker in session replays, so a recording of a masked keypad no longer reveals which keys were pressed. The frame is still recorded, and interaction events still carry their touch coordinates.
+- User interaction events now report `***` for the text of any view inside a masked area. Previously only the masked view itself was redacted, so a tap on a key inside a masked keypad sent the key's label in clear.
+
+### Changed
+- Redacted `target_element_inner_text` is now reported as `***` rather than omitted, matching the Android SDK. This affects views rejected by `shouldSendText`, password fields, and fields with a sensitive `textContentType`, which previously sent no `target_element_inner_text` at all.
+
 ## [2.13.2] - 2026-07-30
 
 ### Fixed

--- a/Coralogix.podspec
+++ b/Coralogix.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "Coralogix"
-  spec.version      = "2.13.2"
+  spec.version      = "2.13.3"
   spec.summary      = "Coralogix OpenTelemetry pod for iOS."
 
   spec.description  = <<-DESC
@@ -29,7 +29,7 @@ Pod::Spec.new do |spec|
 
   spec.static_framework = true
   spec.dependency 'PLCrashReporter', '~> 1.12'
-  spec.dependency 'CoralogixInternal', '2.13.2'
+  spec.dependency 'CoralogixInternal', '2.13.3'
 
   spec.test_spec 'Tests' do |test|
     test.source_files = 'Tests/CoralogixRumTests/**/*.swift'

--- a/Coralogix/Sources/Instrumentation/TapDataExtractor.swift
+++ b/Coralogix/Sources/Instrumentation/TapDataExtractor.swift
@@ -231,7 +231,10 @@ final class ScrollTracker {
 enum TapDataExtractor {
     /// - Parameter shouldSendText: Optional delegate from `CoralogixExporterOptions`.
     ///   When provided, it is called with the view and candidate text before recording
-    ///   `target_element_inner_text`. Return `false` to suppress the text for that view.
+    ///   `target_element_inner_text`. Return `false` to redact the text to `***` — the key is
+    ///   still reported, so a redacted tap stays distinguishable from one on an element with no
+    ///   text. Views that are already masked never reach this delegate and their text is never
+    ///   passed to it; see the redaction rules at the call site below.
     /// - Parameter resolveTargetName: Optional delegate from `CoralogixExporterOptions`.
     ///   When provided, its return value replaces the UIKit class name in `target_element`.
     ///   Returning `nil` falls back to the resolved class name.
@@ -321,7 +324,7 @@ enum TapDataExtractor {
     /// holding sensitive PII — a password mask or a sensitive `textContentType`.
     /// This is intentionally checked via `UITextInputTraits` so it applies uniformly to
     /// `UITextField`, `UITextView`, and `UISearchBar` without repeating logic per class.
-    private static func hasSensitivePIIProperties(_ view: UIView) -> Bool {
+    static func hasSensitivePIIProperties(_ view: UIView) -> Bool {
         guard let traits = view as? UITextInputTraits else { return false }
         if traits.isSecureTextEntry == true { return true }
         if let contentType = traits.textContentType.flatMap({ $0 }),
@@ -329,16 +332,10 @@ enum TapDataExtractor {
         return false
     }
 
-    /// Returns developer-authored or user-typed (non-sensitive) text for a tapped view.
+    /// Returns the text a tapped view displays, whether or not it is sensitive.
     ///
-    /// **Property-based block (always nil — sensitive PII signals present):**
-    /// Text input views (`UITextField`, `UITextView`, `UISearchBar`) are blocked when iOS
-    /// system properties explicitly mark the field as sensitive:
-    /// - `isSecureTextEntry == true` (password / PIN masking)
-    /// - `textContentType` is `.password`, `.newPassword`, or `.creditCardNumber`
-    ///
-    /// **Text extraction (non-sensitive input and developer-authored text):**
-    /// - `UITextField` / `UITextView` / `UISearchBar` → current text (if non-sensitive)
+    /// **Text extraction:**
+    /// - `UITextField` / `UITextView` / `UISearchBar` → current text
     /// - `UIButton`           → button title
     /// - `UILabel`            → label text
     /// - `UITableViewCell`    → `UIListContentConfiguration.text` (iOS 14+), else `textLabel`
@@ -346,23 +343,14 @@ enum TapDataExtractor {
     /// - `UIDatePicker`, `UIStepper` → no text property; fall through to `accessibilityLabel`
     ///
     /// **Fallback:** `accessibilityLabel` — always developer-set, never user-typed.
-    static func safeInnerText(from view: UIView) -> String? {
-        // --- Property-based PII block ---
-        // Checked before any type-specific extraction so it applies to all input classes.
-        if hasSensitivePIIProperties(view) { return nil }
-
-        return rawInnerText(from: view)
-    }
-
-    /// The text `safeInnerText` would extract, without the sensitive-PII block.
     ///
-    /// Split out so a caller can tell "this view has sensitive text" apart from "this view has no
-    /// text" — `safeInnerText` answers nil to both, which is the right answer when the text is
-    /// about to be reported verbatim, but not when it is about to be redacted to `***`.
+    /// Deliberately does **not** apply the sensitive-PII block, so a caller can tell "this view
+    /// has sensitive text" apart from "this view has no text" — a distinction that matters once
+    /// the answer is redaction to `***` rather than omission. Pair it with
+    /// `hasSensitivePIIProperties` before reporting anything.
     ///
-    /// Callers that reach for this take on the obligation not to let the value escape: it may be
-    /// a password. Report `Keys.maskedInnerText` in its place, and never hand it to a customer
-    /// callback.
+    /// Callers take on the obligation not to let the value escape: it may be a password. Report
+    /// `Keys.maskedInnerText` in its place, and never hand it to a customer callback.
     static func rawInnerText(from view: UIView) -> String? {
         // --- Text input views (non-sensitive) ---
         if let textField = view as? UITextField {

--- a/Coralogix/Sources/Instrumentation/TapDataExtractor.swift
+++ b/Coralogix/Sources/Instrumentation/TapDataExtractor.swift
@@ -264,6 +264,15 @@ enum TapDataExtractor {
         // flag it as sensitive (password field, sensitive textContentType), or when the caller's
         // shouldSendText delegate rejects it. The delegate is consulted last and only for text
         // that is not already redacted — a password must not reach the customer's closure.
+        //
+        // Covers UIKit `cxMask` only. SwiftUI's `.cxMask()` installs a non-hit-testing overlay
+        // *sibling*, so a masked composable's content is never below the overlay in the superview
+        // chain and `isInsideMaskedSubtree` is false for it — its pixels and tap marker are masked
+        // (the overlay contributes a real mask rect) but its text is not. `isSecureTextEntry` and
+        // a sensitive `textContentType` still redact, so SwiftUI `SecureField` is covered either
+        // way; a plainly-typed masked field is not. Closing this needs the tap tested against the
+        // frame's mask rects instead of the view tree, which would make every tap a hierarchy
+        // walk — deliberately deferred, and documented in the SessionReplay README.
         if !isContainerView(resolvedClassName),
            let innerText = rawInnerText(from: view),
            !innerText.isEmpty {

--- a/Coralogix/Sources/Instrumentation/TapDataExtractor.swift
+++ b/Coralogix/Sources/Instrumentation/TapDataExtractor.swift
@@ -254,17 +254,23 @@ enum TapDataExtractor {
             tapData[Keys.elementId.rawValue] = accessibilityId
         }
 
-        // target_element_inner_text: PII-safe text only.
-        // Container views are skipped (they span many items; text would be ambiguous).
-        // Input views (UITextField, UITextView, UISearchBar) are always skipped —
-        // they hold user-typed content which may be passwords, emails, or other PII.
-        // If the caller supplied a shouldSendText delegate, it is the final gate:
-        // returning false suppresses the text even when all SDK-side checks pass.
+        // target_element_inner_text: redacted text, never omitted text.
+        // Container views are skipped (they span many items; text would be ambiguous), and a view
+        // with no text at all reports nothing. Everything else reports either its text or `***`,
+        // so a masked tap is visibly masked rather than indistinguishable from a tap on something
+        // that had nothing to say. Matches the Android SDK.
+        //
+        // Text is redacted when the view is inside a masked subtree, when iOS system properties
+        // flag it as sensitive (password field, sensitive textContentType), or when the caller's
+        // shouldSendText delegate rejects it. The delegate is consulted last and only for text
+        // that is not already redacted — a password must not reach the customer's closure.
         if !isContainerView(resolvedClassName),
-           let innerText = safeInnerText(from: view),
-           !innerText.isEmpty,
-           shouldSendText?(view, innerText) ?? true {
-            tapData[Keys.targetElementInnerText.rawValue] = innerText
+           let innerText = rawInnerText(from: view),
+           !innerText.isEmpty {
+            let isMasked = view.isInsideMaskedSubtree || hasSensitivePIIProperties(view)
+            let isAllowedByDelegate = !isMasked && (shouldSendText?(view, innerText) ?? true)
+            tapData[Keys.targetElementInnerText.rawValue] =
+                isAllowedByDelegate ? innerText : Keys.maskedInnerText.rawValue
         }
 
         // scroll_direction: only present for scroll/swipe events
@@ -336,6 +342,19 @@ enum TapDataExtractor {
         // Checked before any type-specific extraction so it applies to all input classes.
         if hasSensitivePIIProperties(view) { return nil }
 
+        return rawInnerText(from: view)
+    }
+
+    /// The text `safeInnerText` would extract, without the sensitive-PII block.
+    ///
+    /// Split out so a caller can tell "this view has sensitive text" apart from "this view has no
+    /// text" — `safeInnerText` answers nil to both, which is the right answer when the text is
+    /// about to be reported verbatim, but not when it is about to be redacted to `***`.
+    ///
+    /// Callers that reach for this take on the obligation not to let the value escape: it may be
+    /// a password. Report `Keys.maskedInnerText` in its place, and never hand it to a customer
+    /// callback.
+    static func rawInnerText(from view: UIView) -> String? {
         // --- Text input views (non-sensitive) ---
         if let textField = view as? UITextField {
             return textField.text

--- a/Coralogix/Sources/Model/CoralogixExporterOptions.swift
+++ b/Coralogix/Sources/Model/CoralogixExporterOptions.swift
@@ -79,14 +79,21 @@ public struct CoralogixExporterOptions {
 
     /// Called before `target_element_inner_text` is recorded for a tapped view.
     ///
-    /// Return `true` to allow the text to be captured, `false` to suppress it.
+    /// Return `true` to allow the text to be captured, `false` to redact it to `***`.
     /// Use this to redact sensitive labels (e.g. account numbers, personal data)
     /// on a per-view or per-text basis without disabling text capture globally.
+    ///
+    /// Redacted text is reported as `***` rather than omitted, so a redacted tap stays
+    /// distinguishable from a tap on an element that had no text to begin with.
     ///
     /// - Important: This closure is called on the **main thread** only when the SDK would
     ///   otherwise record text — views where text extraction returns nothing (e.g. a plain
     ///   `UIView` with no label) never trigger this callback.
     ///   Keep the implementation fast and non-blocking.
+    ///
+    /// - Note: Views that are already masked never reach this closure, and their text is never
+    ///   passed to it: a view inside a `cxMask` subtree, a `isSecureTextEntry` field, or a field
+    ///   with a sensitive `textContentType` reports `***` outright.
     ///
     /// - Parameters:
     ///   - view: The UIView that was tapped.

--- a/CoralogixInternal.podspec
+++ b/CoralogixInternal.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "CoralogixInternal"
-  spec.version      = "2.13.2"
+  spec.version      = "2.13.3"
   spec.summary      = "Coralogix Internal Package. This module is not for public use."
 
   spec.description  = <<-DESC

--- a/CoralogixInternal/Sources/Extention/UIViewExt.swift
+++ b/CoralogixInternal/Sources/Extention/UIViewExt.swift
@@ -10,6 +10,23 @@ import ObjectiveC
 
 private var kCxMaskKey: UInt8 = 0
 
+/// A rendered frame together with the mask rectangles that were painted onto it, in screen
+/// points.
+///
+/// The rects travel with the image so a later stage can test a tap against the regions this
+/// frame actually blacked out, rather than re-deriving what is masked from a second walk of a
+/// hierarchy that has since moved on. One capture, one answer — the pixels and the tap marker
+/// cannot disagree.
+public struct CapturedFrame {
+    public let image: UIImage
+    public let maskRects: [CGRect]
+
+    public init(image: UIImage, maskRects: [CGRect]) {
+        self.image = image
+        self.maskRects = maskRects
+    }
+}
+
 // Resolved once; safe when Flutter is not on the classpath.
 private let _flutterViewClass: AnyClass? =
     NSClassFromString("FlutterView")
@@ -21,6 +38,25 @@ public extension UIView {
     var cxMask: Bool {
         get { (objc_getAssociatedObject(self, &kCxMaskKey) as? Bool) ?? false }
         set { objc_setAssociatedObject(self, &kCxMaskKey, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC) }
+    }
+
+    /// True when this view is masked, either directly or because an ancestor is.
+    ///
+    /// Masking is inherited: everything inside a masked view is masked, with no way to opt a
+    /// descendant back out. This is what makes a tap on an unmasked key inside a masked keypad
+    /// count as a tap on masked content — hit-testing resolves the key, which carries no masking
+    /// signal of its own, so asking the key alone would report it unmasked.
+    ///
+    /// Resolved by walking up rather than by threading state down: the mask rects are collected
+    /// from a live view hierarchy per capture, and the interaction path starts from an already
+    /// hit-tested leaf, so there is no shared tree to seed.
+    var isInsideMaskedSubtree: Bool {
+        var view: UIView? = self
+        while let current = view {
+            if current.cxMask { return true }
+            view = current.superview
+        }
+        return false
     }
 
     func activeForegroundWindowScene() -> UIWindowScene? {
@@ -261,8 +297,35 @@ public extension UIView {
         flutterViewRect: CGRect? = nil,
         isClickFrame: Bool = false
     ) -> UIImage? {
+        return captureFrame(
+            scale: scale,
+            maskText: maskText,
+            maskAllImages: maskAllImages,
+            flutterCGImage: flutterCGImage,
+            flutterViewRect: flutterViewRect,
+            isClickFrame: isClickFrame
+        )?.image
+    }
+
+    /// As `captureScreenshotImage`, but also returns the mask rectangles painted onto the frame
+    /// so a later stage can decide whether a tap landed inside one. See `CapturedFrame`.
+    ///
+    /// The Flutter branch contributes no rects, and cannot: Dart masks the widget tree inside its
+    /// own bitmap and reports no geometry back, so the host cannot know where a masked Flutter
+    /// widget sits. Tap markers over masked Flutter content are therefore not suppressed — only
+    /// masked native views on the same screen are.
+    ///
+    /// Must be called on the main thread.
+    func captureFrame(
+        scale: CGFloat = UIScreen.main.scale,
+        maskText: [String]? = nil,
+        maskAllImages: Bool = false,
+        flutterCGImage: CGImage? = nil,
+        flutterViewRect: CGRect? = nil,
+        isClickFrame: Bool = false
+    ) -> CapturedFrame? {
         guard Thread.isMainThread else {
-            Log.e("captureScreenshotImage must be called on the main thread")
+            Log.e("captureFrame must be called on the main thread")
             return nil
         }
 
@@ -283,7 +346,7 @@ public extension UIView {
         format.scale = scale
         let renderer = UIGraphicsImageRenderer(bounds: bounds, format: format)
 
-        return renderer.image { rendererContext in
+        let image = renderer.image { rendererContext in
             for win in windows {
                 if UIView.subtreeContainsFlutterView(win) {
                     // Flutter window: paste Dart pre-masked bitmap; black-fill on nil/missing rect.
@@ -336,6 +399,10 @@ public extension UIView {
                 for rect in nativeMaskRects { UIRectFill(rect) }
             }
         }
+
+        // Read after the renderer block, which runs synchronously — every rect the frame masked
+        // has been appended by this point.
+        return CapturedFrame(image: image, maskRects: nativeMaskRects)
     }
 
     /// Convenience wrapper — captures and JPEG-encodes inline. Prefer calling
@@ -358,6 +425,12 @@ public extension UIView {
                 if !rect.isNull && !rect.isEmpty {
                     rects.append(rect)
                 }
+                // Deliberately keeps descending. Android's equivalent stops at a masked node
+                // because masking is inherited there, so every descendant reports itself masked
+                // and the walk would emit a rect per node. Here `cxMask` stays per-view, so a
+                // descendant only contributes a rect when it was masked explicitly — and it must,
+                // since subviews are not clipped to their parent and a masked child can extend
+                // past a masked parent's bounds.
             }
             for subview in view.subviews {
                 traverse(subview)

--- a/CoralogixInternal/Sources/Keys.swift
+++ b/CoralogixInternal/Sources/Keys.swift
@@ -74,6 +74,9 @@ public enum Keys: String {
     case targetElement = "target_element"
     case targetElementType = "target_element_type"
     case targetElementInnerText = "target_element_inner_text"
+    // Wire value, not a key: what a redacted `target_element_inner_text` reads as. Matches the
+    // Android SDK so the same masked tap looks the same whichever platform sent it.
+    case maskedInnerText = "***"
     case scrollDirection = "scroll_direction"
     case fetch
     case networkRequestContext = "network_request_context"
@@ -227,6 +230,7 @@ public enum Keys: String {
     case page
     case screenshotData
     case containsSwiftUIContent
+    case maskRects
     case screenshotContext = "screenshot_context"
     case queueScreenshotManager = "com.coralogix.screenshotmanager.queue"
     case queueExporter = "com.coralogix.exporter.queue"

--- a/CoralogixInternal/Sources/Utils.swift
+++ b/CoralogixInternal/Sources/Utils.swift
@@ -16,7 +16,7 @@ public enum ImageFormat {
 }
 
 public enum Global: String {
-    case sdk = "2.13.2"
+    case sdk = "2.13.3"
     case swiftVersion = "5.9"
     case coralogixPath = "/browser/v1beta/logs"
     case sessionReplayPath = "/browser/alpha/sessionrecording"

--- a/Example/DemoAppSwift/MaskViewController.swift
+++ b/Example/DemoAppSwift/MaskViewController.swift
@@ -136,17 +136,23 @@ class MaskViewController: UIViewController {
     /// Masking is applied to the container only — the keys inside carry no `cxMask` of their own.
     /// They still inherit it: the replay draws no tap marker over them and their interaction
     /// events report `***` instead of the digit.
+    ///
+    /// The keys deliberately share one identifier. `element_id` comes from
+    /// `accessibilityIdentifier` and is **not** redacted inside a masked subtree — it is
+    /// developer-authored, so the SDK takes it at face value. A per-digit identifier here would
+    /// leak the sequence through `element_id` and defeat the masking this screen demonstrates.
     private lazy var maskedKeypad: UIView = {
-        let keypad = makeKeypad(tint: .systemRed)
+        let keypad = makeKeypad(tint: .systemRed) { _ in "masked_keypad_key" }
         keypad.cxMask = true // 👈 masks the whole subtree, keys included
         return keypad
     }()
 
     /// The same keypad without masking — its digits appear in the replay and in the interaction
     /// events, which is what makes the masked one's behaviour visible as a difference.
-    private lazy var unmaskedKeypad: UIView = makeKeypad(tint: .systemBlue)
+    private lazy var unmaskedKeypad: UIView = makeKeypad(tint: .systemBlue) { "keypad_key_\($0)" }
 
-    private func makeKeypad(tint: UIColor) -> UIView {
+    private func makeKeypad(tint: UIColor,
+                            identifierForDigit: (Int) -> String) -> UIView {
         let rows = (0..<2).map { row -> UIStackView in
             let buttons = (0..<3).map { column -> UIButton in
                 let digit = row * 3 + column + 1
@@ -157,7 +163,7 @@ class MaskViewController: UIViewController {
                 key.layer.borderWidth = 1
                 key.layer.borderColor = tint.withAlphaComponent(0.4).cgColor
                 key.layer.cornerRadius = 6
-                key.accessibilityIdentifier = "keypad_key_\(digit)"
+                key.accessibilityIdentifier = identifierForDigit(digit)
                 key.addTarget(self, action: #selector(keypadKeyTapped(_:)), for: .touchUpInside)
                 return key
             }

--- a/Example/DemoAppSwift/MaskViewController.swift
+++ b/Example/DemoAppSwift/MaskViewController.swift
@@ -122,7 +122,65 @@ class MaskViewController: UIViewController {
         label.cxMask = true // 👈 masked example
         return label
     }()
-    
+
+    private let keypadCaption: UILabel = {
+        let label = UILabel()
+        label.text = "Keypads: the left one is masked at the container. "
+            + "Tap both and compare them in the replay."
+        label.font = .systemFont(ofSize: 13)
+        label.textColor = .secondaryLabel
+        label.numberOfLines = 0
+        return label
+    }()
+
+    /// Masking is applied to the container only — the keys inside carry no `cxMask` of their own.
+    /// They still inherit it: the replay draws no tap marker over them and their interaction
+    /// events report `***` instead of the digit.
+    private lazy var maskedKeypad: UIView = {
+        let keypad = makeKeypad(tint: .systemRed)
+        keypad.cxMask = true // 👈 masks the whole subtree, keys included
+        return keypad
+    }()
+
+    /// The same keypad without masking — its digits appear in the replay and in the interaction
+    /// events, which is what makes the masked one's behaviour visible as a difference.
+    private lazy var unmaskedKeypad: UIView = makeKeypad(tint: .systemBlue)
+
+    private func makeKeypad(tint: UIColor) -> UIView {
+        let rows = (0..<2).map { row -> UIStackView in
+            let buttons = (0..<3).map { column -> UIButton in
+                let digit = row * 3 + column + 1
+                let key = UIButton(type: .system)
+                key.setTitle("\(digit)", for: .normal)
+                key.titleLabel?.font = .boldSystemFont(ofSize: 20)
+                key.tintColor = tint
+                key.layer.borderWidth = 1
+                key.layer.borderColor = tint.withAlphaComponent(0.4).cgColor
+                key.layer.cornerRadius = 6
+                key.accessibilityIdentifier = "keypad_key_\(digit)"
+                key.addTarget(self, action: #selector(keypadKeyTapped(_:)), for: .touchUpInside)
+                return key
+            }
+            let rowStack = UIStackView(arrangedSubviews: buttons)
+            rowStack.axis = .horizontal
+            rowStack.spacing = 6
+            rowStack.distribution = .fillEqually
+            return rowStack
+        }
+
+        let keypad = UIStackView(arrangedSubviews: rows)
+        keypad.axis = .vertical
+        keypad.spacing = 6
+        keypad.distribution = .fillEqually
+        keypad.heightAnchor.constraint(equalToConstant: 92).isActive = true
+        return keypad
+    }
+
+    @objc private func keypadKeyTapped(_ sender: UIButton) {
+        sender.alpha = 0.4
+        UIView.animate(withDuration: 0.2) { sender.alpha = 1.0 }
+    }
+
     // MARK: - Lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -132,6 +190,11 @@ class MaskViewController: UIViewController {
     
     // MARK: - Layout
     private func setupLayout() {
+        let keypadRow = UIStackView(arrangedSubviews: [maskedKeypad, unmaskedKeypad])
+        keypadRow.axis = .horizontal
+        keypadRow.spacing = 16
+        keypadRow.distribution = .fillEqually
+
         let stack = UIStackView(arrangedSubviews: [
             titleLabel,
             descriptionLabel,
@@ -139,6 +202,8 @@ class MaskViewController: UIViewController {
             passwordField,
             textView,
             maskedLabel,
+            keypadCaption,
+            keypadRow,
             button,
             toggleSwitch,
             slider,
@@ -147,21 +212,31 @@ class MaskViewController: UIViewController {
             progressView,
             imageView
         ])
-        
+
         stack.axis = .vertical
         stack.spacing = 16
         stack.alignment = .fill
         stack.distribution = .equalSpacing
         stack.translatesAutoresizingMaskIntoConstraints = false
-        
-        view.addSubview(stack)
-        
+
+        // Scrolls because the content no longer fits a single screen once the keypads are added.
+        let scrollView = UIScrollView()
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.addSubview(stack)
+        view.addSubview(scrollView)
+
         NSLayoutConstraint.activate([
-            stack.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
-            stack.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
-            stack.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 20),
-            stack.bottomAnchor.constraint(lessThanOrEqualTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -20),
-            
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+
+            stack.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor, constant: 20),
+            stack.trailingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.trailingAnchor, constant: -20),
+            stack.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor, constant: 20),
+            stack.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor, constant: -20),
+            stack.widthAnchor.constraint(equalTo: scrollView.frameLayoutGuide.widthAnchor, constant: -40),
+
             textView.heightAnchor.constraint(equalToConstant: 100),
             imageView.heightAnchor.constraint(equalToConstant: 80)
         ])

--- a/Example/DemoAppSwiftUI/MaskViewController.swift
+++ b/Example/DemoAppSwiftUI/MaskViewController.swift
@@ -56,7 +56,25 @@ struct MaskDemoView: View {
                 Text("Sensitive Info")
                     .foregroundColor(.red)
                     .cxMask() // masked example
-                
+
+                // Keypads — mirrors the UIKit demo's masked/unmasked pair.
+                //
+                // `.cxMask()` overlays a masked UIView on top of this container, so the replay
+                // blacks the keypad out and draws no tap marker over it. Unlike the UIKit
+                // `cxMask`, the overlay is not an ancestor of the keys, so their interaction
+                // events still report the digit. Masking a SwiftUI control's interaction text is
+                // not supported yet — see the SessionReplay README.
+                Text("Keypads: the left one is masked at the container. "
+                     + "Tap both and compare them in the replay.")
+                    .font(.system(size: 13))
+                    .foregroundColor(.secondary)
+
+                HStack(spacing: 16) {
+                    KeypadView(tint: .red)
+                        .cxMask() // 👈 masks the whole container, keys included
+                    KeypadView(tint: .blue)
+                }
+
                 // Button
                 Button(action: {}) {
                     Text("Submit")
@@ -112,5 +130,35 @@ struct MaskDemoView: View {
             .padding(20)
         }
         .background(Color(.systemBackground))
+    }
+}
+
+/// A 3×2 grid of individually tappable keys — the shape that made masking-by-container matter:
+/// hit-testing resolves a single key, not the container the mask was applied to.
+struct KeypadView: View {
+    let tint: Color
+
+    var body: some View {
+        VStack(spacing: 6) {
+            ForEach(0..<2, id: \.self) { row in
+                HStack(spacing: 6) {
+                    ForEach(0..<3, id: \.self) { column in
+                        let digit = row * 3 + column + 1
+                        Button(action: {}) {
+                            Text("\(digit)")
+                                .font(.system(size: 20, weight: .bold))
+                                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        }
+                        .foregroundColor(tint)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 6)
+                                .stroke(tint.opacity(0.4), lineWidth: 1)
+                        )
+                        .accessibilityIdentifier("keypad_key_\(digit)")
+                    }
+                }
+            }
+        }
+        .frame(height: 92)
     }
 }

--- a/Example/DemoAppSwiftUI/MaskViewController.swift
+++ b/Example/DemoAppSwiftUI/MaskViewController.swift
@@ -70,9 +70,12 @@ struct MaskDemoView: View {
                     .foregroundColor(.secondary)
 
                 HStack(spacing: 16) {
-                    KeypadView(tint: .red)
+                    // One shared identifier on the masked pad: `element_id` comes from
+                    // accessibilityIdentifier and is not redacted, so per-digit identifiers would
+                    // leak the sequence the masking is meant to hide.
+                    KeypadView(tint: .red) { _ in "masked_keypad_key" }
                         .cxMask() // 👈 masks the whole container, keys included
-                    KeypadView(tint: .blue)
+                    KeypadView(tint: .blue) { "keypad_key_\($0)" }
                 }
 
                 // Button
@@ -137,6 +140,7 @@ struct MaskDemoView: View {
 /// hit-testing resolves a single key, not the container the mask was applied to.
 struct KeypadView: View {
     let tint: Color
+    let identifierForDigit: (Int) -> String
 
     var body: some View {
         VStack(spacing: 6) {
@@ -154,7 +158,7 @@ struct KeypadView: View {
                             RoundedRectangle(cornerRadius: 6)
                                 .stroke(tint.opacity(0.4), lineWidth: 1)
                         )
-                        .accessibilityIdentifier("keypad_key_\(digit)")
+                        .accessibilityIdentifier(identifierForDigit(digit))
                     }
                 }
             }

--- a/README.md
+++ b/README.md
@@ -322,7 +322,9 @@ let options = CoralogixExporterOptions(coralogixDomain: CORALOGIX-DOMAIN,
 > **Note:** Only allowlist URLs and header names you are comfortable logging. Avoid capturing `Authorization` or other sensitive headers unless intentional. Body and header capture should not be used for endpoints that return or send PII or secrets. Request and response bodies over 1024 characters are **dropped** (not truncated) and do not appear in RUM.
 
 ### User Action Text Redaction (`shouldSendText`)
-Called before `target_element_inner_text` is recorded for a tapped view. Return `false` to suppress text capture for sensitive views (e.g. fields showing account numbers or personal data) without disabling text capture globally.
+Called before `target_element_inner_text` is recorded for a tapped view. Return `false` to redact text for sensitive views (e.g. fields showing account numbers or personal data) without disabling text capture globally.
+
+Redacted text is reported as `***` rather than omitted, so a redacted tap stays distinguishable from a tap on an element that had no text at all. Views that are already masked — a view inside a [masked subtree](SessionReplay/Sources/Docs/README.md#masking-a-specific-view-cxmask), a password field, or a field with a sensitive `textContentType` — report `***` without consulting this closure, so their text is never passed to your code.
 
 This closure is called on the **main thread** only when the SDK would otherwise record text. Keep it fast and non-blocking.
 ```swift

--- a/SessionReplay.podspec
+++ b/SessionReplay.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "SessionReplay"
-  spec.version      = "2.13.2"
+  spec.version      = "2.13.3"
   spec.summary      = "Coralogix Session-Replay pod for iOS."
 
   spec.description  = <<-DESC
@@ -23,7 +23,7 @@ Pod::Spec.new do |spec|
   spec.static_framework = true
 
   spec.source_files  = 'SessionReplay/Sources/**/*.swift'
-  spec.dependency 'CoralogixInternal', '2.13.2'
+  spec.dependency 'CoralogixInternal', '2.13.3'
   
     spec.test_spec 'Tests' do |test|
         test.source_files = 'Tests/SessionReplayTests/**/*.swift'

--- a/SessionReplay/Sources/Docs/README.md
+++ b/SessionReplay/Sources/Docs/README.md
@@ -24,6 +24,8 @@ Holds the configuration used to initialize SessionReplay. This includes capture 
 - `maskFaces`: Whether faces should be masked (default: `false`).
 - `creditCardPredicate`: Custom text patterns to identify images that may contain credit card content.
 
+See [Masking a specific view (`cxMask`)](#masking-a-specific-view-cxmask) for opting an individual view in, regardless of these global options.
+
 #### Initializer
 ```swift
 public init(
@@ -54,6 +56,41 @@ let options = SessionReplayOptions(
 
 SessionReplay.initializeWithOptions(sessionReplayOptions: options)
 ```
+
+---
+
+## Masking a specific view (`cxMask`)
+
+Opts a single view into Coralogix masking, regardless of the global masking policy.
+
+```swift
+accountNumberLabel.cxMask = true
+```
+
+Masking applies to the **whole subtree**: every subview is masked too, and a subview cannot be opted back out. Applying it to a container is therefore enough to cover its contents, which is the recommended way to protect a composite element such as a PIN keypad whose keys are individually tappable.
+
+A masked view, and anything inside it:
+
+- is covered by a black rectangle in session replays;
+- absorbs tap markers — a tap landing anywhere inside it draws no marker in the recording, so the replay does not reveal which part of the masked area was touched;
+- reports its text as `***` in user interaction events.
+
+Masking does not suppress the interaction event itself, and the event still carries the touch coordinates. Masking hides *what* an element is and *what it says*, not *that it was used*.
+
+### Which masking sources suppress a tap marker
+
+Only masking that reports geometry to the capture pass can suppress a marker, because the marker is tested against the exact rectangles the frame blacked out — the pixels and the marker can never disagree.
+
+| Masking source | Pixels masked | Tap marker suppressed | Interaction text `***` |
+|---|---|---|---|
+| `cxMask` on a `UIView` (and its subviews) | ✅ | ✅ | ✅ |
+| `.cxMask()` on a SwiftUI view | ✅ | ✅ | ❌ — see below |
+| `maskText`, `maskAllImages`, `maskFaces`, `creditCardPredicate` | ✅ | ❌ | ❌ |
+| Flutter (Dart-supplied pre-masked bitmap) | ✅ | ❌ | ❌ |
+
+The global policy options and the Flutter path deliberately do not affect interaction text: they answer "should these pixels be hidden in this frame", which is not the same question as "may this text leave the device". Password fields and fields with a sensitive `textContentType` are redacted to `***` independently of any of this.
+
+> **Limitation — SwiftUI:** `.cxMask()` works by overlaying a masked `UIView` on top of the composable content. That overlay masks the pixels and suppresses tap markers over the area, but it is a sibling of the content rather than an ancestor of it, so the views underneath do not inherit masking and their interaction events still report their real text. If a SwiftUI control's text is sensitive, use the `shouldSendText` option to redact it.
 
 ---
 

--- a/SessionReplay/Sources/Docs/README.md
+++ b/SessionReplay/Sources/Docs/README.md
@@ -79,7 +79,7 @@ Masking does not suppress the interaction event itself, and the event still carr
 
 ### Which masking sources suppress a tap marker
 
-Only masking that reports geometry to the capture pass can suppress a marker, because the marker is tested against the exact rectangles the frame blacked out — the pixels and the marker can never disagree. The synchronous `UIView` walk reports geometry; the Vision-based scanners and the Dart bitmap mask pixels in place and report none.
+Only masking that reports geometry to the capture pass can suppress a marker, because the marker is tested against the exact rectangles the frame blacked out — the pixels and the marker can never disagree. The synchronous `UIView` walk reports geometry. The Vision-based scanners and the Dart-supplied bitmap both modify pixels in place and report none, so masking that relies on them cannot suppress a marker.
 
 | Masking source | Pixels masked | Tap marker suppressed | Interaction text `***` |
 |---|---|---|---|

--- a/SessionReplay/Sources/Docs/README.md
+++ b/SessionReplay/Sources/Docs/README.md
@@ -79,16 +79,20 @@ Masking does not suppress the interaction event itself, and the event still carr
 
 ### Which masking sources suppress a tap marker
 
-Only masking that reports geometry to the capture pass can suppress a marker, because the marker is tested against the exact rectangles the frame blacked out — the pixels and the marker can never disagree.
+Only masking that reports geometry to the capture pass can suppress a marker, because the marker is tested against the exact rectangles the frame blacked out — the pixels and the marker can never disagree. The synchronous `UIView` walk reports geometry; the Vision-based scanners and the Dart bitmap mask pixels in place and report none.
 
 | Masking source | Pixels masked | Tap marker suppressed | Interaction text `***` |
 |---|---|---|---|
 | `cxMask` on a `UIView` (and its subviews) | ✅ | ✅ | ✅ |
 | `.cxMask()` on a SwiftUI view | ✅ | ✅ | ❌ — see below |
-| `maskText`, `maskAllImages`, `maskFaces`, `creditCardPredicate` | ✅ | ❌ | ❌ |
+| `maskText` / `maskAllImages` on **UIKit** views (`UILabel`, `UITextField`, `UITextView`, `UINavigationBar` titles, `UIImageView`) | ✅ | ✅ | ❌ |
+| `maskText` / `maskAllImages` on **SwiftUI** content (OCR / rectangle detection) | ✅ | ❌ | ❌ |
+| `maskFaces`, `creditCardPredicate` (Vision) | ✅ | ❌ | ❌ |
 | Flutter (Dart-supplied pre-masked bitmap) | ✅ | ❌ | ❌ |
 
 The global policy options and the Flutter path deliberately do not affect interaction text: they answer "should these pixels be hidden in this frame", which is not the same question as "may this text leave the device". Password fields and fields with a sensitive `textContentType` are redacted to `***` independently of any of this.
+
+> **`element_id` is never redacted.** It carries the view's `accessibilityIdentifier`, which is developer-authored rather than user data, so the SDK reports it as-is even for a view inside a masked subtree. Avoid encoding sensitive values in identifiers: on a masked keypad, per-digit identifiers such as `keypad_key_7` would reconstruct the entered sequence from the tap spans even though the text is `***`. Both demo apps give the masked keypad's keys a single shared identifier for this reason. This matches the Android SDK, which does not redact `resourceId` either.
 
 > **Limitation — SwiftUI:** `.cxMask()` works by overlaying a masked `UIView` on top of the composable content. That overlay masks the pixels and suppresses tap markers over the area, but it is a sibling of the content rather than an ancestor of it, so the views underneath do not inherit masking and their interaction events still report their real text. If a SwiftUI control's text is sensitive, use the `shouldSendText` option to redact it.
 

--- a/SessionReplay/Sources/ScannerPipeline.swift
+++ b/SessionReplay/Sources/ScannerPipeline.swift
@@ -9,6 +9,21 @@ import Foundation
 import CoreImage
 import CoralogixInternal
 
+extension Array where Element == CGRect {
+    /// Whether a tap at `point` (screen points) landed inside one of a frame's masked regions.
+    ///
+    /// Fails closed: any rect containing the point counts, including one belonging to a window a
+    /// higher z-order layer later painted over. Resolving stacking precisely would risk drawing a
+    /// marker over content the customer asked to be masked; the cost of the conservative answer is
+    /// only a missing marker in a rare layering case.
+    ///
+    /// Internal, and deliberately not on the shared `CoralogixInternal` surface: the capture pass
+    /// only collects the rects, and this question is asked in exactly one place — here.
+    func containsTap(_ point: CGPoint) -> Bool {
+        contains { $0.contains(point) }
+    }
+}
+
 class ScannerPipeline {
     func runPipeline(
         options: SessionReplayOptions,
@@ -36,6 +51,11 @@ class ScannerPipeline {
         //   detection) stages here. Probabilistic — accepted interim trade-off (BUGV2-6045).
         // - Credit-card image detection (ImageScanner, maskAll: false) runs for everyone
         //   when enabled.
+        //
+        // Only the UIKit walk reports geometry back (URLEntry.maskRects). The OCR/Vision and
+        // Dart-bitmap stages mask pixels in place and report none, so a tap over content masked
+        // only by those still draws its marker. Suppressing those needs the scanners to surface
+        // their observation rects in screen points, which is its own work.
         let needsSwiftUIMasking = urlEntry.containsSwiftUIContent
         let isTextScannerEnabled = needsSwiftUIMasking && !(options.maskText?.isEmpty ?? true)
         let isImageScannerEnabled = options.maskOnlyCreditCards || (needsSwiftUIMasking && options.maskAllImages)
@@ -91,6 +111,19 @@ class ScannerPipeline {
         func runClickScanner(input: CIImage, completion: @escaping (CIImage) -> Void) {
             guard let point = urlEntry.point else {
                 Log.e("Tap point not provided. Cannot run ClickScanner.")
+                completion(input)
+                return
+            }
+
+            // A tap inside a masked region is drawn nowhere: the marker would give away which
+            // element under the mask was hit, and a run of markers reconstructs what was entered
+            // on a masked keypad. The frame itself is kept — only the position is withheld.
+            //
+            // Tested against the rects the capture pass actually painted, so the marker cannot
+            // contradict the pixels. Regions masked by the OCR/Vision stages above report no
+            // geometry and so cannot suppress a marker — see the SwiftUI note in runPipeline.
+            guard !urlEntry.maskRects.containsTap(point) else {
+                Log.d("[SR] tap inside a masked region — marker suppressed")
                 completion(input)
                 return
             }

--- a/SessionReplay/Sources/ScannerPipeline.swift
+++ b/SessionReplay/Sources/ScannerPipeline.swift
@@ -19,6 +19,12 @@ extension Array where Element == CGRect {
     ///
     /// Internal, and deliberately not on the shared `CoralogixInternal` surface: the capture pass
     /// only collects the rects, and this question is asked in exactly one place — here.
+    ///
+    /// `CGRect.contains` excludes the `maxX`/`maxY` edges, so a tap exactly on a mask's bottom or
+    /// right boundary reads as outside and still draws a marker. Left as-is: the marker is centred
+    /// on the tap, and its radius already overlaps masked pixels for any tap within ~25pt of a
+    /// mask, so treating the boundary as inside would not stop that — only insetting every rect by
+    /// the marker radius would, which would suppress markers well outside the masked area.
     func containsTap(_ point: CGPoint) -> Bool {
         contains { $0.contains(point) }
     }

--- a/SessionReplay/Sources/SessionReplayModel.swift
+++ b/SessionReplay/Sources/SessionReplayModel.swift
@@ -80,18 +80,18 @@ public class SessionReplayModel {
     /// For the Flutter path, `flutterCGImage` and `flutterViewRect` carry the pre-masked
     /// Dart bitmap and its position in screen points.
     /// Must be called on the main thread.
-    private func prepareScreenshotImageOnMain(
+    private func prepareCapturedFrameOnMain(
         options: SessionReplayOptions,
         flutterCGImage: CGImage?,
         flutterViewRect: CGRect?,
         isClickFrame: Bool = false
-    ) -> UIImage? {
+    ) -> CapturedFrame? {
         guard Thread.isMainThread else { return nil }
         guard isValidSessionReplayOptions(options) else {
             Log.e("Invalid sessionReplayOptions")
             return nil
         }
-        return UIView().captureScreenshotImage(
+        return UIView().captureFrame(
             scale: options.captureScale,
             maskText: options.maskText,
             maskAllImages: options.maskAllImages,
@@ -102,10 +102,10 @@ public class SessionReplayModel {
     }
 
     /// Legacy signature kept for test compatibility and the synchronous captureAutomatic path.
-    internal func prepareScreenshotImageOnMain(properties: [String: Any]?) -> UIImage? {
+    internal func prepareCapturedFrameOnMain(properties: [String: Any]?) -> CapturedFrame? {
         guard let options = sessionReplayOptions else { return nil }
         let isClickFrame = getClickPoint(from: properties) != nil
-        return prepareScreenshotImageOnMain(options: options, flutterCGImage: nil, flutterViewRect: nil, isClickFrame: isClickFrame)
+        return prepareCapturedFrameOnMain(options: options, flutterCGImage: nil, flutterViewRect: nil, isClickFrame: isClickFrame)
     }
 
     /// Synchronous capture-and-encode, retained as a back-compat shim.
@@ -117,11 +117,11 @@ public class SessionReplayModel {
             return nil
         }
 
-        guard let image = prepareScreenshotImageOnMain(properties: properties),
+        guard let frame = prepareCapturedFrameOnMain(properties: properties),
               let quality = sessionReplayOptions?.captureCompressionQuality else {
             return nil
         }
-        return image.jpegData(compressionQuality: quality)
+        return frame.image.jpegData(compressionQuality: quality)
     }
 
     internal func saveScreenshotToFileSystem(
@@ -174,16 +174,16 @@ public class SessionReplayModel {
         }
 
         // Native path: synchronous UIView walk on main thread, encode off-main.
-        guard let image = prepareScreenshotImageOnMain(properties: properties),
+        guard let frame = prepareCapturedFrameOnMain(properties: properties),
               let options = sessionReplayOptions else {
             return .failure(.captureFailed)
         }
 
         let callerIncrementedCounter = properties?[Keys.segmentIndex.rawValue] as? Int != nil
         encodeAndProcess(
-            image: image,
+            image: frame.image,
             compressionQuality: options.captureCompressionQuality,
-            properties: propertiesWithSwiftUIFlag(properties),
+            properties: propertiesWithCaptureMetadata(properties, maskRects: frame.maskRects),
             callerIncrementedCounter: callerIncrementedCounter
         )
         return .success(())
@@ -209,7 +209,7 @@ public class SessionReplayModel {
 
         // No FlutterView visible — capture native windows only.
         guard let rect = flutterViewRect else {
-            guard let image = prepareScreenshotImageOnMain(
+            guard let frame = prepareCapturedFrameOnMain(
                 options: options, flutterCGImage: nil, flutterViewRect: nil, isClickFrame: isClickFrame
             ) else {
                 if callerIncrementedCounter {
@@ -217,8 +217,8 @@ public class SessionReplayModel {
                 }
                 return
             }
-            encodeAndProcess(image: image, compressionQuality: options.captureCompressionQuality,
-                             properties: propertiesWithSwiftUIFlag(properties),
+            encodeAndProcess(image: frame.image, compressionQuality: options.captureCompressionQuality,
+                             properties: propertiesWithCaptureMetadata(properties, maskRects: frame.maskRects),
                              callerIncrementedCounter: callerIncrementedCounter)
             return
         }
@@ -249,7 +249,7 @@ public class SessionReplayModel {
             // if the view is no longer visible (e.g., navigation transition).
             let compositeRect = self.findFlutterViewRect() ?? rect
 
-            guard let image = self.prepareScreenshotImageOnMain(
+            guard let frame = self.prepareCapturedFrameOnMain(
                 options: options, flutterCGImage: flutterCGImage, flutterViewRect: compositeRect, isClickFrame: isClickFrame
             ) else {
                 if callerIncrementedCounter {
@@ -258,8 +258,8 @@ public class SessionReplayModel {
                 return
             }
 
-            self.encodeAndProcess(image: image, compressionQuality: options.captureCompressionQuality,
-                                  properties: self.propertiesWithSwiftUIFlag(properties),
+            self.encodeAndProcess(image: frame.image, compressionQuality: options.captureCompressionQuality,
+                                  properties: self.propertiesWithCaptureMetadata(properties, maskRects: frame.maskRects),
                                   callerIncrementedCounter: callerIncrementedCounter)
         }
     }
@@ -336,11 +336,16 @@ public class SessionReplayModel {
             .contains { UIView.subtreeContainsSwiftUIHostingView($0) }
     }
 
-    /// Merges the SwiftUI-content flag (detected on the main thread) into the
-    /// capture properties so it reaches `handleCapturedData` → `URLEntry`.
-    private func propertiesWithSwiftUIFlag(_ properties: [String: Any]?) -> [String: Any] {
+    /// Merges the facts that are only knowable on the main thread at capture time — the
+    /// SwiftUI-content flag and the frame's mask rects — into the capture properties so they
+    /// reach `handleCapturedData` → `URLEntry`. Same channel the click point already travels on.
+    private func propertiesWithCaptureMetadata(
+        _ properties: [String: Any]?,
+        maskRects: [CGRect]
+    ) -> [String: Any] {
         var props = properties ?? [:]
         props[Keys.containsSwiftUIContent.rawValue] = detectSwiftUIContentOnMain()
+        props[Keys.maskRects.rawValue] = maskRects
         return props
     }
 
@@ -520,6 +525,7 @@ public class SessionReplayModel {
             let page = self.getPage(from: properties)
             let point = self.getClickPoint(from: properties)
             let containsSwiftUIContent = (properties?[Keys.containsSwiftUIContent.rawValue] as? Bool) ?? false
+            let maskRects = (properties?[Keys.maskRects.rawValue] as? [CGRect]) ?? []
 
             let completion: URLProcessingCompletion = { [weak self] ciImage, urlEntry in
                 if let ciImage = ciImage,
@@ -539,6 +545,7 @@ public class SessionReplayModel {
                                     screenshotData: data,
                                     point: point,
                                     containsSwiftUIContent: containsSwiftUIContent,
+                                    maskRects: maskRects,
                                     completion: completion)
 
             self.urlManager.addURL(urlEntry: urlEntry)

--- a/SessionReplay/Sources/URLManager.swift
+++ b/SessionReplay/Sources/URLManager.swift
@@ -24,6 +24,9 @@ struct URLEntry {
     /// time (detected on the main thread). Gates the SwiftUI-scoped OCR text /
     /// image maskAll stages in ScannerPipeline.
     var containsSwiftUIContent: Bool = false
+    /// The regions this frame blacked out, in screen points, as collected by the capture pass.
+    /// ScannerPipeline tests `point` against these to decide whether to draw a tap marker.
+    var maskRects: [CGRect] = []
     let completion: URLProcessingCompletion?
     var finalImage: CIImage? = nil
     var ciImage: CIImage? {

--- a/Tests/CoralogixInternalTests/UIViewExtMaskInheritanceTests.swift
+++ b/Tests/CoralogixInternalTests/UIViewExtMaskInheritanceTests.swift
@@ -1,0 +1,185 @@
+//
+//  UIViewExtMaskInheritanceTests.swift
+//  CoralogixInternalTests
+//
+
+import XCTest
+import UIKit
+@testable import CoralogixInternal
+
+/// Masking is inherited downward — everything inside a masked view is masked — and the rects the
+/// capture pass paints are the single definition of "masked" that the tap check reuses.
+final class UIViewExtMaskInheritanceTests: XCTestCase {
+
+    // MARK: - isInsideMaskedSubtree
+
+    func testDirectlyMaskedView_isInsideMaskedSubtree() {
+        let view = UIView()
+        view.cxMask = true
+
+        XCTAssertTrue(view.isInsideMaskedSubtree)
+    }
+
+    func testUnmaskedStandaloneView_isNotInsideMaskedSubtree() {
+        XCTAssertFalse(UIView().isInsideMaskedSubtree)
+    }
+
+    /// The keypad case: the key carries no masking signal of its own, and hit-testing resolves the
+    /// key rather than the masked container. Asking the key alone must still answer "masked".
+    func testUnmaskedChildOfMaskedContainer_isInsideMaskedSubtree() {
+        let container = UIView()
+        container.cxMask = true
+        let key = UIButton()
+        container.addSubview(key)
+
+        XCTAssertTrue(key.isInsideMaskedSubtree,
+                      "A child of a masked container must inherit masking")
+    }
+
+    func testMaskingIsInheritedThroughMultipleLevels() {
+        let masked = UIView()
+        masked.cxMask = true
+        let middle = UIView()
+        let leaf = UILabel()
+        masked.addSubview(middle)
+        middle.addSubview(leaf)
+
+        XCTAssertTrue(leaf.isInsideMaskedSubtree,
+                      "Masking must reach a descendant at any depth, not just direct children")
+    }
+
+    func testSiblingSubtreeOfMaskedContainerStaysUnmasked() {
+        let root = UIView()
+        let maskedContainer = UIView()
+        maskedContainer.cxMask = true
+        let insideKey = UIButton()
+        maskedContainer.addSubview(insideKey)
+        let outsideButton = UIButton()
+        root.addSubview(maskedContainer)
+        root.addSubview(outsideButton)
+
+        XCTAssertTrue(insideKey.isInsideMaskedSubtree)
+        XCTAssertFalse(outsideButton.isInsideMaskedSubtree,
+                       "A sibling of a masked container must not be masked")
+    }
+
+    // MARK: - collectCxMaskRects
+
+    /// A masked container whose keys are *not* individually masked contributes exactly one rect.
+    /// The keys inherit masking for interaction purposes, but they carry no `cxMask` of their own,
+    /// so the rect walk must not invent rects for them.
+    func testMaskedContainerWithUnmaskedKeysYieldsOneRect() {
+        let root = UIView(frame: CGRect(x: 0, y: 0, width: 300, height: 300))
+        let keypad = UIView(frame: CGRect(x: 20, y: 40, width: 200, height: 160))
+        keypad.cxMask = true
+        for index in 0..<9 {
+            let key = UIButton(frame: CGRect(x: (index % 3) * 60, y: (index / 3) * 50,
+                                             width: 50, height: 40))
+            keypad.addSubview(key)
+        }
+        root.addSubview(keypad)
+
+        let rects = root.collectCxMaskRects(in: root)
+
+        XCTAssertEqual(rects.count, 1,
+                       "Unmasked keys inside a masked container must not each add a rect")
+        XCTAssertEqual(rects.first, CGRect(x: 20, y: 40, width: 200, height: 160))
+    }
+
+    /// The keys of a masked keypad carry no masking signal of their own, so the container's rect
+    /// is the only thing covering them. It must span the whole keypad.
+    func testMaskedContainerRectCoversItsUnmaskedKeys() {
+        let root = UIView(frame: CGRect(x: 0, y: 0, width: 300, height: 300))
+        let keypad = UIView(frame: CGRect(x: 20, y: 40, width: 200, height: 160))
+        keypad.cxMask = true
+        let key = UIButton(frame: CGRect(x: 60, y: 50, width: 50, height: 40))
+        keypad.addSubview(key)
+        root.addSubview(keypad)
+
+        let rects = root.collectCxMaskRects(in: root)
+
+        XCTAssertEqual(rects.count, 1)
+        let keyInRoot = key.convert(key.bounds, to: root)
+        XCTAssertTrue(rects[0].contains(keyInRoot),
+                      "The container's mask rect must cover its keys")
+        XCTAssertTrue(rects[0].contains(CGPoint(x: keyInRoot.midX, y: keyInRoot.midY)),
+                      "A tap at the centre of a key must fall inside the container's mask rect")
+    }
+
+    /// An unmasked container must still yield the rects of the masked views inside it — stopping
+    /// at a masked node must not turn into stopping at any node.
+    func testUnmaskedContainerYieldsItsMaskedDescendants() {
+        let root = UIView(frame: CGRect(x: 0, y: 0, width: 300, height: 300))
+        let plainContainer = UIView(frame: CGRect(x: 0, y: 0, width: 300, height: 300))
+        let maskedA = UIView(frame: CGRect(x: 10, y: 10, width: 50, height: 20))
+        maskedA.cxMask = true
+        let maskedB = UIView(frame: CGRect(x: 10, y: 100, width: 80, height: 30))
+        maskedB.cxMask = true
+        plainContainer.addSubview(maskedA)
+        plainContainer.addSubview(maskedB)
+        root.addSubview(plainContainer)
+
+        let rects = root.collectCxMaskRects(in: root)
+
+        XCTAssertEqual(rects.count, 2)
+        XCTAssertTrue(rects.contains(CGRect(x: 10, y: 10, width: 50, height: 20)))
+        XCTAssertTrue(rects.contains(CGRect(x: 10, y: 100, width: 80, height: 30)))
+    }
+
+    /// A masked subview that extends beyond its masked parent's bounds must still be masked over
+    /// its whole area. Subviews are not clipped unless `clipsToBounds` is set, so the parent's
+    /// rect does not necessarily cover its descendants — collapsing a masked subtree to the
+    /// ancestor's rect alone would leave the overflow visible.
+    func testMaskedSubviewOverflowingItsMaskedParentIsStillCovered() {
+        let root = UIView(frame: CGRect(x: 0, y: 0, width: 400, height: 400))
+        let parent = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+        parent.cxMask = true
+        let overflowing = UIView(frame: CGRect(x: 50, y: 50, width: 200, height: 200))
+        overflowing.cxMask = true
+        parent.addSubview(overflowing)
+        root.addSubview(parent)
+
+        let rects = root.collectCxMaskRects(in: root)
+
+        // A point inside the overflowing subview but outside the parent.
+        let overflowPoint = CGPoint(x: 200, y: 200)
+        XCTAssertFalse(rects.contains { $0.contains(CGPoint(x: 300, y: 300)) },
+                       "Sanity: a point outside both views must not be masked")
+        XCTAssertTrue(rects.contains { $0.contains(overflowPoint) },
+                      "The part of a masked subview outside its masked parent must stay masked")
+    }
+
+    /// A masked view inside a scrolled scroll view must report its rect at the scrolled position,
+    /// not its unscrolled layout position — otherwise the mask lands somewhere the content is not
+    /// and the tap check consults the wrong region.
+    func testMaskedViewInsideScrolledScrollViewReportsScrolledPosition() {
+        let root = UIView(frame: CGRect(x: 0, y: 0, width: 300, height: 300))
+        let scrollView = UIScrollView(frame: CGRect(x: 0, y: 0, width: 300, height: 300))
+        let masked = UIView(frame: CGRect(x: 0, y: 200, width: 100, height: 50))
+        masked.cxMask = true
+        scrollView.addSubview(masked)
+        scrollView.contentSize = CGSize(width: 300, height: 600)
+        root.addSubview(scrollView)
+
+        let unscrolled = root.collectCxMaskRects(in: root)
+        XCTAssertEqual(unscrolled.first?.origin.y, 200)
+
+        scrollView.contentOffset = CGPoint(x: 0, y: 150)
+        let scrolled = root.collectCxMaskRects(in: root)
+
+        XCTAssertEqual(scrolled.first?.origin.y, 50,
+                       "The mask rect must follow the content as it scrolls")
+    }
+
+    func testHiddenMaskedViewYieldsNoRect() {
+        let root = UIView(frame: CGRect(x: 0, y: 0, width: 300, height: 300))
+        let masked = UIView(frame: CGRect(x: 10, y: 10, width: 50, height: 20))
+        masked.cxMask = true
+        masked.isHidden = true
+        root.addSubview(masked)
+
+        XCTAssertTrue(root.collectCxMaskRects(in: root).isEmpty,
+                      "A hidden view is not painted, so it masks nothing")
+    }
+
+}

--- a/Tests/CoralogixRumTests/InteractionContextTests.swift
+++ b/Tests/CoralogixRumTests/InteractionContextTests.swift
@@ -23,6 +23,15 @@ final class InteractionContextTests: XCTestCase {
         return nil
     }
 
+    /// The composition `extract` performs: extract the text, then treat it as unavailable when the
+    /// view carries a sensitive-PII signal. Production redacts to `***` at that point rather than
+    /// dropping the value; these tests predate that and assert the extraction rules themselves, so
+    /// they keep asking the narrower question "would this text have been reportable verbatim?".
+    private func safeInnerText(from view: UIView) -> String? {
+        if TapDataExtractor.hasSensitivePIIProperties(view) { return nil }
+        return TapDataExtractor.rawInnerText(from: view)
+    }
+
     private func makeSpan(tapObject: [String: Any]) -> SpanDataProtocol {
         let now = Date()
         return MockSpanData(
@@ -151,7 +160,7 @@ final class InteractionContextTests: XCTestCase {
     func testSafeInnerText_textField_nonSensitive_returnsText() {
         let tf = UITextField()
         tf.text = "user@example.com"
-        XCTAssertEqual(TapDataExtractor.safeInnerText(from: tf), "user@example.com")
+        XCTAssertEqual(safeInnerText(from: tf), "user@example.com")
     }
 
     /// UITextField with isSecureTextEntry must return nil — password/PIN field.
@@ -159,7 +168,7 @@ final class InteractionContextTests: XCTestCase {
         let tf = UITextField()
         tf.isSecureTextEntry = true
         tf.text = "super-secret"
-        XCTAssertNil(TapDataExtractor.safeInnerText(from: tf))
+        XCTAssertNil(safeInnerText(from: tf))
     }
 
     /// UITextField whose textContentType is .password must return nil.
@@ -167,7 +176,7 @@ final class InteractionContextTests: XCTestCase {
         let tf = UITextField()
         tf.textContentType = .password
         tf.text = "hunter2"
-        XCTAssertNil(TapDataExtractor.safeInnerText(from: tf))
+        XCTAssertNil(safeInnerText(from: tf))
     }
 
     /// UITextField whose textContentType is .newPassword must return nil.
@@ -175,7 +184,7 @@ final class InteractionContextTests: XCTestCase {
         let tf = UITextField()
         tf.textContentType = .newPassword
         tf.text = "S3cur3P@ss!"
-        XCTAssertNil(TapDataExtractor.safeInnerText(from: tf))
+        XCTAssertNil(safeInnerText(from: tf))
     }
 
     /// UITextField whose textContentType is .creditCardNumber must return nil.
@@ -183,7 +192,7 @@ final class InteractionContextTests: XCTestCase {
         let tf = UITextField()
         tf.textContentType = .creditCardNumber
         tf.text = "4111111111111111"
-        XCTAssertNil(TapDataExtractor.safeInnerText(from: tf))
+        XCTAssertNil(safeInnerText(from: tf))
     }
 
     // MARK: UITextView
@@ -192,7 +201,7 @@ final class InteractionContextTests: XCTestCase {
     func testSafeInnerText_textView_nonSensitive_returnsText() {
         let tv = UITextView()
         tv.text = "some user note"
-        XCTAssertEqual(TapDataExtractor.safeInnerText(from: tv), "some user note")
+        XCTAssertEqual(safeInnerText(from: tv), "some user note")
     }
 
     /// UITextView with isSecureTextEntry must return nil.
@@ -200,14 +209,14 @@ final class InteractionContextTests: XCTestCase {
         let tv = UITextView()
         tv.isSecureTextEntry = true
         tv.text = "secret"
-        XCTAssertNil(TapDataExtractor.safeInnerText(from: tv))
+        XCTAssertNil(safeInnerText(from: tv))
     }
 
     /// Empty UITextView (no text) must return nil — nothing useful to capture.
     func testSafeInnerText_textView_empty_returnsNil() {
         let tv = UITextView()
         tv.text = ""
-        XCTAssertNil(TapDataExtractor.safeInnerText(from: tv))
+        XCTAssertNil(safeInnerText(from: tv))
     }
 
     // MARK: UISearchBar
@@ -216,7 +225,7 @@ final class InteractionContextTests: XCTestCase {
     func testSafeInnerText_searchBar_nonSensitive_returnsText() {
         let sb = UISearchBar()
         sb.text = "search term"
-        XCTAssertEqual(TapDataExtractor.safeInnerText(from: sb), "search term")
+        XCTAssertEqual(safeInnerText(from: sb), "search term")
     }
 
     /// UISearchBar with isSecureTextEntry must return nil.
@@ -224,28 +233,28 @@ final class InteractionContextTests: XCTestCase {
         let sb = UISearchBar()
         sb.isSecureTextEntry = true
         sb.text = "pin"
-        XCTAssertNil(TapDataExtractor.safeInnerText(from: sb))
+        XCTAssertNil(safeInnerText(from: sb))
     }
 
     /// UIButton title is developer-authored — must be captured.
     func testSafeInnerText_button_returnsTitle() {
         let btn = UIButton()
         btn.setTitle("Add to Cart", for: .normal)
-        XCTAssertEqual(TapDataExtractor.safeInnerText(from: btn), "Add to Cart")
+        XCTAssertEqual(safeInnerText(from: btn), "Add to Cart")
     }
 
     /// UILabel text is developer-authored — must be captured.
     func testSafeInnerText_label_returnsText() {
         let lbl = UILabel()
         lbl.text = "Section Header"
-        XCTAssertEqual(TapDataExtractor.safeInnerText(from: lbl), "Section Header")
+        XCTAssertEqual(safeInnerText(from: lbl), "Section Header")
     }
 
     /// UITableViewCell primary text is developer-authored — must be captured.
     func testSafeInnerText_tableViewCell_returnsTextLabel() {
         let cell = UITableViewCell()
         cell.textLabel?.text = "Settings"
-        XCTAssertEqual(TapDataExtractor.safeInnerText(from: cell), "Settings")
+        XCTAssertEqual(safeInnerText(from: cell), "Settings")
     }
 
     /// UITableViewCell with an empty textLabel must not return "" and must fall through to accessibilityLabel.
@@ -256,7 +265,7 @@ final class InteractionContextTests: XCTestCase {
         if #available(iOS 14.0, *) {
             cell.contentConfiguration = nil
         }
-        XCTAssertEqual(TapDataExtractor.safeInnerText(from: cell), "Item Row",
+        XCTAssertEqual(safeInnerText(from: cell), "Item Row",
                        "Whitespace-only textLabel must fall through to accessibilityLabel")
     }
 
@@ -270,7 +279,7 @@ final class InteractionContextTests: XCTestCase {
         config.secondaryText = "   "
         cell.contentConfiguration = config
         cell.accessibilityLabel = "Product Row"
-        XCTAssertEqual(TapDataExtractor.safeInnerText(from: cell), "Product Row",
+        XCTAssertEqual(safeInnerText(from: cell), "Product Row",
                        "UIListContentConfiguration with empty text and whitespace secondaryText must fall through to accessibilityLabel")
     }
 
@@ -284,7 +293,7 @@ final class InteractionContextTests: XCTestCase {
         config.secondaryText = "Subtitle"
         cell.contentConfiguration = config
         cell.accessibilityLabel = "Should Not Be Used"
-        XCTAssertEqual(TapDataExtractor.safeInnerText(from: cell), "Subtitle",
+        XCTAssertEqual(safeInnerText(from: cell), "Subtitle",
                        "Non-empty secondaryText must be returned when primary text is empty")
     }
 
@@ -292,26 +301,26 @@ final class InteractionContextTests: XCTestCase {
     func testSafeInnerText_segmentedControl_returnsSelectedTitle() {
         let seg = UISegmentedControl(items: ["Day", "Week", "Month"])
         seg.selectedSegmentIndex = 1
-        XCTAssertEqual(TapDataExtractor.safeInnerText(from: seg), "Week")
+        XCTAssertEqual(safeInnerText(from: seg), "Week")
     }
 
     /// UISegmentedControl with no selection must return nil.
     func testSafeInnerText_segmentedControl_noSelection_returnsNil() {
         let seg = UISegmentedControl(items: ["Day", "Week"])
         seg.selectedSegmentIndex = UISegmentedControl.noSegment
-        XCTAssertNil(TapDataExtractor.safeInnerText(from: seg))
+        XCTAssertNil(safeInnerText(from: seg))
     }
 
     /// accessibilityLabel is the safe fallback for any other view type.
     func testSafeInnerText_genericView_usesAccessibilityLabel() {
         let view = UIView()
         view.accessibilityLabel = "Profile Avatar"
-        XCTAssertEqual(TapDataExtractor.safeInnerText(from: view), "Profile Avatar")
+        XCTAssertEqual(safeInnerText(from: view), "Profile Avatar")
     }
 
     /// A generic UIView with no text and no accessibilityLabel must return nil.
     func testSafeInnerText_genericView_noText_returnsNil() {
-        XCTAssertNil(TapDataExtractor.safeInnerText(from: UIView()))
+        XCTAssertNil(safeInnerText(from: UIView()))
     }
 
     // MARK: - safeInnerText — UIDatePicker / UIStepper fall through to accessibilityLabel
@@ -320,14 +329,14 @@ final class InteractionContextTests: XCTestCase {
     func testSafeInnerText_datePicker_usesAccessibilityLabel() {
         let picker = UIDatePicker()
         picker.accessibilityLabel = "Birth Date"
-        XCTAssertEqual(TapDataExtractor.safeInnerText(from: picker), "Birth Date")
+        XCTAssertEqual(safeInnerText(from: picker), "Birth Date")
     }
 
     /// UIStepper has no text property — must fall through to accessibilityLabel.
     func testSafeInnerText_stepper_usesAccessibilityLabel() {
         let stepper = UIStepper()
         stepper.accessibilityLabel = "Quantity"
-        XCTAssertEqual(TapDataExtractor.safeInnerText(from: stepper), "Quantity")
+        XCTAssertEqual(safeInnerText(from: stepper), "Quantity")
     }
 
     // MARK: - TapDataExtractor.extract — swipe events

--- a/Tests/CoralogixRumTests/InteractionContextTests.swift
+++ b/Tests/CoralogixRumTests/InteractionContextTests.swift
@@ -415,17 +415,18 @@ final class InteractionContextTests: XCTestCase {
                        "shouldSendText returning true must allow text capture")
     }
 
-    /// When shouldSendText returns false the inner text must be suppressed even though
-    /// the SDK would otherwise record it.
-    func testExtract_shouldSendText_returnsFalse_suppressesInnerText() {
+    /// When shouldSendText returns false the inner text must be redacted to `***` — reported,
+    /// but not readable. The key stays present so a rejected tap is distinguishable from a tap on
+    /// an element that had no text at all.
+    func testExtract_shouldSendText_returnsFalse_redactsInnerText() {
         let button = UIButton()
         button.setTitle("Submit", for: .normal) // safeInnerText reads currentTitle, not accessibilityLabel
         let event = TouchEvent(view: button, location: .zero, eventType: .click, scrollDirection: nil)
 
         let data = TapDataExtractor.extract(from: event, shouldSendText: { _, _ in false })
 
-        XCTAssertNil(data[Keys.targetElementInnerText.rawValue],
-                     "shouldSendText returning false must suppress target_element_inner_text")
+        XCTAssertEqual(data[Keys.targetElementInnerText.rawValue] as? String, "***",
+                       "shouldSendText returning false must redact target_element_inner_text to ***")
     }
 
     /// With no shouldSendText delegate the inner text must be captured as normal (defaults to true).

--- a/Tests/CoralogixRumTests/MaskedInteractionTextTests.swift
+++ b/Tests/CoralogixRumTests/MaskedInteractionTextTests.swift
@@ -1,0 +1,155 @@
+//
+//  MaskedInteractionTextTests.swift
+//  CoralogixRumTests
+//
+
+import XCTest
+import UIKit
+import CoralogixInternal
+@testable import Coralogix
+
+/// Interaction events for anything inside a masked area must report `***` rather than the real
+/// text. Masking hides what an element says, not that it was used — the event is still reported.
+final class MaskedInteractionTextTests: XCTestCase {
+
+    private func clickEvent(on view: UIView) -> TouchEvent {
+        TouchEvent(view: view, location: .zero, eventType: .click, scrollDirection: nil)
+    }
+
+    private func innerText(_ data: [String: Any]) -> String? {
+        data[Keys.targetElementInnerText.rawValue] as? String
+    }
+
+    // MARK: - Inherited masking
+
+    /// The keypad case. Hit-testing resolves the key, which is not itself masked; without
+    /// inheritance the digit ships in clear and the PIN is reconstructible from the tap spans.
+    func testKeyInsideMaskedContainer_reportsRedactedText() {
+        let keypad = UIView()
+        keypad.cxMask = true
+        let key = UIButton()
+        key.setTitle("7", for: .normal)
+        keypad.addSubview(key)
+
+        let data = TapDataExtractor.extract(from: clickEvent(on: key))
+
+        XCTAssertEqual(innerText(data), "***",
+                       "A key inside a masked keypad must not report its digit")
+    }
+
+    /// The same control outside the masked container still reports normally — the redaction must
+    /// be caused by the masking, not by the test setup.
+    func testUnmaskedTwinOfMaskedKey_reportsItsText() {
+        let key = UIButton()
+        key.setTitle("7", for: .normal)
+
+        let data = TapDataExtractor.extract(from: clickEvent(on: key))
+
+        XCTAssertEqual(innerText(data), "7",
+                       "An identical control outside a masked container must report its text")
+    }
+
+    func testDirectlyMaskedView_reportsRedactedText() {
+        let label = UILabel()
+        label.text = "Account 12345"
+        label.cxMask = true
+
+        let data = TapDataExtractor.extract(from: clickEvent(on: label))
+
+        XCTAssertEqual(innerText(data), "***")
+    }
+
+    func testMaskingIsInheritedThroughMultipleLevels() {
+        let masked = UIView()
+        masked.cxMask = true
+        let middle = UIView()
+        let label = UILabel()
+        label.text = "Balance 4,200"
+        masked.addSubview(middle)
+        middle.addSubview(label)
+
+        let data = TapDataExtractor.extract(from: clickEvent(on: label))
+
+        XCTAssertEqual(innerText(data), "***",
+                       "Masking must reach a descendant at any depth")
+    }
+
+    // MARK: - Sensitive-field detection
+
+    /// Previously the key was dropped entirely. It is now present and redacted, so iOS and Android
+    /// describe a masked tap the same way.
+    func testSecureTextField_reportsRedactedText() {
+        let field = UITextField()
+        field.isSecureTextEntry = true
+        field.text = "hunter2"
+
+        let data = TapDataExtractor.extract(from: clickEvent(on: field))
+
+        XCTAssertEqual(innerText(data), "***",
+                       "A password field must report *** rather than dropping the key")
+    }
+
+    func testCreditCardContentTypeField_reportsRedactedText() {
+        let field = UITextField()
+        field.textContentType = .creditCardNumber
+        field.text = "4111111111111111"
+
+        let data = TapDataExtractor.extract(from: clickEvent(on: field))
+
+        XCTAssertEqual(innerText(data), "***")
+    }
+
+    // MARK: - The delegate must never see redacted text
+
+    /// The customer's `shouldSendText` closure is a reporting gate, not an inspection hook. Text
+    /// that is already masked must not be handed to it.
+    func testShouldSendTextIsNotCalledForAMaskedView() {
+        let container = UIView()
+        container.cxMask = true
+        let button = UIButton()
+        button.setTitle("7", for: .normal)
+        container.addSubview(button)
+
+        var delegateCalled = false
+        let data = TapDataExtractor.extract(from: clickEvent(on: button), shouldSendText: { _, _ in
+            delegateCalled = true
+            return true
+        })
+
+        XCTAssertFalse(delegateCalled,
+                       "A masked view's text must not reach the customer's closure")
+        XCTAssertEqual(innerText(data), "***",
+                       "A delegate returning true must not un-mask a masked view")
+    }
+
+    func testShouldSendTextIsNotCalledForASecureField() {
+        let field = UITextField()
+        field.isSecureTextEntry = true
+        field.text = "hunter2"
+
+        var capturedText: String?
+        _ = TapDataExtractor.extract(from: clickEvent(on: field), shouldSendText: { _, text in
+            capturedText = text
+            return true
+        })
+
+        XCTAssertNil(capturedText,
+                     "A password must never be passed to the customer's closure")
+    }
+
+    // MARK: - Absent text stays absent
+
+    /// Redaction applies to text that exists. A view with nothing to say still reports no key,
+    /// so `***` continues to mean "there was something here".
+    func testMaskedViewWithNoText_reportsNoInnerTextKey() {
+        let container = UIView()
+        container.cxMask = true
+        let stepper = UIStepper()
+        container.addSubview(stepper)
+
+        let data = TapDataExtractor.extract(from: clickEvent(on: stepper))
+
+        XCTAssertNil(data[Keys.targetElementInnerText.rawValue],
+                     "A masked view with no text must not invent a redacted value")
+    }
+}

--- a/Tests/SessionReplayTests/MaskedTapMarkerTests.swift
+++ b/Tests/SessionReplayTests/MaskedTapMarkerTests.swift
@@ -1,0 +1,167 @@
+//
+//  MaskedTapMarkerTests.swift
+//  SessionReplayTests
+//
+
+import XCTest
+import UIKit
+import CoreImage
+import CoralogixInternal
+@testable import SessionReplay
+
+/// A tap landing inside a region this frame masked must draw no marker: the marker would reveal
+/// which element under the mask was hit, and a run of markers reconstructs what was entered on a
+/// masked keypad. The frame itself is still recorded.
+final class MaskedTapMarkerTests: XCTestCase {
+
+    private let ciContext = CIContext()
+
+    // MARK: - Helpers
+
+    /// Plain white frame — any pixel difference in these tests is the click marker and nothing
+    /// else, since no masking or scanner stage is enabled.
+    private func makeBlankFrameData(size: CGSize = CGSize(width: 400, height: 400)) -> Data {
+        let renderer = UIGraphicsImageRenderer(size: size)
+        return renderer.image { ctx in
+            UIColor.white.setFill()
+            ctx.fill(CGRect(origin: .zero, size: size))
+        }.pngData()!
+    }
+
+    private func makeEntry(data: Data, point: CGPoint?, maskRects: [CGRect]) -> URLEntry {
+        URLEntry(url: URL(fileURLWithPath: "/tmp/masked_tap_marker_test.png"),
+                 timestamp: 0,
+                 screenshotId: "test-screenshot-id",
+                 segmentIndex: 0,
+                 page: "0",
+                 screenshotData: data,
+                 point: point,
+                 containsSwiftUIContent: false,
+                 maskRects: maskRects,
+                 completion: nil)
+    }
+
+    /// All scanner stages off, so the click stage is the only one that can alter the frame.
+    private func makeOptions() -> SessionReplayOptions {
+        SessionReplayOptions(maskText: nil, maskOnlyCreditCards: false, maskAllImages: false)
+    }
+
+    private func pngBytes(_ image: CIImage) -> Data? {
+        ciContext.pngRepresentation(of: image,
+                                    format: .RGBA8,
+                                    colorSpace: CGColorSpaceCreateDeviceRGB())
+    }
+
+    private func runPipeline(entry: URLEntry) -> CIImage? {
+        let expectation = self.expectation(description: "pipeline completes")
+        var result: CIImage?
+        ScannerPipeline().runPipeline(options: makeOptions(), urlEntry: entry) { ciImage, _ in
+            result = ciImage
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 30, handler: nil)
+        return result
+    }
+
+    // MARK: - Tests
+
+    func testTapInsideMaskedRegion_drawsNoMarker() {
+        let data = makeBlankFrameData()
+        let entry = makeEntry(data: data,
+                              point: CGPoint(x: 100, y: 100),
+                              maskRects: [CGRect(x: 50, y: 50, width: 150, height: 150)])
+
+        guard let output = runPipeline(entry: entry) else {
+            XCTFail("Pipeline returned nil image")
+            return
+        }
+
+        XCTAssertEqual(pngBytes(output), pngBytes(CIImage(data: data)!),
+                       "A tap inside a masked region must leave the frame untouched")
+    }
+
+    func testTapOutsideMaskedRegion_drawsMarker() {
+        let data = makeBlankFrameData()
+        let entry = makeEntry(data: data,
+                              point: CGPoint(x: 300, y: 300),
+                              maskRects: [CGRect(x: 50, y: 50, width: 150, height: 150)])
+
+        guard let output = runPipeline(entry: entry) else {
+            XCTFail("Pipeline returned nil image")
+            return
+        }
+
+        XCTAssertNotEqual(pngBytes(output), pngBytes(CIImage(data: data)!),
+                          "A tap outside every masked region must still draw its marker")
+    }
+
+    /// Guards the suppression from swallowing the ordinary case: a frame that masked nothing must
+    /// keep drawing markers exactly as before.
+    func testTapOnUnmaskedFrame_drawsMarker() {
+        let data = makeBlankFrameData()
+        let entry = makeEntry(data: data, point: CGPoint(x: 100, y: 100), maskRects: [])
+
+        guard let output = runPipeline(entry: entry) else {
+            XCTFail("Pipeline returned nil image")
+            return
+        }
+
+        XCTAssertNotEqual(pngBytes(output), pngBytes(CIImage(data: data)!),
+                          "With no masked regions the marker must be drawn")
+    }
+
+    // MARK: - containsTap
+
+    func testContainsTap_pointInsideRect() {
+        let rects = [CGRect(x: 20, y: 40, width: 200, height: 160)]
+
+        XCTAssertTrue(rects.containsTap(CGPoint(x: 100, y: 100)))
+    }
+
+    func testContainsTap_pointOutsideRect() {
+        let rects = [CGRect(x: 20, y: 40, width: 200, height: 160)]
+
+        XCTAssertFalse(rects.containsTap(CGPoint(x: 250, y: 100)),
+                       "A tap to the right of the only masked region is not masked")
+        XCTAssertFalse(rects.containsTap(CGPoint(x: 100, y: 10)),
+                       "A tap above the only masked region is not masked")
+    }
+
+    func testContainsTap_noRects() {
+        XCTAssertFalse([CGRect]().containsTap(CGPoint(x: 100, y: 100)),
+                       "A frame that masked nothing suppresses no markers")
+    }
+
+    /// Fails closed across layers: it is enough for any one region to contain the tap.
+    func testContainsTap_matchesAnyRectInAMultiRectFrame() {
+        let rects = [
+            CGRect(x: 0, y: 0, width: 50, height: 50),
+            CGRect(x: 200, y: 300, width: 80, height: 80),
+            CGRect(x: 100, y: 100, width: 20, height: 20)
+        ]
+
+        XCTAssertTrue(rects.containsTap(CGPoint(x: 240, y: 340)),
+                      "A tap inside the second region must count")
+        XCTAssertFalse(rects.containsTap(CGPoint(x: 160, y: 160)),
+                       "A tap in the gap between regions must not count")
+    }
+
+    // MARK: - Multi-region frames
+
+    /// Fails closed across layers — a tap inside any one of the frame's regions is suppressed.
+    func testTapInsideSecondOfSeveralMaskedRegions_drawsNoMarker() {
+        let data = makeBlankFrameData()
+        let entry = makeEntry(data: data,
+                              point: CGPoint(x: 320, y: 320),
+                              maskRects: [CGRect(x: 10, y: 10, width: 40, height: 40),
+                                          CGRect(x: 300, y: 300, width: 60, height: 60)])
+
+        guard let output = runPipeline(entry: entry) else {
+            XCTFail("Pipeline returned nil image")
+            return
+        }
+
+        XCTAssertEqual(pngBytes(output), pngBytes(CIImage(data: data)!),
+                       "Any masked region containing the tap must suppress the marker")
+    }
+}

--- a/Tests/SessionReplayTests/SessionReplayModelTests.swift
+++ b/Tests/SessionReplayTests/SessionReplayModelTests.swift
@@ -101,9 +101,25 @@ final class SessionReplayModelTests: XCTestCase {
         XCTAssertEqual(model.passedScreenshotData, "mock image".data(using: .utf8))
     }
 
+    /// The rects the capture pass painted must reach the properties that build the `URLEntry`.
+    /// If they are dropped here, every tap looks unmasked to ScannerPipeline and markers are drawn
+    /// over masked content — silently, since the frame itself still looks correct.
+    func testCaptureImage_carriesCaptureMaskRectsIntoProperties() {
+        let model = MockSessionReplayModel2()
+        model.sessionId = "abc123"
+        model.sessionReplayOptions = SessionReplayOptions(captureScale: 1.0, captureCompressionQuality: 0.8)
+        model.stubbedMaskRects = [CGRect(x: 20, y: 40, width: 200, height: 160)]
+
+        _ = model.captureImage(properties: nil)
+
+        let carried = model.passedProperties?[Keys.maskRects.rawValue] as? [CGRect]
+        XCTAssertEqual(carried, [CGRect(x: 20, y: 40, width: 200, height: 160)],
+                       "Capture-time mask rects must travel with the frame")
+    }
+
     func testCaptureImage_logsAndReturnsIfPrepareScreenshotFails() {
         class FailingScreenshotModel: MockSessionReplayModel2 {
-            override func prepareScreenshotImageOnMain(properties: [String : Any]?) -> UIImage? {
+            override func prepareCapturedFrameOnMain(properties: [String : Any]?) -> CapturedFrame? {
                 didCallPrepareScreenshot = true
                 return nil
             }
@@ -722,14 +738,18 @@ class MockSessionReplayModel2: SessionReplayModel {
     var passedScreenshotData: Data?
     var passedProperties: [String: Any]?
 
-    override func prepareScreenshotImageOnMain(properties: [String : Any]?) -> UIImage? {
+    /// Mask rects the stubbed capture reports, as a real capture pass would.
+    var stubbedMaskRects: [CGRect] = []
+
+    override func prepareCapturedFrameOnMain(properties: [String : Any]?) -> CapturedFrame? {
         didCallPrepareScreenshot = true
         // 1x1 white image — real UIImage so the encode pipeline can run, but cheap.
         let renderer = UIGraphicsImageRenderer(size: CGSize(width: 1, height: 1))
-        return renderer.image { ctx in
+        let image = renderer.image { ctx in
             UIColor.white.setFill()
             ctx.fill(CGRect(x: 0, y: 0, width: 1, height: 1))
         }
+        return CapturedFrame(image: image, maskRects: stubbedMaskRects)
     }
 
     /// Bypass the encodingQueue + JPEG path and inject a deterministic byte


### PR DESCRIPTION
iOS half of CX-52293. Mirrors the Android implementation in coralogix/android-sdk#241 (CX-52294) — all behavioural decisions were settled on that batch and carried over unchanged.

## Problem

Masking applied to a container did not reach its subviews. A masked keypad was blacked out in the replay, but each key is its own tappable view, and hit-testing resolves the key — which carried no masking signal of its own.

So for a masked PIN pad, every keypress produced:

- a tap marker drawn at the key's true position in the replay, and
- an interaction span whose `target_element_inner_text` was the digit, in clear.

Reading the tap spans in order reconstructed the PIN directly.

## Approach

Resolve masking where each consumer already stands, rather than re-deriving it per consumer.

- **`UIView.isInsideMaskedSubtree`** walks up from the tapped view, so a control inside a `cxMask` subtree counts as masked. Walking up rather than threading a context down (as Android does) because there is no persistent view-params tree here: rects come from a live hierarchy per capture, and the interaction path starts from an already hit-tested leaf.
- **`captureFrame`** returns the mask rects it painted (`CapturedFrame`), which thread through the capture properties — the same channel the click point and SwiftUI flag already use — into `URLEntry.maskRects`. `ScannerPipeline` tests the tap against those exact rects, so the marker cannot contradict the pixels. No second walk, no second definition of what is masked. Fails closed on z-order.
- **`target_element_inner_text` is `***`** rather than an absent key, so a masked tap stays distinguishable from an element that had no text. `rawInnerText` is split out of `safeInnerText` to tell "sensitive text" apart from "no text"; sensitive text is never handed to the customer's `shouldSendText` closure.

`collectCxMaskRects` deliberately keeps descending past a masked view, unlike Android's equivalent. Android stops there because masking is inherited in its tree, so every descendant reports itself masked and the walk would emit a rect per node. Here `cxMask` stays per-view, so a descendant only contributes a rect when explicitly masked — and it must, because subviews are not clipped to their parent and a masked child can extend past a masked parent's bounds. An earlier revision of this branch did stop, and a test caught it leaving the overflow unmasked.

## Deviations from the ticket, both agreed

- The ticket says "default: do not emit the touch". We suppress the **marker** and keep the frame, and interaction events still carry `x`/`y`. Coordinates were ruled out of scope, so the entered sequence is still reconstructible from the coordinates on the tap spans — the epic's acceptance criterion needs the same rewording noted on the Android PR.
- The ticket asks to cover "the global policy options" too. They are covered for tap markers wherever they report geometry: `maskText` and `maskAllImages` applied to UIKit views (`collectTextViewRects`, `collectMatchingNavigationBarRects`, `collectImageViewRects`) feed the same `nativeMaskRects` the check consults, so a tap on a natively-masked label or image draws no marker. The Vision-based stages — OCR/rectangle detection for SwiftUI content, `maskFaces`, `creditCardPredicate` — mask pixels without reporting geometry, so those cannot suppress a marker. None of the global options redact interaction text, matching Android, where unifying replay masking with interaction masking is tracked as separate work.

## Known limitations, documented

- **SwiftUI.** `.cxMask()` overlays a masked `UIView`, so pixels are masked *and* markers are suppressed — but the overlay is a sibling of the content, not an ancestor, so interaction text underneath is not redacted. Structurally the same gap as Android's `AndroidView {}` case. `shouldSendText` is the workaround.
- **Flutter.** Dart masks inside its own bitmap and reports no geometry, so markers over masked Flutter widgets are not suppressed.
- **`element_id` is not redacted.** It carries the developer-authored `accessibilityIdentifier`, so it is reported as-is even inside a masked subtree — matching Android, which does not redact `resourceId`. Encoding sensitive values in identifiers therefore defeats masking; documented, with the demo keypad as the worked example.
- **Offset windows.** Mask rects are screen-space; the tap point comes from `touch.location(in: nil)`, which is window-space. These agree for a window at the origin, which is the pre-existing assumption in `ClickScanner`. Not changed here.

Both are captured in a table in `SessionReplay/Sources/Docs/README.md`, which previously did not document `cxMask` at all.

## Testing

- Masked container with an unmasked tappable key: the key reports `***`; its unmasked twin still reports `7`.
- Inheritance through multiple levels; siblings of a masked container stay unmasked.
- `containsTap` inside / outside / multi-rect / empty; marker drawn outside a masked region and on an unmasked frame.
- Mask rects survive the capture → properties → `URLEntry` threading.
- A masked subview overflowing its masked parent stays covered; a masked view inside a scrolled scroll view reports its scrolled position.
- Verified the new tests fail without the fix — reverting the inheritance and the marker guard fails 9 of them.
- All three suites pass (`CoralogixInternalTests`, `CoralogixRumTests`, `SessionReplayTests`); both demo apps build.
- Manual: new side-by-side masked/unmasked keypad on the Mask UI screen in both demo apps, driven on an iPhone 16 simulator. `[SR] tap inside a masked region — marker suppressed` fired on the masked keypad, and the session was confirmed reaching Coralogix server-side - [see session replay here](https://c4c.app.eu2.coralogix.com/rum/session?v=2&t=4000017&login_flow_id=ef7b73e2-5cb4-4808-9196-ee93e91cfb59&rum-sessions-query-id=75f382abbb050e63a0d81560f47abb3ba316b97860d23d68fcdf041e&is-archive=true&from=1785910515426&to=1785911415426&rum-apps=DemoApp-iOS-swift&timestamp=1785911178000&user-name=&has-recording=false&has-screenshot=false&session-event-id=b48bd1ea-29aa-43c8-a692-96d6a2568f32&session-tab=SESSION_REPLAY&session-actions-filter=Navigation,Network,Click)

## Release

`2.13.2` → `2.13.3`. A patch: behaviour fix, no API removed or renamed.

Note under **Changed** in the changelog: redacted `target_element_inner_text` is now `***` where password fields and `shouldSendText` rejections previously sent no key at all. Wire-visible for anything treating an absent key as "no text".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
